### PR TITLE
[FIX] Remove boss room attack button

### DIFF
--- a/.codex/tasks/ac8cbde0-panda3d-task-order.md
+++ b/.codex/tasks/ac8cbde0-panda3d-task-order.md
@@ -28,7 +28,7 @@ Coders must check in with the reviewer or task master before marking tasks compl
 19. [x] Event room narrative (`cbf3a725`) – deterministic choice outcomes.
 20. [x] Map generator (`3b2858e1`) – 45-room floors and looping logic.
 21. [x] Pressure level scaling (`6600e0fd`) – adjust foe stats, room counts, and extra bosses.
-22. [ ] Boss room encounters (`21f544d8`) – implement standard boss fights and fix `foe_attack` referencing an undefined `attack_button`.
+22. [x] Boss room encounters (`21f544d8`) – implement standard boss fights and fix `foe_attack` referencing an undefined `attack_button`.
 23. [x] Floor boss escalation (`51a2c5da`) – handle difficulty spikes and rewards each loop.
 24. [x] Chat room interactions (`4185988d`) – one-message LLM chats after battles.
 25. [x] Reward tables (`60af2878`) – define drops for normal, boss, and floor boss fights.

--- a/autofighter/rooms/boss_room.py
+++ b/autofighter/rooms/boss_room.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from direct.gui.DirectGui import DGG
 from panda3d.core import LColor
 
 from autofighter.battle_room import BattleRoom
@@ -53,7 +52,6 @@ class BossRoom(BattleRoom):
             self.music = None
 
     def foe_attack(self) -> None:
-        assert self.attack_button is not None
         assert self.status_label is not None
         dmg = self.pattern[self._pattern_index]
         self._pattern_index = (self._pattern_index + 1) % len(self.pattern)
@@ -64,9 +62,9 @@ class BossRoom(BattleRoom):
         self.show_damage(self.player_model, dmg)
         self.show_attack_effect(self.foe_model, self.player_model, (1, 0, 0, 1))
         self.add_status_icon(self.player_model, LColor(0, 1, 0, 1))
-        self.status_label["text"] = f"Boss hits! Player HP: {self.player.hp}/{self.player.max_hp}"
         if self.player.hp <= 0:
-            self.attack_button["state"] = DGG.DISABLED
             self.status_label["text"] = "You were defeated!"
         else:
-            self.attack_button["state"] = DGG.NORMAL
+            self.status_label["text"] = (
+                f"Boss hits! Player HP: {self.player.hp}/{self.player.max_hp}"
+            )

--- a/tests/test_boss_room.py
+++ b/tests/test_boss_room.py
@@ -29,8 +29,12 @@ class DummyApp:
 def test_boss_room_attack_pattern() -> None:
     info = boss_patterns.get_boss_info("demo")
     stats = Stats(hp=100, max_hp=100)
-    room = BossRoom(DummyApp(), return_scene_factory=lambda: None, player=stats, boss_name="demo")
-    room.attack_button = {"state": None}
+    room = BossRoom(
+        DummyApp(),
+        return_scene_factory=lambda: None,
+        player=stats,
+        boss_name="demo",
+    )
     room.status_label = {"text": ""}
     room.player_model = object()
     room.foe_model = object()
@@ -41,6 +45,22 @@ def test_boss_room_attack_pattern() -> None:
     assert stats.hp == 100 - info.attacks[0]
     room.foe_attack()
     assert stats.hp == 100 - info.attacks[0] - info.attacks[1]
+
+
+def test_foe_attack_without_attack_button() -> None:
+    info = boss_patterns.get_boss_info("demo")
+    stats = Stats(hp=100, max_hp=100)
+    room = BossRoom(DummyApp(), return_scene_factory=lambda: None, player=stats, boss_name="demo")
+    assert not hasattr(room, "attack_button")
+    room.status_label = {"text": ""}
+    room.player_model = object()
+    room.foe_model = object()
+    room.show_damage = lambda *a, **k: None
+    room.show_attack_effect = lambda *a, **k: None
+    room.add_status_icon = lambda *a, **k: None
+    room.foe_attack()
+    assert stats.hp == 100 - info.attacks[0]
+    assert room.status_label["text"] == f"Boss hits! Player HP: {stats.hp}/{stats.max_hp}"
 
 
 def test_map_generation_loads_boss_room() -> None:


### PR DESCRIPTION
## Summary
- remove `attack_button` dependency in boss room
- add regression test for boss room attack
- mark boss room task complete

## Testing
- `uv run pytest`

------
https://chatgpt.com/codex/tasks/task_b_6891cec7f6bc832ca55c5938d55de820