### PR TITLE
[REVIEW] Panda3D task audit notes

### DIFF
--- a/.codex/reviews/ea292727-review-note.md
+++ b/.codex/reviews/ea292727-review-note.md
@@ -1,0 +1,18 @@
+# Review Note
+
+## Scope
+- .codex/planning/8a7d9c1e-panda3d-game-plan.md
+- .codex/tasks/ac8cbde0-panda3d-task-order.md
+- .codex/implementation/asset-pipeline.md
+- .codex/implementation/game-workflow.md
+- .codex/implementation/gacha-system.md
+- .codex/audit/ac8cbde0-audit-report.audit.md
+
+## Findings
+- Asset conversion and loading are documented in `asset-pipeline.md`, but the task list still shows the asset manifest step unchecked.
+- The main menu and Player Creator flows are detailed in `game-workflow.md`; however, the Player customization section in the task list leaves the implementation documentation checkbox empty.
+- `gacha-system.md` outlines a presentation flow, yet the actual gacha presentation remains unimplemented and all corresponding task items are unchecked.
+
+## Recommendations
+- Update the Panda3D task order to mark completed documentation steps for the asset manifest and Player customization.
+- Implement the gacha presentation and update both documentation and task status when complete.

--- a/.codex/tasks/TMT-8785e737-player-customization-doc-checkbox.md
+++ b/.codex/tasks/TMT-8785e737-player-customization-doc-checkbox.md
@@ -1,0 +1,10 @@
+# Mark player customization doc complete
+
+## Summary
+`game-workflow.md` documents the Player Creator, yet the corresponding line in `.codex/tasks/ac8cbde0-panda3d-task-order.md` remains unchecked.
+
+## Tasks
+- [ ] Update `.codex/tasks/ac8cbde0-panda3d-task-order.md` to check off "Document this feature in `.codex/implementation`." under **Player customization (`f8d277d7`)**.
+
+## Context
+Keeps the task list synchronized with existing documentation and reduces confusion for future reviewers.

--- a/.codex/tasks/TMT-ebeed360-asset-manifest-checkbox.md
+++ b/.codex/tasks/TMT-ebeed360-asset-manifest-checkbox.md
@@ -1,0 +1,10 @@
+# Update asset manifest checkbox
+
+## Summary
+`assets.toml` exists but `.codex/tasks/ac8cbde0-panda3d-task-order.md` still shows the manifest creation step unchecked.
+
+## Tasks
+- [ ] Mark "Create an `assets.toml` mapping logical keys to file paths and hashes" as complete in `.codex/tasks/ac8cbde0-panda3d-task-order.md`.
+
+## Context
+Ensures task list reflects current repository state so future contributors don't redo completed work.


### PR DESCRIPTION
## Summary
- record review findings for Panda3D task list and docs
- note missing task checkboxes for asset manifest and player customization docs

## Testing
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_b_6892a00fd024832c99136eb6c0640e51