### PR TITLE
[FEAT] Add asset retrieval helpers

### DIFF
--- a/autofighter/assets/__init__.py
+++ b/autofighter/assets/__init__.py
@@ -1,5 +1,28 @@
 """Asset management utilities for Autofighter."""
 
+from typing import Any
+
 from .manager import AssetManager
 
-__all__ = ["AssetManager"]
+ASSETS = AssetManager()
+
+
+def get_model(name: str) -> Any:
+    return ASSETS.get_model(name)
+
+
+def get_texture(name: str) -> Any:
+    return ASSETS.get_texture(name)
+
+
+def get_audio(name: str) -> Any:
+    return ASSETS.get_audio(name)
+
+
+__all__ = [
+    "AssetManager",
+    "ASSETS",
+    "get_model",
+    "get_texture",
+    "get_audio",
+]

--- a/autofighter/assets/manager.py
+++ b/autofighter/assets/manager.py
@@ -61,3 +61,18 @@ class AssetManager:
         asset = self._load_file(category, file_path)
         self.cache[category][name] = asset
         return asset
+
+    def get_model(self, name: str) -> Any:
+        """Return a model asset by ``name``."""
+
+        return self.load("models", name)
+
+    def get_texture(self, name: str) -> Any:
+        """Return a texture asset by ``name``."""
+
+        return self.load("textures", name)
+
+    def get_audio(self, name: str) -> Any:
+        """Return an audio asset by ``name``."""
+
+        return self.load("audio", name)

--- a/autofighter/audio.py
+++ b/autofighter/audio.py
@@ -60,7 +60,8 @@ except Exception:  # pragma: no cover - Panda3D not available during tests
             for interval in self.intervals:
                 interval.start()
 
-from autofighter.assets.manager import AssetManager
+from autofighter.assets import ASSETS
+from autofighter.assets import AssetManager
 
 class AudioManager:
     """Load and play music and sound effects with volume control."""
@@ -84,7 +85,7 @@ class AudioManager:
             sound.setVolume(volume)
 
     def play_music(self, name: str, loop: bool = True) -> AudioSound:
-        sound: AudioSound = self.assets.load("audio", name)
+        sound: AudioSound = self.assets.get_audio(name)
         sound.setLoop(loop)
         sound.setVolume(self.music_volume)
         sound.play()
@@ -100,7 +101,7 @@ class AudioManager:
     def crossfade_music(
         self, name: str, duration: float = 1.0, loop: bool = True
     ) -> AudioSound:
-        new_sound: AudioSound = self.assets.load("audio", name)
+        new_sound: AudioSound = self.assets.get_audio(name)
         new_sound.setLoop(loop)
         new_sound.setVolume(0)
         new_sound.play()
@@ -119,7 +120,7 @@ class AudioManager:
         return new_sound
 
     def play_sfx(self, name: str) -> AudioSound:
-        sound: AudioSound = self.assets.load("audio", name)
+        sound: AudioSound = self.assets.get_audio(name)
         sound.setLoop(False)
         sound.setVolume(self.sfx_volume)
         sound.play()
@@ -140,5 +141,5 @@ def get_audio() -> AudioManager:
 
     global _global_audio
     if _global_audio is None:
-        _global_audio = AudioManager(AssetManager())
+        _global_audio = AudioManager(ASSETS)
     return _global_audio

--- a/autofighter/battle_room.py
+++ b/autofighter/battle_room.py
@@ -12,6 +12,7 @@ from direct.showbase.ShowBase import ShowBase
 from autofighter.gui import set_widget_pos
 from autofighter.scene import Scene
 from autofighter.stats import Stats
+from autofighter.assets import ASSETS
 from autofighter.assets import AssetManager
 from autofighter.audio import get_audio
 from autofighter.rewards import Reward
@@ -63,26 +64,26 @@ class BattleRoom(Scene):
         self._flash_state = False
         self.reward: Reward | None = None
         self._round_task: Task | None = None
-        self.assets = assets or AssetManager()
+        self.assets = assets or ASSETS
         self.player_model_name = "cube"
         self.foe_model_name = "cube"
 
     def setup(self) -> None:
-        model = self.assets.load("models", self.player_model_name)
+        model = self.assets.get_model(self.player_model_name)
         if hasattr(model, "copyTo"):
             self.player_model = model.copyTo(self.app.render)
             self.player_model.setPos(-1, 10, 0)
-            texture = self.assets.load("textures", "white")
+            texture = self.assets.get_texture("white")
             try:
                 self.player_model.setTexture(texture, 1)
             except Exception:
                 pass
 
-        model = self.assets.load("models", self.foe_model_name)
+        model = self.assets.get_model(self.foe_model_name)
         if hasattr(model, "copyTo"):
             self.foe_model = model.copyTo(self.app.render)
             self.foe_model.setPos(1, 10, 0)
-            texture = self.assets.load("textures", "white")
+            texture = self.assets.get_texture("white")
             try:
                 self.foe_model.setTexture(texture, 1)
             except Exception:
@@ -222,7 +223,7 @@ class BattleRoom(Scene):
     ) -> None:
         if source is None or target is None:
             return
-        model = self.assets.load("models", "cube")
+        model = self.assets.get_model("cube")
         if not hasattr(model, "copyTo"):
             return
         effect = model.copyTo(self.app.render)
@@ -257,7 +258,7 @@ class BattleRoom(Scene):
     def add_status_icon(self, target: NodePath | None, color: LColor) -> None:
         if target is None:
             return
-        model = self.assets.load("models", "cube")
+        model = self.assets.get_model("cube")
         if hasattr(model, "copyTo"):
             icon = model.copyTo(target)
             icon.setScale(0.2)

--- a/autofighter/menu.py
+++ b/autofighter/menu.py
@@ -78,18 +78,15 @@ from autofighter.gui import WIDGET_SCALE
 from autofighter.gui import set_widget_pos
 from autofighter.save import load_player
 from autofighter.save import load_run
+from autofighter.assets import get_texture
 from autofighter.audio import get_audio
 from autofighter.scene import Scene
-from autofighter.assets import AssetManager
 
 
 ISSUE_URL = (
     "https://github.com/Midori-AI-OSS/Midori-AI-AutoFighter/issues/"
     "new?template=feedback.md&title=Feedback"
 )
-
-
-ASSETS = AssetManager()
 
 
 def add_tooltip(widget: DirectFrame | DirectButton | DirectSlider | DirectCheckButton, text: str) -> None:
@@ -127,7 +124,7 @@ class MainMenu(Scene):
                 pass
         if hasattr(self.app, "render2d") and hasattr(self.app, "taskMgr"):
             try:
-                tex = ASSETS.load("textures", "icon_refresh_cw")  # dummy texture for bg
+                tex = get_texture("icon_refresh_cw")  # dummy texture for bg
                 cm = CardMaker("bg")
                 cm.setFrame(-1, 1, -1, 1)
                 self.bg = self.app.render2d.attachNewNode(cm.generate())
@@ -160,7 +157,7 @@ class MainMenu(Scene):
         ]
         cols = 2
         for i, (label, icon_name, cmd) in enumerate(buttons):
-            img = ASSETS.load("textures", icon_name)
+            img = get_texture(icon_name)
             button = DirectButton(
                 text=label,
                 command=cmd,
@@ -364,7 +361,7 @@ class OptionsMenu(Scene):
         )
         DirectFrame(
             parent=self.sfx_slider,
-            image=ASSETS.load("textures", "icon_volume_2"),
+            image=get_texture("icon_volume_2"),
             frameColor=(0, 0, 0, 0),
             scale=WIDGET_SCALE,
             pos=(-0.7, 0, 0),
@@ -388,7 +385,7 @@ class OptionsMenu(Scene):
         )
         DirectFrame(
             parent=self.music_slider,
-            image=ASSETS.load("textures", "icon_music"),
+            image=get_texture("icon_music"),
             frameColor=(0, 0, 0, 0),
             scale=WIDGET_SCALE,
             pos=(-0.7, 0, 0),
@@ -412,7 +409,7 @@ class OptionsMenu(Scene):
         )
         DirectFrame(
             parent=self.refresh_slider,
-            image=ASSETS.load("textures", "icon_refresh_cw"),
+            image=get_texture("icon_refresh_cw"),
             frameColor=(0, 0, 0, 0),
             scale=WIDGET_SCALE,
             pos=(-0.7, 0, 0),
@@ -437,7 +434,7 @@ class OptionsMenu(Scene):
         )
         DirectFrame(
             parent=self._pause_button,
-            image=ASSETS.load("textures", "icon_pause"),
+            image=get_texture("icon_pause"),
             frameColor=(0, 0, 0, 0),
             scale=WIDGET_SCALE,
             pos=(-1.2, 0, 0),

--- a/autofighter/rooms/boss_room.py
+++ b/autofighter/rooms/boss_room.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 from panda3d.core import LColor
 from direct.gui.DirectGui import DGG
 
-from autofighter.audio import get_audio
 from autofighter.assets import AssetManager
+from autofighter.audio import get_audio
 from autofighter.battle_room import BattleRoom
 from autofighter.rooms.boss_patterns import get_boss_info
 

--- a/tests/test_asset_manager.py
+++ b/tests/test_asset_manager.py
@@ -7,6 +7,9 @@ import pytest
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
+from autofighter.assets import get_audio
+from autofighter.assets import get_model
+from autofighter.assets import get_texture
 from autofighter.assets import AssetManager
 
 
@@ -33,3 +36,16 @@ def test_hash_verification_failure() -> None:
     manager.manifest["models"]["cube"]["sha256"] = "bad"
     with pytest.raises(ValueError):
         manager.load("models", "cube")
+
+
+def test_asset_getters() -> None:
+    manager = AssetManager(Path("assets.toml"))
+    assert manager.get_model("cube") is manager.get_model("cube")
+    assert manager.get_texture("white") is manager.get_texture("white")
+    assert manager.get_audio("boss_theme") is manager.get_audio("boss_theme")
+
+
+def test_module_level_helpers() -> None:
+    assert get_model("cube") is get_model("cube")
+    assert get_texture("white") is get_texture("white")
+    assert get_audio("boss_theme") is get_audio("boss_theme")

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -24,7 +24,7 @@ class DummySound:
 
 
 class DummyAssets:
-    def load(self, _category: str, _name: str) -> DummySound:
+    def get_audio(self, _name: str) -> DummySound:
         return DummySound()
 
 


### PR DESCRIPTION
## Summary
- add category-specific asset getters and a shared AssetManager instance
- update audio, battle room, and menu to use convenience helpers
- extend asset manager tests for new getters

## Testing
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_b_6892bfed4630832c9aecdf92a2667946