### PR TITLE
[DOC] Expand Panda3D tasks and add audit report

### DIFF
--- a/.codex/audit/58e83a76-audit-report.audit.md
+++ b/.codex/audit/58e83a76-audit-report.audit.md
@@ -1,0 +1,16 @@
+# Panda3D Tasks and Plan Audit
+
+## Scope
+- Reviewed `.codex/planning/8a7d9c1e-panda3d-game-plan.md`.
+- Audited Panda3D task order and all tasks under `.codex/tasks/d801ffaa-panda3d-remake`.
+- Inspected `.github` workflows and documentation files.
+
+## Findings
+- Task files lacked detail and did not fully reflect the planning document.
+- Planning document is comprehensive and required no edits.
+
+## Actions
+- Expanded task order and individual Panda3D tasks with verbose, actionable steps aligned to the plan.
+
+## Next Steps
+- Implement tasks in the documented order and keep tasks synchronized with future planning updates.

--- a/.codex/tasks/ac8cbde0-panda3d-task-order.md
+++ b/.codex/tasks/ac8cbde0-panda3d-task-order.md
@@ -4,26 +4,26 @@
 Define the execution order for Panda3D remake subtasks based on the existing task list and planning document.
 
 ## Tasks
-1. [ ] Project scaffold (`0f95beef`)
-2. [ ] Main loop and window handling (`869cac49`)
-3. [ ] Plugin loader (`56f168aa`)
-4. [ ] Damage and healing migration (`7b715405`)
-5. [ ] Main menu and settings (`0d21008f`) ~ Par
-6. [ ] Player creator (`f8d277d7`) ~ Par
-7. [ ] Stat screen (`58ea00c8`) ~ Par
-8. [ ] Battle room implementation (`1bfd343f`)
-9. [ ] Rest room implementation (`5109746a`) ~ Par
-10. [ ] Shop room implementation (`07c1ea52`) ~ Par
-11. [ ] Event room implementation (`cbf3a725`) ~ Par
-12. [ ] Map generation system (`3b2858e1`)
-13. [ ] Gacha system (`4289a6e2`)
-14. [ ] Upgrade item crafting (`418f603a`)
-15. [ ] SQLCipher save system (`798aafd3`)
-16. [ ] Asset pipeline (`ad61da93`) ~ Par
-17. [ ] Audio system (`7f5c8c36`) ~ Par
-18. [ ] UI polish and accessibility (`d6a657b0`) ~ Par
-19. [ ] Documentation and contributor guidelines (`ca46e97e`) ~ Par
-20. [ ] Testing and CI integration (`93a6a994`)
+1. [ ] Project scaffold (`0f95beef`) – move legacy code, initialize uv project, install Panda3D, and set up assets and package structure.
+2. [ ] Main loop and window handling (`869cac49`) – create ShowBase subclass, handle window events, and introduce scene manager skeleton.
+3. [ ] Plugin loader (`56f168aa`) – build discovery system for player, foe, passive, DoT, HoT, weapon, and room plugins with event bus wrapper.
+4. [ ] Damage and healing migration (`7b715405`) – port DoT/HoT logic and Stats dataclass into new architecture.
+5. [ ] Main menu and settings (`0d21008f`) – implement themed menus with options for new/load runs and audio controls.
+6. [ ] Player creator (`f8d277d7`) – allow body and hair customization and 100-point stat allocation with item-based extras.
+7. [ ] Stat screen (`58ea00c8`) – display grouped stats, status effects, and relics with configurable refresh rate.
+8. [ ] Battle room implementation (`1bfd343f`) – create combat scenes, apply stat-based accuracy, and show overtime warnings.
+9. [ ] Rest room implementation (`5109746a`) – offer healing or item trades and record limited uses per floor.
+10. [ ] Shop room implementation (`07c1ea52`) – sell upgrade items and cards with pricing and reroll costs.
+11. [ ] Event room implementation (`cbf3a725`) – provide narrative choices with deterministic outcomes.
+12. [ ] Map generation system (`3b2858e1`) – build 45-room floors, Pressure levels, and looping logic.
+13. [ ] Gacha system (`4289a6e2`) – manage pulls, pity, duplicates, and reward presentation.
+14. [ ] Upgrade item crafting (`418f603a`) – combine lower-star items, trade for pulls, and handle dual types.
+15. [ ] SQLCipher save system (`798aafd3`) – store encrypted run data with migrations and key management.
+16. [ ] Asset pipeline (`ad61da93`) – research art style, convert assets, and implement AssetManager with manifest.
+17. [ ] Audio system (`7f5c8c36`) – play music and effects with volume control and boss/overtime cues.
+18. [ ] UI polish and accessibility (`d6a657b0`) – apply dark glassy theme, color-blind options, and keyboard navigation.
+19. [ ] Documentation and contributor guidelines (`ca46e97e`) – update README and contributor docs for new structure.
+20. [ ] Testing and CI integration (`93a6a994`) – add headless tests and GitHub workflows.
 
 ## Context
 Derived from the Panda3D game plan and existing Panda3D remake task list to coordinate development.

--- a/.codex/tasks/d801ffaa-panda3d-remake/07c1ea52-shop-room.md
+++ b/.codex/tasks/d801ffaa-panda3d-remake/07c1ea52-shop-room.md
@@ -4,9 +4,9 @@
 Create shop rooms where players can spend gold on upgrade items or cards.
 
 ## Tasks
-- [ ] Design a shop interface listing items with prices and star ratings.
-- [ ] Implement purchasing logic that deducts gold and grants items.
-- [ ] Include refresh or reroll functionality using a small gold fee.
+- [ ] Design a shop interface listing items with prices, star ratings, and limited stock.
+- [ ] Implement purchasing logic that deducts gold, grants items, and supports rerolls for a small fee.
+- [ ] Ensure at least two shop rooms appear per floor and inventory scales with difficulty.
 
 ## Context
 Shops allow players to customize builds between battles.

--- a/.codex/tasks/d801ffaa-panda3d-remake/0d21008f-main-menu-and-settings.md
+++ b/.codex/tasks/d801ffaa-panda3d-remake/0d21008f-main-menu-and-settings.md
@@ -1,12 +1,13 @@
 # Main Menu and Settings
 
 ## Summary
-Build a Panda3D-based main menu with basic settings options.
+Build a Panda3D-based main menu with navigation and options.
 
 ## Tasks
-- [ ] Create a main menu scene with start, options, and exit buttons.
-- [ ] Implement a settings submenu for sound and music volume.
-- [ ] Ensure menu navigation works with keyboard and mouse input.
+- [ ] Create a main menu with buttons for New Run, Load Run, Edit Player, Options, and Quit.
+- [ ] Implement Options submenu with sound-effects volume, music volume, and toggle for stat-screen pause behaviour.
+- [ ] Ensure keyboard and mouse navigation using DirectGUI with dark, glassy themed widgets.
+- [ ] Stub actions: New Run starts new state, Load Run lists save slots, Edit Player opens customization.
 
 ## Context
 The menu system provides entry points to gameplay and configuration.

--- a/.codex/tasks/d801ffaa-panda3d-remake/0f95beef-project-scaffold.md
+++ b/.codex/tasks/d801ffaa-panda3d-remake/0f95beef-project-scaffold.md
@@ -4,9 +4,16 @@
 Set up the initial Panda3D project structure and environment.
 
 ## Tasks
-- [ ] Create a `src/` directory with a minimal `main.py` that opens a Panda3D window.
-- [ ] Add Panda3D as a dependency in `pyproject.toml` using `uv add panda3d`.
-- [ ] Document how to run the project with `uv run python src/main.py`.
+- [ ] Move existing Pygame code into `legacy/` and keep it read-only.
+- [ ] Run `uv init` to create a fresh environment.
+- [ ] Install Panda3D and optional LLM tooling via `uv add panda3d` and `uv add --optional llm`.
+- [ ] Add `main.py` that launches `ShowBase` and renders a placeholder cube to verify the engine.
+- [ ] Scaffold directories: `assets/models/`, `assets/textures/`, `assets/audio/`, `plugins/`, `mods/`, and `llms/`.
+- [ ] Document the new directory structure in `README.md` and warn contributors not to modify `legacy/`.
+- [ ] Update `README.md` with installation instructions using `uv add git+https://github.com/Midori-AI/Midori-AI-AutoFighter@main`.
+- [ ] Define `pyproject.toml` with package name `autofighter` and expose an entry point for `main.py`.
+- [ ] Research publishing `autofighter` to PyPI and note considerations for native dependencies.
+- [ ] Commit minimal setup once `main.py` runs.
 
 ## Context
 A clean scaffold establishes the foundation for all future Panda3D development.

--- a/.codex/tasks/d801ffaa-panda3d-remake/1bfd343f-battle-room.md
+++ b/.codex/tasks/d801ffaa-panda3d-remake/1bfd343f-battle-room.md
@@ -4,9 +4,11 @@
 Create the combat room with turn-based foe interactions.
 
 ## Tasks
-- [ ] Render player and foe models or placeholders.
-- [ ] Implement turn-based logic using existing damage and passive systems.
-- [ ] Display damage numbers and status effect icons.
+- [ ] Render player and foe models or placeholders using Panda3D node graphs.
+- [ ] Implement turn-based logic using messenger events and the shared `Stats` dataclass for accuracy and damage.
+- [ ] Scale foes according to floor, room, Pressure level, and loop count.
+- [ ] Display damage numbers, status effect icons, and reusable attack effects.
+- [ ] Trigger overtime warnings after 100 turns (500 for floor bosses) with red/blue flashes and an `Enraged` buff.
 
 ## Context
 Battle rooms are the core gameplay loop and must mirror current mechanics.

--- a/.codex/tasks/d801ffaa-panda3d-remake/3b2858e1-map-generation.md
+++ b/.codex/tasks/d801ffaa-panda3d-remake/3b2858e1-map-generation.md
@@ -4,9 +4,12 @@
 Implement the run map with room nodes, links, and seeded randomization.
 
 ## Tasks
-- [ ] Generate per-floor room layouts with battle, event, shop, rest, and boss nodes.
-- [ ] Seed RNG for reproducible maps and store the seed in save data.
-- [ ] Render a vertical map UI showing room connections and player position.
+- [ ] Generate 45-room floors containing rest, chat, battle-weak, battle-normal, battle-boss, battle-boss-floor, and shop nodes.
+- [ ] Ensure each floor has at least two shops and two rest stops; chats occur after fights without consuming room count.
+- [ ] Support Pressure Level selection that scales foes and adds rooms or bosses at specified intervals.
+- [ ] Loop maps endlessly after the final floor with enemy scaling per loop.
+- [ ] Render a color-coded vertical map showing room connections, current location, and valid paths.
+- [ ] Seed each floor from a run-specific base seed and forbid seed reuse.
 
 ## Context
 The map guides progression and needs deterministic generation for testing.

--- a/.codex/tasks/d801ffaa-panda3d-remake/418f603a-upgrade-item-crafting.md
+++ b/.codex/tasks/d801ffaa-panda3d-remake/418f603a-upgrade-item-crafting.md
@@ -4,8 +4,9 @@
 Add crafting mechanics for combining lower-star upgrade items into higher-star ones.
 
 ## Tasks
-- [ ] Allow conversion of 1★ items into 2★, 2★ into 3★, and 3★ into 4★ at the specified ratios.
+- [ ] Allow conversion of 125×1★ to 1×2★, 125×2★ to 1×3★, and 125×3★ to 1×4★ items.
 - [ ] Support dual-type requirements for upgrading dual-element characters.
+- [ ] Permit trading 10×4★ items for an extra gacha pull.
 - [ ] Provide a UI panel for crafting and confirming conversions.
 
 ## Context

--- a/.codex/tasks/d801ffaa-panda3d-remake/4289a6e2-gacha-system.md
+++ b/.codex/tasks/d801ffaa-panda3d-remake/4289a6e2-gacha-system.md
@@ -4,9 +4,13 @@
 Implement the character gacha with escalating odds and upgrade-item rewards.
 
 ## Tasks
-- [ ] Create a pull interface supporting 1, 5, and 10 pulls.
-- [ ] Apply pity logic reaching 100% at 180 pulls, starting at 0.001%.
-- [ ] Grant random upgrade items on failed pulls, respecting damage-type requirements.
+- [ ] Seed the pull pool with existing player plugins and allow 1, 5, or 10 pulls.
+- [ ] Play a skippable video keyed to the highest rarity obtained and show a results menu afterward.
+- [ ] Apply pity logic starting at 0.001%, rising to ~5% at pull 159, and guaranteeing the featured character at 180 pulls.
+- [ ] Handle duplicate logic: 25% chance before completing the 5★ roster, weighted duplicates after the roster is full.
+- [ ] Grant upgrade items on failed pulls based on damage types, with item costs for upgrading and trading 10×4★ items for an extra pull.
+- [ ] Implement Vitality bonus stacking for duplicates (0.01% first, each increment +5% more than the last).
+- [ ] Serialize rewards, pity counts, and character stacks for persistence.
 
 ## Context
 The gacha provides new characters and progression outside runs.

--- a/.codex/tasks/d801ffaa-panda3d-remake/5109746a-rest-room.md
+++ b/.codex/tasks/d801ffaa-panda3d-remake/5109746a-rest-room.md
@@ -4,9 +4,9 @@
 Develop rest rooms where players can heal or spend items for upgrades.
 
 ## Tasks
-- [ ] Offer healing or upgrade-item trade options at rest sites.
-- [ ] Animate a brief rest scene to communicate the choice outcome.
-- [ ] Track rest usage per run for balance tuning.
+- [ ] Offer choices to heal or trade upgrade items for benefits.
+- [ ] Animate a brief rest scene to communicate outcomes.
+- [ ] Track rest usage per floor, ensuring at least two rest rooms appear on each floor.
 
 ## Context
 Rest rooms provide recovery opportunities between battles.

--- a/.codex/tasks/d801ffaa-panda3d-remake/56f168aa-plugin-loader.md
+++ b/.codex/tasks/d801ffaa-panda3d-remake/56f168aa-plugin-loader.md
@@ -5,7 +5,9 @@ Create a plugin-loading system compatible with the Panda3D remake.
 
 ## Tasks
 - [ ] Implement a loader that discovers Python modules under `plugins/` and registers them with the game.
-- [ ] Provide hooks for player, foe, passive, and room plugins.
+- [ ] Provide hooks for player, weapon, foe, passive, DoT, HoT, and room plugins.
+- [ ] Expose a mod interface and avoid importing legacy Pygame code.
+- [ ] Wrap Panda3D's `messenger` with an event bus so plugins can subscribe and emit without engine imports.
 - [ ] Document the plugin API and how to add new plugins.
 
 ## Context

--- a/.codex/tasks/d801ffaa-panda3d-remake/58ea00c8-stat-screen.md
+++ b/.codex/tasks/d801ffaa-panda3d-remake/58ea00c8-stat-screen.md
@@ -1,12 +1,17 @@
 # Player Stat Screen
 
 ## Summary
-Develop a detailed stat screen showing core, defensive, and status effects.
+Develop a detailed stat screen showing core, offensive, defensive, vitality, advanced, and status data.
 
 ## Tasks
-- [ ] Display Max HP, Attack, Defense, and other core stats.
-- [ ] List passives, DoTs, HoTs, damage types, and relic stacks.
-- [ ] Provide pause-menu integration for reviewing stats mid-run.
+- [ ] Display core stats: HP, Max HP, EXP, Level, EXP buff multiplier, Actions per Turn.
+- [ ] Show offense stats: Attack, Crit Rate, Crit Damage, Effect Hit Rate, base damage type.
+- [ ] Show defense stats: Defense, Mitigation, Regain, Dodge Odds, Effect Resistance.
+- [ ] Show vitality and advanced stats including Action Points, cumulative damage taken/dealt, and kills.
+- [ ] List active passives, DoTs, HoTs, damage types, and relic stacks, including all effects from the planning document.
+- [ ] Refresh the screen at a user-defined rate (default every 5 frames, adjustable 1–10).
+- [ ] Allow ESC or close to return to the previous scene, respecting the Options pause setting.
+- [ ] Expose hooks for plugins to append custom lines to the Status section.
 
 ## Context
 A comprehensive stat screen helps players track progression and effects.

--- a/.codex/tasks/d801ffaa-panda3d-remake/798aafd3-save-system-sqlcipher.md
+++ b/.codex/tasks/d801ffaa-panda3d-remake/798aafd3-save-system-sqlcipher.md
@@ -4,9 +4,12 @@
 Implement an encrypted save system using SQLCipher with salted passwords.
 
 ## Tasks
-- [ ] Integrate SQLCipher database storage for run and player data.
-- [ ] Derive encryption keys from a user-provided password plus random salt.
-- [ ] Document backup and recovery steps for encrypted saves.
+- [ ] Integrate SQLCipher to store run and player data with batched writes and compact schemas.
+- [ ] Derive encryption keys from a user-supplied salted password and store them in encrypted config with optional cloud backup.
+- [ ] Provide migration tooling for legacy saves using versioned scripts.
+- [ ] Explore alternative key sources such as OS keyrings, environment variables, or hardware tokens.
+- [ ] Wrap database access in a `SaveManager` with context-managed sessions.
+- [ ] Document backup, recovery, and key management steps.
 
 ## Context
 Encrypted saves protect player progress and enable cross-device transfers.

--- a/.codex/tasks/d801ffaa-panda3d-remake/7b715405-damage-healing-migration.md
+++ b/.codex/tasks/d801ffaa-panda3d-remake/7b715405-damage-healing-migration.md
@@ -4,8 +4,11 @@
 Port existing damage-over-time and healing-over-time systems to the new architecture.
 
 ## Tasks
+- [ ] Define a shared `Stats` dataclass for players and foes.
 - [ ] Reimplement DoT and HoT handling using Panda3D-friendly data structures.
-- [ ] Ensure stacking and reset rules match the current game's mechanics.
+- [ ] Support the following DoTs with their effects: Bleed, Celestial Atrophy, Abyssal Corruption, Abyssal Weakness, Gale Erosion, Charged Decay, Frozen Wound, Blazing Torment, Cold Wound (5-stack cap), Twilight Decay, Impact Echo.
+- [ ] Support HoTs: Regeneration, PlayerName's Echo, PlayerName's Heal.
+- [ ] Ensure stacking and reset rules match the current game's mechanics and clear after battles unless made permanent.
 - [ ] Add unit tests for each damage and healing type.
 
 ## Context

--- a/.codex/tasks/d801ffaa-panda3d-remake/7f5c8c36-audio-system.md
+++ b/.codex/tasks/d801ffaa-panda3d-remake/7f5c8c36-audio-system.md
@@ -4,9 +4,9 @@
 Integrate sound effects and music playback into the Panda3D framework.
 
 ## Tasks
-- [ ] Set up an audio manager for playing background music and sound effects.
-- [ ] Add volume controls tied to the settings menu.
-- [ ] Implement cross-fades for boss themes and overtime warnings.
+- [ ] Set up an audio manager for playing background music and sound effects with volume controls tied to settings.
+- [ ] Implement cross-fades for boss themes and overtime warnings after long battles.
+- [ ] Support toggling stat-screen pause behaviour for audio if needed.
 
 ## Context
 Audio feedback enhances immersion and communicates combat states.

--- a/.codex/tasks/d801ffaa-panda3d-remake/869cac49-main-loop-and-window.md
+++ b/.codex/tasks/d801ffaa-panda3d-remake/869cac49-main-loop-and-window.md
@@ -1,15 +1,17 @@
 # Main Loop and Window Handling
 
 ## Summary
-Implement the Panda3D application loop and basic input handling.
+Implement the Panda3D application loop, scene management, and input hooks.
 
 ## Tasks
 - [ ] Expand `main.py` with a `ShowBase` subclass to manage the app lifecycle.
+- [ ] Route events through Panda3D's `messenger` and schedule updates with `taskMgr`.
+- [ ] Add a lightweight scene manager for swapping menus, gameplay states, and overlays.
 - [ ] Handle window close events and keyboard input for quitting the game.
-- [ ] Ensure the window title reflects the game's name.
+- [ ] Set the window title to the game's name.
 
 ## Context
-A robust main loop is required before integrating menus, maps, or combat systems.
+A robust main loop with scene switching is required before integrating menus, maps, or combat systems.
 
 ## Testing
 - [ ] Run `uv run pytest`.

--- a/.codex/tasks/d801ffaa-panda3d-remake/93a6a994-testing-and-ci.md
+++ b/.codex/tasks/d801ffaa-panda3d-remake/93a6a994-testing-and-ci.md
@@ -4,8 +4,9 @@
 Establish automated tests and GitHub workflows for the Panda3D remake.
 
 ## Tasks
-- [ ] Add unit tests for new modules under `tests/`.
-- [ ] Configure a GitHub Actions workflow to run `uv run pytest` on pushes and pull requests.
+- [ ] Add unit tests for menus, stat screen, map navigation, gacha logic, and data wiring under `tests/`.
+- [ ] Configure headless Panda3D fixtures to run in CI.
+- [ ] Create a GitHub Actions workflow to run `uv run pytest` and lint on pushes and pull requests.
 - [ ] Document how to run tests locally.
 
 ## Context

--- a/.codex/tasks/d801ffaa-panda3d-remake/ad61da93-asset-pipeline.md
+++ b/.codex/tasks/d801ffaa-panda3d-remake/ad61da93-asset-pipeline.md
@@ -4,8 +4,10 @@
 Set up a pipeline for importing and optimizing art assets for Panda3D.
 
 ## Tasks
-- [ ] Define folder structure for sprites, models, and audio under `assets/`.
-- [ ] Add conversion scripts for resizing or reformatting assets as needed.
+- [ ] Research low-poly or pixelated 3D art styles and evaluate free/CC model sources for compatibility.
+- [ ] Establish a conversion workflow (e.g., Blender to `.bam`/`.egg`) with cached builds.
+- [ ] Maintain `assets/` structure for models, textures, and audio, and create an `assets.toml` manifest mapping keys to paths and hashes.
+- [ ] Build an `AssetManager` that loads and caches models, textures, and sounds on demand.
 - [ ] Document guidelines for artists to contribute compatible assets.
 
 ## Context

--- a/.codex/tasks/d801ffaa-panda3d-remake/ca46e97e-docs-and-contributor-guidelines.md
+++ b/.codex/tasks/d801ffaa-panda3d-remake/ca46e97e-docs-and-contributor-guidelines.md
@@ -4,9 +4,10 @@
 Document setup instructions and coding standards for the Panda3D remake.
 
 ## Tasks
-- [ ] Write developer setup steps for installing dependencies and running the game.
-- [ ] Outline coding style and directory conventions for new modules.
-- [ ] Provide guidelines for contributing plugins and assets.
+- [ ] Write developer setup steps for installing dependencies with `uv` and running `main.py`.
+- [ ] Outline coding style and directory conventions for the new `game/` package and `assets/` structure.
+- [ ] Warn contributors not to modify `legacy/` and explain plugin documentation expectations.
+- [ ] Provide guidelines for contributing plugins and assets, including the `Give Feedback` menu and issue links.
 
 ## Context
 Clear documentation helps new contributors get started quickly and keeps the project consistent.

--- a/.codex/tasks/d801ffaa-panda3d-remake/cbf3a725-event-room.md
+++ b/.codex/tasks/d801ffaa-panda3d-remake/cbf3a725-event-room.md
@@ -1,15 +1,16 @@
 # Event Room Implementation
 
 ## Summary
-Add interactive event rooms offering choices with rewards or penalties.
+Add interactive event or chat rooms offering choices with rewards or penalties.
 
 ## Tasks
-- [ ] Define a simple event framework with text prompts and selectable options.
-- [ ] Implement at least two sample events affecting player stats or items.
-- [ ] Ensure events respect seeded randomness for reproducibility.
+- [ ] Define an event framework with text prompts, selectable options, and seeded randomness.
+- [ ] Implement chat rooms where players can send one message to an LLM character, limited to six chats per floor.
+- [ ] Provide at least two sample events affecting player stats or items.
+- [ ] Ensure events triggered after battles do not consume the floor's room count.
 
 ## Context
-Event rooms break up combat and give players strategic decisions.
+Event and chat rooms break up combat and give players strategic decisions.
 
 ## Testing
 - [ ] Run `uv run pytest`.

--- a/.codex/tasks/d801ffaa-panda3d-remake/d6a657b0-ui-polish-and-accessibility.md
+++ b/.codex/tasks/d801ffaa-panda3d-remake/d6a657b0-ui-polish-and-accessibility.md
@@ -4,9 +4,10 @@
 Refine the user interface for clarity, responsiveness, and accessibility.
 
 ## Tasks
-- [ ] Implement scalable layouts that work on desktop and mobile resolutions.
-- [ ] Add color-blind friendly options and readable star colors.
-- [ ] Audit input navigation to ensure keyboard-only play is possible.
+- [ ] Implement dark, glassy theme with blurred gradient backgrounds, rounded panels, and accent highlights.
+- [ ] Provide color-blind friendly options and ensure star colors (1 gray, 2 blue, 3 green, 4 purple, 5 red, 6 gold) are readable.
+- [ ] Audit keyboard-only navigation and scalable layouts for desktop and mobile resolutions.
+- [ ] Offer settings to adjust or disable overtime warning colors and speed.
 
 ## Context
 Polished and accessible UI improves usability for a broader audience.

--- a/.codex/tasks/d801ffaa-panda3d-remake/f8d277d7-player-creator.md
+++ b/.codex/tasks/d801ffaa-panda3d-remake/f8d277d7-player-creator.md
@@ -4,9 +4,10 @@
 Implement the player creation screen with body types, hair options, and stat allocation.
 
 ## Tasks
-- [ ] Allow players to choose among A/B/C body types and select hair styles.
-- [ ] Provide a 100-point pool for distributing core stats.
-- [ ] Persist the created character for use in runs.
+- [ ] Allow players to choose among three body types and select hair styles, colors, and accessories.
+- [ ] Provide a 100-point pool for distributing core stats, each point granting +1% to the chosen stat.
+- [ ] Permit spending 100 of each damage type's 4★ upgrade items to purchase one additional stat point.
+- [ ] Save the created character for use in runs.
 
 ## Context
 The creator personalizes the player's avatar before entering gameplay.


### PR DESCRIPTION
## Summary
- detail Panda3D task order and individual tasks
- add audit report for Panda3D planning review

## Testing
- `uv run pytest`

------
https://chatgpt.com/codex/tasks/task_b_689031596e18832cbd18146710105bd6