### PR TITLE
[TASK] Refresh Panda3D task list after audit

### DIFF
--- a/.codex/tasks/ac8cbde0-panda3d-task-order.md
+++ b/.codex/tasks/ac8cbde0-panda3d-task-order.md
@@ -28,14 +28,14 @@ Coders must check in with the reviewer or task master before marking tasks compl
 19. [x] Event room narrative (`cbf3a725`) – deterministic choice outcomes.
 20. [x] Map generator (`3b2858e1`) – 45-room floors and looping logic.
 21. [x] Pressure level scaling (`6600e0fd`) – adjust foe stats, room counts, and extra bosses.
-22. [ ] Boss room encounters (`21f544d8`) – implement standard boss fights.
+22. [ ] Boss room encounters (`21f544d8`) – implement standard boss fights and fix `foe_attack` referencing an undefined `attack_button`.
 23. [x] Floor boss escalation (`51a2c5da`) – handle difficulty spikes and rewards each loop.
 24. [x] Chat room interactions (`4185988d`) – one-message LLM chats after battles.
 25. [x] Reward tables (`60af2878`) – define drops for normal, boss, and floor boss fights.
 26. [x] Gacha pulls (`4289a6e2`) – spend upgrade items on character rolls.
 27. [x] Gacha pity system (`f3df3de8`) – raise odds until a featured character drops.
-28. [ ] Duplicate handling (`6e2558e7`) – apply stack rules and Vitality bonuses.
-29. [ ] Gacha presentation (`a0f85dbd`) – play rarity video and show results menu.
+28. [ ] Duplicate handling (`6e2558e7`) – enforce stack rules and apply stat bonuses, not just Vitality.
+29. [ ] Gacha presentation (`a0f85dbd`) – implement `play_animation` and render a results menu after pulls.
 30. [ ] Upgrade item crafting (`418f603a`) – combine lower-star items into higher ranks.
 31. [ ] Item trade for pulls (`38fe381f`) – exchange 4★ items for gacha tickets.
 32. [x] SQLCipher schema (`798aafd3`) – store run and player data securely.
@@ -48,6 +48,7 @@ Coders must check in with the reviewer or task master before marking tasks compl
 39. [ ] UI polish and accessibility (`d6a657b0`) – dark glass theme, color-blind mode, keyboard navigation.
 40. [ ] Documentation and contributor guidelines (`ca46e97e`) – update README and contributor docs for new structure.
 41. [ ] Testing and CI integration (`93a6a994`) – add headless tests, GitHub workflows, and run `uv run pytest` last.
+42. [ ] Main menu/New Run polish (`dc3d4f2e`) – audit DirectGUI scaling, fix New Run bugs, add a character picker and map route selection before the first fight, and remove placeholder code.
 
 ## Context
 Derived from the Panda3D game plan and existing Panda3D remake task list to coordinate development.

--- a/.codex/tasks/d801ffaa-panda3d-remake/21f544d8-boss-room-encounters.md
+++ b/.codex/tasks/d801ffaa-panda3d-remake/21f544d8-boss-room-encounters.md
@@ -7,6 +7,7 @@ Implement standard boss fights that conclude each floor.
 - [ ] Load boss-specific scenes, assets, and music.
 - [ ] Define unique attack patterns and rewards for each boss.
 - [ ] Transition back to the map and grant loot after victory.
+- [ ] Ensure `foe_attack` logic does not reference missing UI elements like `attack_button`.
 - [ ] Document this feature in `.codex/implementation`.
 - [ ] Add unit tests covering success and failure cases.
 

--- a/.codex/tasks/d801ffaa-panda3d-remake/6e2558e7-gacha-duplicate-handling.md
+++ b/.codex/tasks/d801ffaa-panda3d-remake/6e2558e7-gacha-duplicate-handling.md
@@ -1,11 +1,12 @@
 # Duplicate Handling
 
 ## Summary
-Handle duplicate character pulls and apply Vitality bonuses.
+Handle duplicate character pulls and apply Vitality and stat bonuses.
 
 ## Tasks
 - [ ] Detect duplicates and stack them per character.
 - [ ] Grant Vitality bonuses with each duplicate according to rules.
+- [ ] Apply duplicate stacks to relevant stats (e.g., increasing increments by 5% per stack) and enforce stacking behaviour.
 - [ ] Update save data and roster displays after stacking.
 - [ ] Document this feature in `.codex/implementation`.
 - [ ] Add unit tests covering success and failure cases.

--- a/.codex/tasks/d801ffaa-panda3d-remake/a0f85dbd-gacha-presentation.md
+++ b/.codex/tasks/d801ffaa-panda3d-remake/a0f85dbd-gacha-presentation.md
@@ -7,6 +7,7 @@ Show a rarity-based video and results menu for gacha pulls.
 - [ ] Play a skippable animation tied to the highest rarity pulled.
 - [ ] Display a results screen listing characters and rewards.
 - [ ] Support single and multi-pull presentations.
+- [ ] Implement `play_animation` to actually play the video clip.
 - [ ] Document this feature in `.codex/implementation`.
 - [ ] Add unit tests covering success and failure cases.
 

--- a/.codex/tasks/d801ffaa-panda3d-remake/dc3d4f2e-main-menu-ui-pass.md
+++ b/.codex/tasks/d801ffaa-panda3d-remake/dc3d4f2e-main-menu-ui-pass.md
@@ -1,0 +1,22 @@
+# Main Menu UI Pass
+
+## Summary
+Audit and fix the main menu, especially the New Run flow, to resolve scaling issues and eliminate prototype code.
+
+## Tasks
+- [ ] Reproduce and fix New Run menu bugs.
+- [ ] Standardize DirectGUI scale values across all menus.
+- [ ] Show a character picker before runs start, even if no characters exist, letting players choose damage type and melee or spellcaster roles.
+- [ ] Display the floor map after setup so players can select a route instead of entering a fight immediately.
+- [ ] Remove placeholder or prototyping code from menu implementation.
+- [ ] Document this feature in `.codex/implementation`.
+- [ ] Add unit tests covering success and failure cases.
+
+## Context
+Recent feedback shows the New Run and settings menus render at inconsistent scales and rely on temporary code.
+
+## Testing
+- [ ] Run `uv run pytest`.
+
+Once complete, update this task with `status: ready for review` and request an auditor to update this status.
+status: in progress


### PR DESCRIPTION
## Summary
- expand Panda3D subtasks for duplicate bonuses and New Run flow
- capture audit fixes for boss rooms and gacha presentation

## Testing
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_b_6891c8b2ad78832c87f2d87709336213