### PR TITLE
[FEATURE] Add gacha pity system

### DIFF
--- a/autofighter/gacha/system.py
+++ b/autofighter/gacha/system.py
@@ -2,15 +2,20 @@ from __future__ import annotations
 
 import json
 import random
-from dataclasses import dataclass
-from dataclasses import field
+
 from typing import Any
 from typing import Dict
 from typing import List
-
-from plugins.plugin_loader import PluginLoader
+from dataclasses import field
+from dataclasses import dataclass
 
 from .vitality import vitality_bonus
+from plugins.plugin_loader import PluginLoader
+
+
+DEFAULT_BASE_RATE = 0.00001
+DEFAULT_SOFT_PITY = 159
+DEFAULT_HARD_PITY = 180
 
 
 @dataclass
@@ -29,9 +34,16 @@ class GachaSystem:
         self,
         player_dir: str = "plugins/players",
         rng: random.Random | None = None,
+        base_rate: float = DEFAULT_BASE_RATE,
+        soft_pity: int = DEFAULT_SOFT_PITY,
+        hard_pity: int = DEFAULT_HARD_PITY,
     ) -> None:
         self.rng = rng or random.Random()
         self.owned: Dict[str, int] = {}
+        self.base_rate = base_rate
+        self.soft_pity = soft_pity
+        self.hard_pity = hard_pity
+        self.pity_counter = 0
 
         loader = PluginLoader()
         loader.discover(player_dir)
@@ -43,19 +55,30 @@ class GachaSystem:
 
         result = GachaResult()
         for _ in range(count):
-            if self.rng.random() < 0.5:
+            rate = self.current_rate()
+            if self.rng.random() < rate:
                 character = self.rng.choice(self.pool)
                 stacks = self.owned.get(character, 0)
                 self.owned[character] = stacks + 1
                 result.characters.append(character)
+                self.pity_counter = 0
                 if stacks:
                     result.vitality[character] = vitality_bonus(stacks)
             else:
                 result.upgrade_items += 1
+                self.pity_counter += 1
         return result
 
     def serialize(self) -> str:
-        return json.dumps({"owned": self.owned})
+        return json.dumps(
+            {
+                "owned": self.owned,
+                "pity": self.pity_counter,
+                "base_rate": self.base_rate,
+                "soft_pity": self.soft_pity,
+                "hard_pity": self.hard_pity,
+            }
+        )
 
     @classmethod
     def deserialize(
@@ -64,7 +87,24 @@ class GachaSystem:
         player_dir: str = "plugins/players",
         rng: random.Random | None = None,
     ) -> "GachaSystem":
-        obj = cls(player_dir=player_dir, rng=rng)
         payload: Dict[str, Any] = json.loads(data)
+        obj = cls(
+            player_dir=player_dir,
+            rng=rng,
+            base_rate=float(payload.get("base_rate", DEFAULT_BASE_RATE)),
+            soft_pity=int(payload.get("soft_pity", DEFAULT_SOFT_PITY)),
+            hard_pity=int(payload.get("hard_pity", DEFAULT_HARD_PITY)),
+        )
         obj.owned = {str(k): int(v) for k, v in payload.get("owned", {}).items()}
+        obj.pity_counter = int(payload.get("pity", 0))
         return obj
+
+    def current_rate(self) -> float:
+        pity = self.pity_counter + 1
+        if pity >= self.hard_pity:
+            return 1.0
+        if pity <= self.soft_pity:
+            return self.base_rate
+        span = self.hard_pity - self.soft_pity
+        progress = pity - self.soft_pity
+        return self.base_rate + (1 - self.base_rate) * (progress / span)

--- a/tests/test_gacha_system.py
+++ b/tests/test_gacha_system.py
@@ -13,6 +13,14 @@ def count_player_plugins() -> int:
     return len([p for p in path.glob("*.py") if p.name != "__init__.py"])
 
 
+class FixedRandom:
+    def random(self) -> float:
+        return 0.999999
+
+    def choice(self, seq):
+        return seq[0]
+
+
 def test_seeded_pool_matches_plugins() -> None:
     gs = GachaSystem()
     assert len(gs.pool) == count_player_plugins()
@@ -28,7 +36,7 @@ def test_failed_pull_grants_item() -> None:
 
 def test_duplicate_vitality_stack() -> None:
     gs = GachaSystem(rng=random.Random(0))
-    with patch.object(gs.rng, "random", return_value=0.1), patch.object(
+    with patch.object(gs.rng, "random", return_value=0.0), patch.object(
         gs.rng, "choice", return_value="ally"
     ):
         gs.pull(1)
@@ -39,10 +47,40 @@ def test_duplicate_vitality_stack() -> None:
 
 def test_serialization_round_trip() -> None:
     gs = GachaSystem(rng=random.Random(0))
-    with patch.object(gs.rng, "random", return_value=0.1), patch.object(
+    with patch.object(gs.rng, "random", return_value=0.0), patch.object(
         gs.rng, "choice", return_value="ally"
     ):
         gs.pull(1)
     data = gs.serialize()
     loaded = GachaSystem.deserialize(data, rng=random.Random(0))
     assert loaded.owned == gs.owned
+
+
+def test_pity_rate_escalates() -> None:
+    gs = GachaSystem(rng=FixedRandom())
+    for _ in range(gs.soft_pity - 1):
+        gs.pull(1)
+    assert gs.pity_counter == gs.soft_pity - 1
+    assert gs.current_rate() == gs.base_rate
+    gs.pull(1)
+    assert gs.pity_counter == gs.soft_pity
+    assert gs.current_rate() > gs.base_rate
+
+
+def test_hard_pity_guarantees_character() -> None:
+    gs = GachaSystem(rng=FixedRandom())
+    for _ in range(gs.hard_pity - 1):
+        result = gs.pull(1)
+        assert result.characters == []
+    result = gs.pull(1)
+    assert len(result.characters) == 1
+    assert gs.pity_counter == 0
+
+
+def test_pity_serialization_persists() -> None:
+    gs = GachaSystem(rng=FixedRandom())
+    for _ in range(10):
+        gs.pull(1)
+    data = gs.serialize()
+    loaded = GachaSystem.deserialize(data, rng=FixedRandom())
+    assert loaded.pity_counter == gs.pity_counter


### PR DESCRIPTION
## Summary
- add persistent pity counters and configurable thresholds to gacha system
- cover pity escalation and state persistence with new tests

## Testing
- `uv run pytest` *(fails: ModuleNotFoundError: No module named 'panda3d')*
- `PYTHONPATH=. uv run pytest tests/test_gacha_system.py`

------
https://chatgpt.com/codex/tasks/task_b_6891b05d0330832c885aa362dcb14d2c