### PR TITLE
[FEAT] Add gacha presentation

### DIFF
--- a/.codex/implementation/gacha.md
+++ b/.codex/implementation/gacha.md
@@ -21,3 +21,9 @@ A single random roll decides the outcome each pull. 6★ is checked first, then 
 
 Failed pulls increment both counters.
 
+## Presentation flow
+- `GachaPresentation.present()` determines the highest rarity in the pull batch.
+- `play_animation()` starts a Panda3D interval keyed to that rarity; `skip_animation()` finishes it early.
+- After the clip—or immediately when skipped—`show_results()` builds a DirectGUI frame listing each result.
+  - Single pulls show one entry; multiple pulls stack labels vertically.
+

--- a/autofighter/gacha/presentation.py
+++ b/autofighter/gacha/presentation.py
@@ -2,6 +2,62 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+try:
+    from direct.gui.DirectGui import DirectFrame
+    from direct.gui.DirectGui import DirectLabel
+    from direct.interval.IntervalGlobal import Func
+    from direct.interval.IntervalGlobal import Sequence
+    from direct.interval.IntervalGlobal import Wait
+except Exception:  # pragma: no cover - allow headless tests
+    class _Widget:
+        """Minimal widget stand-ins for headless tests."""
+
+        def __init__(self, **kwargs: object) -> None:
+            self.options = dict(kwargs)
+
+        def __getitem__(self, key: str) -> object:
+            return self.options.get(key)
+
+        def __setitem__(self, key: str, value: object) -> None:
+            self.options[key] = value
+
+        def destroy(self) -> None:  # noqa: D401 - match Panda3D API
+            """Pretend to remove the widget."""
+
+    class DirectFrame(_Widget):  # type: ignore[dead-code]
+        pass
+
+    class DirectLabel(_Widget):  # type: ignore[dead-code]
+        pass
+
+    class Sequence:  # type: ignore[dead-code]
+        def __init__(self, *_: object) -> None:
+            pass
+
+        def start(self) -> None:
+            pass
+
+        def finish(self) -> None:
+            pass
+
+    class Wait:  # type: ignore[dead-code]
+        def __init__(self, *_: object) -> None:
+            pass
+
+    class Func:  # type: ignore[dead-code]
+        def __init__(self, func, *args: object, **kwargs: object) -> None:
+            self.func = func
+            self.args = args
+            self.kwargs = kwargs
+
+        def __call__(self) -> None:
+            self.func(*self.args, **self.kwargs)
+
+from autofighter.gui import TEXT_COLOR
+from autofighter.gui import FRAME_COLOR
+from autofighter.gui import WIDGET_SCALE
+from autofighter.gui import set_widget_pos
+
 
 @dataclass
 class GachaResult:
@@ -14,29 +70,80 @@ class GachaResult:
 class GachaPresentation:
     """Display gacha results with rarity-based animations."""
 
+    _ANIMATION_TIME = {
+        1: 0.5,
+        2: 0.5,
+        3: 0.5,
+        4: 1.0,
+        5: 1.5,
+        6: 2.0,
+    }
+
     def __init__(self, app) -> None:
         self.app = app
         self.animation_played: int | None = None
         self.display_mode: str = "single"
         self.last_results: list[GachaResult] = []
+        self._interval: Sequence | None = None
+        self._frame: DirectFrame | None = None
+        self.result_labels: list[DirectLabel] = []
 
     def play_animation(self, rarity: int) -> None:
+        if self._interval:
+            self._interval.finish()
+        duration = self._ANIMATION_TIME.get(rarity, 0.5)
         self.animation_played = rarity
+        self._interval = Sequence(Wait(duration))
+        try:  # pragma: no cover - Panda3D only
+            self._interval.start()
+        except Exception:
+            pass
+
+    def skip_animation(self) -> None:
+        if self._interval:
+            try:  # pragma: no cover - Panda3D only
+                self._interval.finish()
+            except Exception:
+                pass
+            self._interval = None
+        self.animation_played = None
+
+    def clear_results(self) -> None:
+        if self._frame:
+            self._frame.destroy()
+        self._frame = None
+        self.result_labels.clear()
 
     def show_results(self, results: list[GachaResult]) -> list[GachaResult]:
+        self.clear_results()
         self.last_results = results
         self.display_mode = "multi" if len(results) > 1 else "single"
+        self._frame = DirectFrame(frameColor=FRAME_COLOR)
+        for i, result in enumerate(results):
+            label = DirectLabel(
+                text=f"{result.name} ({result.rarity}\u2605)",
+                text_fg=TEXT_COLOR,
+                parent=self._frame,
+                scale=WIDGET_SCALE,
+            )
+            set_widget_pos(label, (0, 0, 0.15 * (len(results) - 1 - i)))
+            self.result_labels.append(label)
         return results
 
     def present(self, results: list[GachaResult], skip: bool = False) -> list[GachaResult]:
         if not results:
-            self.animation_played = None
+            self.skip_animation()
+            self.clear_results()
             return []
 
-        if not skip:
+        if skip:
+            self.skip_animation()
+        else:
             highest = max(r.rarity for r in results)
             self.play_animation(highest)
-        else:
-            self.animation_played = None
 
         return self.show_results(results)
+
+    @property
+    def active_interval(self) -> Sequence | None:
+        return self._interval

--- a/tests/test_gacha_presentation.py
+++ b/tests/test_gacha_presentation.py
@@ -28,3 +28,21 @@ def test_skip_skips_animation() -> None:
     presentation.present(results, skip=True)
     assert presentation.animation_played is None
     assert presentation.display_mode == "single"
+
+
+def test_present_builds_results_screen() -> None:
+    presentation = GachaPresentation(object())
+    results = [GachaResult("Ally", 2), GachaResult("Becca", 5)]
+    presentation.present(results, skip=True)
+    texts = [label["text"] for label in presentation.result_labels]
+    assert texts == ["Ally (2★)", "Becca (5★)"]
+
+
+def test_skip_animation_stops_interval() -> None:
+    presentation = GachaPresentation(object())
+    results = [GachaResult("Ally", 5)]
+    presentation.present(results)
+    assert presentation.active_interval is not None
+    presentation.skip_animation()
+    assert presentation.active_interval is None
+    assert presentation.animation_played is None


### PR DESCRIPTION
## Summary
- use Panda3D intervals for gacha pull animations with skip support
- render results screen using DirectGUI widgets
- document gacha presentation flow

## Testing
- `uv run pytest`

------
https://chatgpt.com/codex/tasks/task_b_689280e9d68c832ca16326b3331085f1