### PR TITLE
[FIX] Improve plugin loader diagnostics

### DIFF
--- a/tests/test_plugin_loader.py
+++ b/tests/test_plugin_loader.py
@@ -34,9 +34,16 @@ def test_discovers_plugins_and_injects_bus() -> None:
             assert getattr(plugin, "bus") is bus
 
 
-def test_missing_category_raises_keyerror() -> None:
+def test_missing_category_raises_runtimeerror() -> None:
+    root = Path(__file__).resolve().parents[1] / "plugins"
+    loader = PluginLoader(required={"missing"})
+    with pytest.raises(RuntimeError):
+        loader.discover(str(root))
+
+
+def test_get_plugins_missing_category_runtimeerror() -> None:
     loader = PluginLoader()
-    with pytest.raises(KeyError):
+    with pytest.raises(RuntimeError):
         loader.get_plugins("missing")
 
 
@@ -45,7 +52,8 @@ def test_logs_import_errors(tmp_path, caplog) -> None:
     bad.write_text("raise RuntimeError('boom')\n")
     loader = PluginLoader()
     with caplog.at_level(logging.ERROR):
-        with pytest.raises(ImportError):
+        with pytest.raises(ImportError) as exc_info:
             loader.discover(str(tmp_path))
     assert "bad.py" in caplog.text
+    assert "RuntimeError: boom" in str(exc_info.value)
 


### PR DESCRIPTION
## Summary
- log import failures with tracebacks and surface details in ImportError
- raise RuntimeError for missing plugin categories and unknown category lookups
- expand plugin loader tests for success, failure, and missing categories

## Testing
- `uv run pytest tests/test_plugin_loader.py`
- `uv run pytest`

## Checklist
- [ ] Updated player roster and foe docs if adding or modifying fighters or enemies

------
https://chatgpt.com/codex/tasks/task_b_6891a9ff9f28832ca8720c45abb66e04