### PR TITLE
[FIX] Persist shop purchases

### DIFF
--- a/.codex/implementation/shop-room.md
+++ b/.codex/implementation/shop-room.md
@@ -1,0 +1,3 @@
+# Shop Room
+
+Offers upgrade items and cards for gold with a reroll option. Purchases deduct gold, disable the item's button, and add it to the player's inventory. Leaving the room now persists the player's remaining gold and inventory using `save_player`, ensuring purchases survive reloads.

--- a/autofighter/shop_room.py
+++ b/autofighter/shop_room.py
@@ -9,6 +9,8 @@ from direct.gui.DirectGui import DirectButton
 from direct.showbase.ShowBase import ShowBase
 
 from autofighter.gui import set_widget_pos
+from autofighter.save import load_player
+from autofighter.save import save_player
 from autofighter.scene import Scene
 
 
@@ -140,4 +142,9 @@ class ShopRoom(Scene):
         return f"Gold: {self.gold}"
 
     def exit(self) -> None:
+        loaded = load_player()
+        if loaded is not None:
+            body, hair, hair_color, accessory, stats, _ = loaded
+            stats.gold = self.gold
+            save_player(body, hair, hair_color, accessory, stats, self.inventory)
         self.app.scene_manager.switch_to(self.return_scene_factory())

--- a/autofighter/stats.py
+++ b/autofighter/stats.py
@@ -10,6 +10,7 @@ class Stats:
     max_hp: int
     atk: int = 0
     defense: int = 0
+    gold: int = 0
 
     # Core
     exp: int = 0

--- a/tests/test_rest_shop_rooms.py
+++ b/tests/test_rest_shop_rooms.py
@@ -7,10 +7,12 @@ except ModuleNotFoundError:  # pragma: no cover - skip if Panda3D missing
 
     pytest.skip("Panda3D not available", allow_module_level=True)
 
+import autofighter.save as save
+
+from autofighter.stats import Stats
 from autofighter.rest_room import RestRoom
 from autofighter.shop_room import ShopItem
 from autofighter.shop_room import ShopRoom
-from autofighter.stats import Stats
 
 
 class DummyApp:
@@ -42,3 +44,32 @@ def test_shop_room_buy_disables_button() -> None:
     room.buy(item, button)
     assert room.inventory["Upgrade Stone"] == 1
     assert button["state"] == "disabled"
+
+
+def test_shop_room_purchases_persist(monkeypatch) -> None:
+    store: dict[str, tuple[str, str, str, str, Stats, dict[str, int]]] = {}
+
+    def fake_save_player(body, hair, hair_color, accessory, stats, inventory, **_kwargs):
+        store["data"] = (body, hair, hair_color, accessory, stats, inventory)
+
+    def fake_load_player(*_args, **_kwargs):
+        return store.get("data")
+
+    monkeypatch.setattr(save, "save_player", fake_save_player)
+    monkeypatch.setattr(save, "load_player", fake_load_player)
+    monkeypatch.setattr("autofighter.shop_room.save_player", fake_save_player)
+    monkeypatch.setattr("autofighter.shop_room.load_player", fake_load_player)
+
+    store["data"] = ("Athletic", "Short", "Black", "None", Stats(hp=5, max_hp=5, gold=100), {})
+
+    room = ShopRoom(DummyApp(), return_scene_factory=lambda: None, floor=1, inventory={})
+    button = {"state": "normal"}
+    item = ShopItem("Upgrade Stone", 20, 1)
+    room.buy(item, button)
+    room.exit()
+
+    loaded = save.load_player()
+    assert loaded is not None
+    _, _, _, _, stats, inventory = loaded
+    assert inventory["Upgrade Stone"] == 1
+    assert stats.gold == 80


### PR DESCRIPTION
## Summary
- save shop gold and inventory on exit
- document shop persistence

## Testing
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_b_68927aee0eb0832cbf51c173ac6a467b