### PR TITLE
[FEAT] Implement pressure-based scaling

### DIFF
--- a/.codex/implementation/map-generation.md
+++ b/.codex/implementation/map-generation.md
@@ -1,0 +1,18 @@
+# Map Generation and Pressure Scaling
+
+The map generator builds deterministic floor layouts using a seeded
+`MapGenerator`. Pressure Level influences both room structure and
+combat difficulty.
+
+## Room Adjustments
+- Base floors contain 45 rooms.
+- Every 10 Pressure Levels add one room before the floor boss.
+- Branching paths are introduced every 15 Pressure Levels. Branches
+  skip one room ahead and rejoin the main path.
+- Extra boss rooms appear at a rate of one per 20 Pressure Levels and
+  are placed throughout the floor.
+
+## Enemy Scaling
+Enemy stats scale with floor, room, and loop counts. Additional
+Pressure Level modifiers are applied via
+`autofighter.balance.pressure.apply_pressure` during battle setup.

--- a/.codex/tasks/ac8cbde0-panda3d-task-order.md
+++ b/.codex/tasks/ac8cbde0-panda3d-task-order.md
@@ -27,7 +27,7 @@ Coders must check in with the reviewer or task master before marking tasks compl
 18. [x] Shop room features (`07c1ea52`) – sell upgrade items and cards with reroll costs.
 19. [x] Event room narrative (`cbf3a725`) – deterministic choice outcomes.
 20. [x] Map generator (`3b2858e1`) – 45-room floors and looping logic.
-21. [ ] Pressure level scaling (`6600e0fd`) – adjust foe stats, room counts, and extra bosses.
+21. [x] Pressure level scaling (`6600e0fd`) – adjust foe stats, room counts, and extra bosses.
 22. [ ] Boss room encounters (`21f544d8`) – implement standard boss fights.
 23. [ ] Floor boss escalation (`51a2c5da`) – handle difficulty spikes and rewards each loop.
 24. [ ] Chat room interactions (`4185988d`) – one-message LLM chats after battles.

--- a/autofighter/balance/__init__.py
+++ b/autofighter/balance/__init__.py
@@ -1,0 +1,1 @@
+"""Balance helpers for gameplay tuning."""

--- a/autofighter/balance/pressure.py
+++ b/autofighter/balance/pressure.py
@@ -1,0 +1,16 @@
+"""Pressure level modifiers for enemy scaling."""
+
+from __future__ import annotations
+
+from autofighter.stats import Stats
+
+
+def apply_pressure(base: Stats, pressure: int) -> Stats:
+    """Return new stats scaled by pressure level."""
+    multiplier = 1 + 0.05 * pressure
+    return Stats(
+        hp=int(base.hp * multiplier),
+        max_hp=int(base.max_hp * multiplier),
+        atk=int(base.atk * multiplier),
+        defense=int(base.defense * multiplier),
+    )

--- a/autofighter/battle_room.py
+++ b/autofighter/battle_room.py
@@ -14,6 +14,7 @@ from direct.showbase.ShowBase import ShowBase
 from autofighter.gui import set_widget_pos
 from autofighter.scene import Scene
 from autofighter.stats import Stats
+from autofighter.balance.pressure import apply_pressure
 
 
 class BattleRoom(Scene):
@@ -107,13 +108,14 @@ class BattleRoom(Scene):
     def scale_foe(
         self, floor: int, room: int, pressure: int, loop: int
     ) -> Stats:
-        factor = floor * room * (1 + 0.05 * pressure) * (1.2 ** loop)
-        return Stats(
+        factor = floor * room * (1.2 ** loop)
+        base = Stats(
             hp=int(self.base_foe.hp * factor),
             max_hp=int(self.base_foe.max_hp * factor),
             atk=int(self.base_foe.atk * factor),
             defense=int(self.base_foe.defense * factor),
         )
+        return apply_pressure(base, pressure)
 
     def send_player_attack(self) -> None:
         self.app.messenger.send("player-attack")

--- a/autofighter/map_generation.py
+++ b/autofighter/map_generation.py
@@ -1,8 +1,9 @@
 """Map generation utilities for building floor layouts.
 
 Generates deterministic room sequences with required shop and rest
-stops plus optional chat rooms. Foe scaling respects floor, room,
-pressure level, and loop count.
+stops plus optional chat rooms. Pressure level raises room count,
+adds branches and bonus bosses, and foe scaling respects floor,
+room, and loop count.
 """
 
 from __future__ import annotations
@@ -39,15 +40,24 @@ class MapGenerator:
         extra_rooms = self.pressure_level // 10
         total_rooms = 45 + extra_rooms
         extra_bosses = self.pressure_level // 20
+        branch_count = min(self.pressure_level // 15, total_rooms - 2)
 
         # Preselect shop and rest positions (exclude final rooms)
         available = list(range(1, total_rooms - 1))
         shop_positions = set(rng.sample(available, k=2))
         remaining = [i for i in available if i not in shop_positions]
         rest_positions = set(rng.sample(remaining, k=2))
+        remaining = [i for i in remaining if i not in rest_positions]
 
-        # Place extra bosses near the end
-        boss_positions = list(range(total_rooms - extra_bosses - 1, total_rooms - 1))
+        # Place extra bosses across the map
+        boss_positions = set()
+        if extra_bosses:
+            boss_positions = set(rng.sample(remaining, k=extra_bosses))
+
+        # Branch positions skip ahead one room
+        branch_positions = set()
+        if branch_count:
+            branch_positions = set(rng.sample(range(1, total_rooms - 2), k=branch_count))
 
         nodes: List[MapNode] = []
         for idx in range(total_rooms):
@@ -64,13 +74,21 @@ class MapGenerator:
 
             chat_after = room_type.startswith("battle") and rng.random() < 0.3
             scale = (floor * (idx + 1))
-            scale *= 1 + 0.05 * self.pressure_level
             scale *= 1.2 ** self.loop
             scale *= rng.uniform(0.95, 1.05)
-            nodes.append(MapNode(index=idx, room_type=room_type, chat_after=chat_after, enemy_scale=scale))
+            nodes.append(
+                MapNode(
+                    index=idx,
+                    room_type=room_type,
+                    chat_after=chat_after,
+                    enemy_scale=scale,
+                )
+            )
 
             if idx + 1 < total_rooms:
                 nodes[-1].links.append(idx + 1)
+                if idx in branch_positions:
+                    nodes[-1].links.append(idx + 2)
 
         return nodes
 

--- a/tests/test_pressure_scaling.py
+++ b/tests/test_pressure_scaling.py
@@ -1,0 +1,21 @@
+from autofighter.stats import Stats
+from autofighter.map_generation import MapGenerator
+from autofighter.balance.pressure import apply_pressure
+
+
+def test_apply_pressure_scales_stats():
+    base = Stats(hp=100, max_hp=100, atk=10, defense=5)
+    scaled = apply_pressure(base, 10)
+    assert scaled.hp == 150
+    assert scaled.atk == 15
+    assert scaled.defense == 7
+
+
+def test_pressure_affects_rooms_branches_bosses():
+    gen = MapGenerator(base_seed=7, pressure_level=45)
+    nodes = gen.generate_floor(1)
+    assert len(nodes) == 49
+    branch_nodes = [n for n in nodes if len(n.links) > 1]
+    assert len(branch_nodes) == 3
+    types = [n.room_type for n in nodes]
+    assert types.count("battle_boss") == 2


### PR DESCRIPTION
## Summary
- adjust map generation to scale room count, branching, and extra bosses with pressure
- add pressure stat modifiers and apply them during battle setup
- document pressure-driven map generation

## Testing
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_b_68919b8776a8832c955e384e14d4a03b