### PR TITLE
[FEAT] Persist options settings

### DIFF
--- a/.codex/implementation/save-system.md
+++ b/.codex/implementation/save-system.md
@@ -26,6 +26,12 @@ with SaveManager(Path("save.db"), "password") as sm:
 - Use `key_manager.backup_key_file(src, dest)` and `key_manager.restore_key_file(src, dest)` to copy or restore the salt file.
 - High-level helpers in `autofighter/save.py` wrap `SaveManager` for run and player data.
 
+## Settings File
+
+- `autofighter/save.py` also reads and writes a plain `settings.json`.
+- `load_settings()` returns audio volumes, stat refresh rate, and pause toggle with defaults.
+- `save_settings(settings)` persists those values so Options menu changes survive restarts.
+
 ## Recovery
 - If a session exits with an exception, pending writes roll back.
 - Lost passwords or salts require restoring from backups; without both the database cannot be decrypted.

--- a/autofighter/menu.py
+++ b/autofighter/menu.py
@@ -76,8 +76,9 @@ from autofighter.gui import SLIDER_SCALE
 from autofighter.gui import TEXT_COLOR
 from autofighter.gui import WIDGET_SCALE
 from autofighter.gui import set_widget_pos
-from autofighter.save import load_player
 from autofighter.save import load_run
+from autofighter.save import load_player
+from autofighter.save import save_settings
 from autofighter.audio import get_audio
 from autofighter.scene import Scene
 from autofighter.assets import AssetManager
@@ -521,18 +522,22 @@ class OptionsMenu(Scene):
     def update_sfx(self) -> None:
         self.sfx_volume = float(self.sfx_slider["value"])
         get_audio().set_sfx_volume(self.sfx_volume)
+        save_settings(self._settings_payload())
 
     def update_music(self) -> None:
         self.music_volume = float(self.music_slider["value"])
         get_audio().set_music_volume(self.music_volume)
+        save_settings(self._settings_payload())
 
     def update_refresh(self) -> None:
         self.stat_refresh_rate = int(self.refresh_slider["value"])
         self.app.stat_refresh_rate = self.stat_refresh_rate
+        save_settings(self._settings_payload())
 
     def toggle_pause(self, _=None) -> None:
         self.pause_on_stats = bool(self.pause_button["indicatorValue"])
         self.app.pause_on_stats = self.pause_on_stats
+        save_settings(self._settings_payload())
 
     def back(self) -> None:
         self.app.scene_manager.switch_to(MainMenu(self.app))
@@ -544,3 +549,11 @@ class OptionsMenu(Scene):
     @property
     def back_button(self) -> DirectButton:
         return self._back_button
+
+    def _settings_payload(self) -> dict[str, object]:
+        return {
+            "sfx_volume": self.sfx_volume,
+            "music_volume": self.music_volume,
+            "stat_refresh_rate": self.stat_refresh_rate,
+            "pause_on_stats": self.pause_on_stats,
+        }

--- a/autofighter/save.py
+++ b/autofighter/save.py
@@ -8,6 +8,29 @@ from autofighter.saves import SaveManager
 from autofighter.stats import Stats
 
 DB_PATH = Path("save.db")
+SETTINGS_PATH = Path("settings.json")
+DEFAULT_SETTINGS: dict[str, Any] = {
+    "sfx_volume": 0.5,
+    "music_volume": 0.5,
+    "stat_refresh_rate": 5,
+    "pause_on_stats": True,
+}
+
+
+def load_settings(path: Path | None = None) -> dict[str, Any]:
+    path = path or SETTINGS_PATH
+    if path.exists():
+        try:
+            data = json.loads(path.read_text())
+            return {**DEFAULT_SETTINGS, **data}
+        except Exception:
+            return DEFAULT_SETTINGS.copy()
+    return DEFAULT_SETTINGS.copy()
+
+
+def save_settings(settings: dict[str, Any], path: Path | None = None) -> None:
+    path = path or SETTINGS_PATH
+    path.write_text(json.dumps(settings))
 
 
 def load_run(source: Path | str, password: str = "", path: Path = DB_PATH) -> Stats | None:

--- a/main.py
+++ b/main.py
@@ -4,6 +4,8 @@ from panda3d.core import WindowProperties
 from direct.showbase.ShowBase import ShowBase
 
 from autofighter.menu import MainMenu
+from autofighter.save import load_settings
+from autofighter.audio import get_audio
 from autofighter.scene import SceneManager
 from plugins.event_bus import EventBus
 from plugins.plugin_loader import PluginLoader
@@ -37,8 +39,12 @@ class AutoFighterApp(ShowBase):
         self.plugin_loader.discover("plugins")
         self.plugin_loader.discover("mods")
 
-        self.pause_on_stats = True
-        self.stat_refresh_rate = 5
+        settings = load_settings()
+        audio = get_audio()
+        audio.set_sfx_volume(settings["sfx_volume"])
+        audio.set_music_volume(settings["music_volume"])
+        self.pause_on_stats = settings["pause_on_stats"]
+        self.stat_refresh_rate = settings["stat_refresh_rate"]
         self.paused = False
 
         props = WindowProperties()

--- a/tests/test_menu.py
+++ b/tests/test_menu.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 from unittest.mock import patch
 
+import autofighter.save as save
 import autofighter.audio as audio
 
 from autofighter.gui import FRAME_COLOR
@@ -94,7 +95,8 @@ def test_load_run_menu_start_run(tmp_path: Path) -> None:
     del sys.modules['autofighter.battle_room']
 
 
-def test_options_menu_volume_arrows_update_audio() -> None:
+def test_options_menu_volume_arrows_update_audio(tmp_path: Path) -> None:
+    save.SETTINGS_PATH = tmp_path / "settings.json"
     class DummyAssets:
         def load(self, *_: object) -> object:
             return object()
@@ -115,7 +117,8 @@ def test_options_menu_volume_arrows_update_audio() -> None:
     audio._global_audio = None
 
 
-def test_options_menu_updates_refresh_rate() -> None:
+def test_options_menu_updates_refresh_rate(tmp_path: Path) -> None:
+    save.SETTINGS_PATH = tmp_path / "settings.json"
     app = DummyApp()
     menu = OptionsMenu(app)
     menu.setup()

--- a/tests/test_options_persistence.py
+++ b/tests/test_options_persistence.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import autofighter.save as save
+import autofighter.audio as audio
+
+from autofighter.menu import OptionsMenu
+
+
+class DummyApp:
+    def __init__(self) -> None:
+        self.scene_manager = object()
+        self.pause_on_stats = True
+        self.stat_refresh_rate = 5
+        self.events: dict[str, object] = {}
+
+    def accept(self, name: str, func) -> None:
+        self.events[name] = func
+
+    def ignore(self, name: str) -> None:
+        self.events.pop(name, None)
+
+    def userExit(self) -> None:  # noqa: N802 - match ShowBase
+        pass
+
+
+class DummyAssets:
+    def load(self, *_: object) -> object:
+        return object()
+
+
+def test_options_persist(tmp_path: Path) -> None:
+    save.SETTINGS_PATH = tmp_path / "settings.json"
+    audio._global_audio = audio.AudioManager(DummyAssets())
+
+    app = DummyApp()
+    menu = OptionsMenu(app)
+    menu.setup()
+
+    menu.sfx_slider["value"] = 0.7
+    menu.update_sfx()
+    menu.music_slider["value"] = 0.3
+    menu.update_music()
+    menu.refresh_slider["value"] = 7
+    menu.update_refresh()
+    menu.pause_button.setIndicatorValue(False)
+    menu.toggle_pause()
+
+    settings = save.load_settings()
+    assert settings["sfx_volume"] == 0.7
+    assert settings["music_volume"] == 0.3
+    assert settings["stat_refresh_rate"] == 7
+    assert settings["pause_on_stats"] is False
+
+    menu.teardown()
+    audio._global_audio = None


### PR DESCRIPTION
## Summary
- persist options menu values to settings.json
- load settings on startup and apply to audio and refresh/pause attributes
- test settings persistence

## Testing
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_b_6892bfd87498832cb992e130df40f447