### PR TITLE
[DOC] Document plugin system

### DIFF
--- a/.codex/implementation/plugin-system.md
+++ b/.codex/implementation/plugin-system.md
@@ -1,0 +1,28 @@
+# Plugin System
+
+Describes how plugins are discovered, categorized, and connected to the event bus.
+
+## Loader Flow
+- `PluginLoader` scans each directory recursively for Python files, skipping `__init__.py` and importing the rest【F:plugins/plugin_loader.py†L24-L38】
+- After loading, any categories listed as required but missing raise a runtime error【F:plugins/plugin_loader.py†L40-L48】
+- Classes defining `plugin_type` are registered under that category and assigned the event bus when provided【F:plugins/plugin_loader.py†L67-L74】
+
+## Plugin Categories
+The following categories are bundled:
+
+- **Players** – controllable characters such as `SamplePlayer`【F:plugins/players/sample_player.py†L4-L8】
+- **Foes** – enemy combatants such as `SampleFoe`【F:plugins/foes/sample_foe.py†L4-L8】
+- **Passives** – always-on effects like `SamplePassive`【F:plugins/passives/sample_passive.py†L4-L8】
+- **DoTs** – damage-over-time effects such as `Bleed`【F:plugins/dots/bleed.py†L4-L15】
+- **HoTs** – healing-over-time effects such as `Regeneration`【F:plugins/hots/regeneration.py†L4-L9】
+- **Weapons** – attack implementations such as `SampleWeapon`【F:plugins/weapons/sample_weapon.py†L4-L8】
+- **Rooms** – scene definitions such as `SampleRoom`【F:plugins/rooms/sample_room.py†L1-L3】
+
+## Event Bus Integration
+`PluginLoader` assigns an `EventBus` instance to each plugin, letting them emit and subscribe to events without importing Panda3D's messenger directly【F:plugins/event_bus.py†L40-L54】【F:plugins/plugin_loader.py†L67-L74】
+
+## Adding New Plugin Types
+1. Create a new subfolder under `plugins/` for the category.
+2. Define classes with a unique `plugin_type` string and optional `id`.
+3. Call `PluginLoader.discover` on the new directory and access the category via `get_plugins`.
+4. Update `required` when constructing `PluginLoader` if the game should fail when the category is missing.

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ uv run pytest
 
 ## Plugins
 
-Custom modules live in `plugins/` or `mods/`. See `.codex/instructions/plugin-system.md` for details on creating new plugins.
+The game auto-discovers classes under `plugins/` and `mods/` by `plugin_type` and wires them to a shared event bus. See `.codex/implementation/plugin-system.md` for loader details and examples.
 
 ## Player Creator
 


### PR DESCRIPTION
## Summary
- document plugin loader flow, categories, and event bus integration
- link README plugin section to the new documentation

## Testing
- `uv run pytest`

------
https://chatgpt.com/codex/tasks/task_b_689280e7b58c832cad14240c28a1f024