### PR TITLE
[TASK] Order Panda3D remake subtasks

### DIFF
--- a/.codex/tasks/ac8cbde0-panda3d-task-order.md
+++ b/.codex/tasks/ac8cbde0-panda3d-task-order.md
@@ -1,0 +1,32 @@
+# Panda3D Remake Task Order
+
+## Summary
+Define the execution order for Panda3D remake subtasks based on the existing task list and planning document.
+
+## Tasks
+1. [ ] Project scaffold (`0f95beef`)
+2. [ ] Main loop and window handling (`869cac49`)
+3. [ ] Plugin loader (`56f168aa`)
+4. [ ] Damage and healing migration (`7b715405`)
+5. [ ] Main menu and settings (`0d21008f`) ~ Par
+6. [ ] Player creator (`f8d277d7`) ~ Par
+7. [ ] Stat screen (`58ea00c8`) ~ Par
+8. [ ] Battle room implementation (`1bfd343f`)
+9. [ ] Rest room implementation (`5109746a`) ~ Par
+10. [ ] Shop room implementation (`07c1ea52`) ~ Par
+11. [ ] Event room implementation (`cbf3a725`) ~ Par
+12. [ ] Map generation system (`3b2858e1`)
+13. [ ] Gacha system (`4289a6e2`)
+14. [ ] Upgrade item crafting (`418f603a`)
+15. [ ] SQLCipher save system (`798aafd3`)
+16. [ ] Asset pipeline (`ad61da93`) ~ Par
+17. [ ] Audio system (`7f5c8c36`) ~ Par
+18. [ ] UI polish and accessibility (`d6a657b0`) ~ Par
+19. [ ] Documentation and contributor guidelines (`ca46e97e`) ~ Par
+20. [ ] Testing and CI integration (`93a6a994`)
+
+## Context
+Derived from the Panda3D game plan and existing Panda3D remake task list to coordinate development.
+
+## Testing
+- [ ] Run `uv run pytest`.


### PR DESCRIPTION
## Summary
- add ordered task list for Panda3D remake tasks

## Testing
- `uv run pytest`

## Checklist
- [ ] Updated player roster and foe docs if adding or modifying fighters or enemies

------
https://chatgpt.com/codex/tasks/task_b_68902bc72898832c99692de36ea345db