### PR TITLE
[FEAT] Add audio crossfade and overtime cue

### DIFF
--- a/.codex/implementation/audio.md
+++ b/.codex/implementation/audio.md
@@ -8,5 +8,8 @@ Provides global helpers for playing music and sound effects loaded via `AssetMan
 - `play_sfx(name: str)` – play a one-shot sound effect.
 - `stop_sfx()` – stop all sound effects.
 - `set_music_volume(value: float)` / `set_sfx_volume(value: float)` – adjust volumes; active sounds update immediately.
+- `crossfade_music(name: str, duration: float = 1.0, loop: bool = True)` – fade the current music out while fading a new track in using Panda3D audio intervals.
 
 Use `get_audio()` to access the shared `AudioManager` instance. The options menu hooks into these setters so slider changes update playback volume.
+
+`BattleRoom.start_overtime()` plays a warning cue by calling `get_audio().play_sfx("overtime_warning")` when fights run long.

--- a/autofighter/audio.py
+++ b/autofighter/audio.py
@@ -21,6 +21,45 @@ except Exception:  # pragma: no cover - Panda3D not available during tests
         def stop(self) -> None:
             self.playing = False
 
+try:
+    from direct.interval.IntervalGlobal import Func
+    from direct.interval.IntervalGlobal import Parallel
+    from direct.interval.IntervalGlobal import Sequence
+    from direct.interval.IntervalGlobal import SoundInterval
+except Exception:  # pragma: no cover - Panda3D not available during tests
+    class SoundInterval:  # type: ignore[dead-code]
+        def __init__(self, sound, *, duration: float = 0.0, volume: float = 1.0) -> None:
+            self.sound = sound
+            self.volume = volume
+
+        def start(self) -> None:
+            self.sound.setVolume(self.volume)
+
+    class Func:  # type: ignore[dead-code]
+        def __init__(self, func, *args, **kwargs) -> None:
+            self.func = func
+            self.args = args
+            self.kwargs = kwargs
+
+        def start(self) -> None:
+            self.func(*self.args, **self.kwargs)
+
+    class Parallel:  # type: ignore[dead-code]
+        def __init__(self, *intervals) -> None:
+            self.intervals = intervals
+
+        def start(self) -> None:
+            for interval in self.intervals:
+                interval.start()
+
+    class Sequence:  # type: ignore[dead-code]
+        def __init__(self, *intervals) -> None:
+            self.intervals = intervals
+
+        def start(self) -> None:
+            for interval in self.intervals:
+                interval.start()
+
 from autofighter.assets.manager import AssetManager
 
 class AudioManager:
@@ -32,6 +71,7 @@ class AudioManager:
         self.sfx: list[AudioSound] = []
         self.music_volume = 0.5
         self.sfx_volume = 0.5
+        self._music_interval: Sequence | None = None
 
     def set_music_volume(self, volume: float) -> None:
         self.music_volume = volume
@@ -55,6 +95,28 @@ class AudioManager:
         if self.music is not None:
             self.music.stop()
             self.music = None
+        self._music_interval = None
+
+    def crossfade_music(
+        self, name: str, duration: float = 1.0, loop: bool = True
+    ) -> AudioSound:
+        new_sound: AudioSound = self.assets.load("audio", name)
+        new_sound.setLoop(loop)
+        new_sound.setVolume(0)
+        new_sound.play()
+        old_sound = self.music
+        self.music = new_sound
+        if old_sound is None:
+            new_sound.setVolume(self.music_volume)
+            return new_sound
+        fade_out = SoundInterval(old_sound, duration=duration, volume=0)
+        fade_in = SoundInterval(new_sound, duration=duration, volume=self.music_volume)
+        self._music_interval = Sequence(
+            Parallel(fade_out, fade_in),
+            Func(old_sound.stop),
+        )
+        self._music_interval.start()
+        return new_sound
 
     def play_sfx(self, name: str) -> AudioSound:
         sound: AudioSound = self.assets.load("audio", name)

--- a/autofighter/battle_room.py
+++ b/autofighter/battle_room.py
@@ -13,6 +13,7 @@ from autofighter.gui import set_widget_pos
 from autofighter.scene import Scene
 from autofighter.stats import Stats
 from autofighter.assets import AssetManager
+from autofighter.audio import get_audio
 from autofighter.rewards import Reward
 from autofighter.rewards import select_rewards
 from autofighter.balance.loop import scale_stats
@@ -268,6 +269,7 @@ class BattleRoom(Scene):
         assert self.overtime_label is not None
         self.overtime = True
         self.overtime_label.show()
+        get_audio().play_sfx("overtime_warning")
         if self.enraged_icon is None:
             self.enraged_icon = DirectLabel(
                 text="Enraged",

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -45,3 +45,18 @@ def test_volume_updates_adjust_playback() -> None:
     assert audio.music is None
     audio.stop_sfx()
     assert not audio.sfx
+
+
+def test_crossfade_music_stops_previous_track() -> None:
+    assets = DummyAssets()
+    audio = AudioManager(assets)
+
+    first = audio.play_music("first")
+    assert first.played is True
+
+    second = audio.crossfade_music("second", duration=0.1)
+    assert second.played is True
+    assert first.stopped is True
+    assert first.volume == 0
+    assert second.volume == audio.music_volume
+    assert audio.music is second

--- a/tests/test_battle_room.py
+++ b/tests/test_battle_room.py
@@ -63,3 +63,21 @@ def test_overtime_triggers_at_threshold() -> None:
     boss_room.turn = boss_room.overtime_threshold - 1
     boss_room.run_round()
     assert boss_room.overtime
+
+
+def test_start_overtime_plays_warning_sfx(monkeypatch) -> None:
+    room = make_room(player=Stats(hp=10, max_hp=10, atk=0, defense=0))
+    room.overtime_label = type("L", (), {"show": lambda self: None})()
+    room.enraged_icon = {}
+
+    calls: list[str] = []
+
+    class DummyAudio:
+        def play_sfx(self, name: str) -> None:  # pragma: no cover - simple capture
+            calls.append(name)
+
+    monkeypatch.setattr("autofighter.battle_room.get_audio", lambda: DummyAudio())
+
+    room.start_overtime()
+
+    assert calls == ["overtime_warning"]


### PR DESCRIPTION
## Summary
- add crossfade_music to AudioManager for smooth transitions
- play overtime warning SFX in BattleRoom
- test crossfades and overtime cue
- document audio crossfade usage

## Testing
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_b_689280e2cbe4832cb533519f7801afce