### PR TITLE
[FEAT] Add responsive GUI helpers

### DIFF
--- a/.codex/implementation/plugin-system.md
+++ b/.codex/implementation/plugin-system.md
@@ -26,3 +26,15 @@ The following categories are bundled:
 2. Define classes with a unique `plugin_type` string and optional `id`.
 3. Call `PluginLoader.discover` on the new directory and access the category via `get_plugins`.
 4. Update `required` when constructing `PluginLoader` if the game should fail when the category is missing.
+
+## Responsive Widgets
+Plugins that render DirectGUI elements should scale and position them according to the current window.  Helpers in `autofighter.gui` provide normalized coordinates and scale values derived from `base.win.get_size()` and display DPI:
+
+```python
+from autofighter.gui import get_normalized_scale_pos
+
+scale, pos = get_normalized_scale_pos(640, 360)
+DirectButton(text="OK", scale=scale, pos=pos)
+```
+
+This keeps UI consistent across resolutions and helps plugins remain responsive.

--- a/autofighter/gacha/crafting_menu.py
+++ b/autofighter/gacha/crafting_menu.py
@@ -25,10 +25,10 @@ except Exception:  # pragma: no cover - headless fallback
     class ShowBase:  # type: ignore[dead-code]
         pass
 
-from autofighter.gui import FRAME_COLOR
 from autofighter.gui import TEXT_COLOR
-from autofighter.gui import WIDGET_SCALE
+from autofighter.gui import FRAME_COLOR
 from autofighter.gui import set_widget_pos
+from autofighter.gui import get_widget_scale
 from autofighter.scene import Scene
 from .crafting import craft_upgrades
 
@@ -51,14 +51,14 @@ class CraftingMenu(Scene):
             frameColor=FRAME_COLOR,
             text_fg=TEXT_COLOR,
             command=self.craft,
-            scale=WIDGET_SCALE,
+            scale=get_widget_scale(),
         )
         self._back_button = DirectButton(
             text="Back",
             frameColor=FRAME_COLOR,
             text_fg=TEXT_COLOR,
             command=self.back,
-            scale=WIDGET_SCALE,
+            scale=get_widget_scale(),
         )
         self.buttons = [self._craft_button, self._back_button]
         top = self.BUTTON_SPACING * (len(self.buttons) - 1) / 2

--- a/autofighter/gacha/presentation.py
+++ b/autofighter/gacha/presentation.py
@@ -57,8 +57,8 @@ except Exception:  # pragma: no cover - allow headless tests
 
 from autofighter.gui import TEXT_COLOR
 from autofighter.gui import FRAME_COLOR
-from autofighter.gui import WIDGET_SCALE
 from autofighter.gui import set_widget_pos
+from autofighter.gui import get_widget_scale
 
 
 @dataclass
@@ -154,7 +154,7 @@ class GachaPresentation:
             text=title,
             text_fg=TEXT_COLOR,
             parent=self._frame,
-            scale=WIDGET_SCALE,
+            scale=get_widget_scale(),
         )
         set_widget_pos(title_label, (0, 0, 0.25))
         for i, result in enumerate(results):
@@ -163,7 +163,7 @@ class GachaPresentation:
                 text=f"{prefix}{result.name} ({result.rarity}\u2605)",
                 text_fg=TEXT_COLOR,
                 parent=self._frame,
-                scale=WIDGET_SCALE,
+                scale=get_widget_scale(),
             )
             set_widget_pos(label, (0, 0, 0.15 * (len(results) - i - 1)))
             self.result_labels.append(label)

--- a/autofighter/gui.py
+++ b/autofighter/gui.py
@@ -1,9 +1,47 @@
 from __future__ import annotations
 
-WIDGET_SCALE = 0.1
-SLIDER_SCALE = WIDGET_SCALE * 3
 FRAME_COLOR = (0, 0, 0, 0.6)
 TEXT_COLOR = (1, 1, 1, 1)
+_BASE_DPI = 96
+
+
+def _window_size() -> tuple[int, int]:
+    win = getattr(globals().get("base"), "win", None)
+    if win:
+        try:
+            return win.get_size()
+        except Exception:
+            props = win.get_properties()
+            return props.get_x_size(), props.get_y_size()
+    return 800, 600
+
+
+def get_widget_scale() -> float:
+    width, height = _window_size()
+    win = getattr(globals().get("base"), "win", None)
+    dpi = _BASE_DPI
+    if win:
+        try:
+            info = win.get_display_information()
+            dpi = getattr(info, "get_pixels_per_display_unit", lambda: _BASE_DPI)() or _BASE_DPI
+        except Exception:
+            dpi = _BASE_DPI
+    return min(width, height) / (dpi * 10)
+
+
+def get_slider_scale() -> float:
+    return get_widget_scale() * 3
+
+
+def get_normalized_scale_pos(
+    x: float,
+    y: float,
+    scale_multiplier: float = 1.0,
+) -> tuple[float, tuple[float, float, float]]:
+    width, height = _window_size()
+    scale = get_widget_scale() * scale_multiplier
+    pos = (x / width) * 2 - 1, 0, 1 - (y / height) * 2
+    return scale, pos
 
 
 def set_widget_pos(widget, pos: tuple[float, float, float]) -> None:

--- a/autofighter/menu.py
+++ b/autofighter/menu.py
@@ -72,9 +72,9 @@ except Exception:  # pragma: no cover - fallback for headless tests
             return object()
 
 from autofighter.gui import FRAME_COLOR
-from autofighter.gui import SLIDER_SCALE
 from autofighter.gui import TEXT_COLOR
-from autofighter.gui import WIDGET_SCALE
+from autofighter.gui import get_slider_scale
+from autofighter.gui import get_widget_scale
 from autofighter.gui import set_widget_pos
 from autofighter.save import load_player
 from autofighter.save import load_run
@@ -98,7 +98,7 @@ def add_tooltip(widget: DirectFrame | DirectButton | DirectSlider | DirectCheckB
             text=text,
             text_fg=TEXT_COLOR,
             frameColor=FRAME_COLOR,
-            scale=WIDGET_SCALE,
+            scale=get_widget_scale(),
             parent=widget,
             pos=(0, 0, -0.2),
         )
@@ -164,11 +164,11 @@ class MainMenu(Scene):
             button = DirectButton(
                 text=label,
                 command=cmd,
-                scale=WIDGET_SCALE * 1.5,
+                scale=get_widget_scale() * 1.5,
                 frameColor=FRAME_COLOR,
                 text_fg=TEXT_COLOR,
                 image=img,
-                image_scale=WIDGET_SCALE,
+                image_scale=get_widget_scale(),
                 text_pos=(0, -0.12),
             )
             col = i % cols
@@ -291,7 +291,7 @@ class LoadRunMenu(Scene):
             button = DirectButton(
                 text=text,
                 command=cmd,
-                scale=WIDGET_SCALE,
+                scale=get_widget_scale(),
                 frameColor=FRAME_COLOR,
                 text_fg=TEXT_COLOR,
             )
@@ -358,7 +358,7 @@ class OptionsMenu(Scene):
         self.sfx_slider = DirectSlider(
             range=(0, 1),
             value=self.sfx_volume,
-            scale=SLIDER_SCALE,
+            scale=get_slider_scale(),
             frameColor=FRAME_COLOR,
             command=self.update_sfx,
         )
@@ -366,7 +366,7 @@ class OptionsMenu(Scene):
             parent=self.sfx_slider,
             image=ASSETS.load("textures", "icon_volume_2"),
             frameColor=(0, 0, 0, 0),
-            scale=WIDGET_SCALE,
+            scale=get_widget_scale(),
             pos=(-0.7, 0, 0),
         )
         DirectLabel(
@@ -374,7 +374,7 @@ class OptionsMenu(Scene):
             text="SFX Volume",
             text_fg=TEXT_COLOR,
             frameColor=(0, 0, 0, 0),
-            scale=WIDGET_SCALE,
+            scale=get_widget_scale(),
             pos=(-0.3, 0, 0),
         )
         add_tooltip(self.sfx_slider, "Adjust sound effect volume.")
@@ -382,7 +382,7 @@ class OptionsMenu(Scene):
         self.music_slider = DirectSlider(
             range=(0, 1),
             value=self.music_volume,
-            scale=SLIDER_SCALE,
+            scale=get_slider_scale(),
             frameColor=FRAME_COLOR,
             command=self.update_music,
         )
@@ -390,7 +390,7 @@ class OptionsMenu(Scene):
             parent=self.music_slider,
             image=ASSETS.load("textures", "icon_music"),
             frameColor=(0, 0, 0, 0),
-            scale=WIDGET_SCALE,
+            scale=get_widget_scale(),
             pos=(-0.7, 0, 0),
         )
         DirectLabel(
@@ -398,7 +398,7 @@ class OptionsMenu(Scene):
             text="Music Volume",
             text_fg=TEXT_COLOR,
             frameColor=(0, 0, 0, 0),
-            scale=WIDGET_SCALE,
+            scale=get_widget_scale(),
             pos=(-0.3, 0, 0),
         )
         add_tooltip(self.music_slider, "Adjust background music volume.")
@@ -406,7 +406,7 @@ class OptionsMenu(Scene):
         self.refresh_slider = DirectSlider(
             range=(1, 10),
             value=self.stat_refresh_rate,
-            scale=SLIDER_SCALE,
+            scale=get_slider_scale(),
             frameColor=FRAME_COLOR,
             command=self.update_refresh,
         )
@@ -414,7 +414,7 @@ class OptionsMenu(Scene):
             parent=self.refresh_slider,
             image=ASSETS.load("textures", "icon_refresh_cw"),
             frameColor=(0, 0, 0, 0),
-            scale=WIDGET_SCALE,
+            scale=get_widget_scale(),
             pos=(-0.7, 0, 0),
         )
         DirectLabel(
@@ -422,7 +422,7 @@ class OptionsMenu(Scene):
             text="Refresh Rate",
             text_fg=TEXT_COLOR,
             frameColor=(0, 0, 0, 0),
-            scale=WIDGET_SCALE,
+            scale=get_widget_scale(),
             pos=(-0.3, 0, 0),
         )
         add_tooltip(self.refresh_slider, "Update stats every N frames.")
@@ -433,13 +433,13 @@ class OptionsMenu(Scene):
             text_fg=TEXT_COLOR,
             indicatorValue=self.pause_on_stats,
             command=self.toggle_pause,
-            scale=WIDGET_SCALE,
+            scale=get_widget_scale(),
         )
         DirectFrame(
             parent=self._pause_button,
             image=ASSETS.load("textures", "icon_pause"),
             frameColor=(0, 0, 0, 0),
-            scale=WIDGET_SCALE,
+            scale=get_widget_scale(),
             pos=(-1.2, 0, 0),
         )
         add_tooltip(self._pause_button, "Stop gameplay while viewing stats.")
@@ -449,7 +449,7 @@ class OptionsMenu(Scene):
             frameColor=FRAME_COLOR,
             text_fg=TEXT_COLOR,
             command=self.back,
-            scale=WIDGET_SCALE,
+            scale=get_widget_scale(),
         )
         add_tooltip(self._back_button, "Return to main menu.")
         self.widgets = [

--- a/autofighter/player_creator.py
+++ b/autofighter/player_creator.py
@@ -40,8 +40,8 @@ except Exception:  # pragma: no cover - fallback for headless tests
 
 from autofighter.gui import TEXT_COLOR
 from autofighter.gui import FRAME_COLOR
-from autofighter.gui import WIDGET_SCALE
 from autofighter.gui import set_widget_pos
+from autofighter.gui import get_widget_scale
 from autofighter.save import save_player
 from autofighter.scene import Scene
 from autofighter.stats import Stats
@@ -95,72 +95,72 @@ class PlayerCreator(Scene):
         label_x = -0.8
         control_x = 0.2
 
-        body_label = DirectLabel(text="Body Type", scale=WIDGET_SCALE)
+        body_label = DirectLabel(text="Body Type", scale=get_widget_scale())
         set_widget_pos(body_label, (label_x, 0, 0.8))
         body = DirectOptionMenu(
             text="Body",
             items=self.body_options,
             initialitem=0,
             command=self.set_body,
-            scale=WIDGET_SCALE,
+            scale=get_widget_scale(),
         )
         set_widget_pos(body, (control_x, 0, 0.8))
-        hair_label = DirectLabel(text="Hair Style", scale=WIDGET_SCALE)
+        hair_label = DirectLabel(text="Hair Style", scale=get_widget_scale())
         set_widget_pos(hair_label, (label_x, 0, 0.6))
         hair = DirectOptionMenu(
             text="Hair",
             items=self.hair_options,
             initialitem=0,
             command=self.set_hair,
-            scale=WIDGET_SCALE,
+            scale=get_widget_scale(),
         )
         set_widget_pos(hair, (control_x, 0, 0.6))
-        color_label = DirectLabel(text="Hair Color", scale=WIDGET_SCALE)
+        color_label = DirectLabel(text="Hair Color", scale=get_widget_scale())
         set_widget_pos(color_label, (label_x, 0, 0.4))
         color = DirectOptionMenu(
             text="Color",
             items=self.color_options,
             initialitem=0,
             command=self.set_color,
-            scale=WIDGET_SCALE,
+            scale=get_widget_scale(),
         )
         set_widget_pos(color, (control_x, 0, 0.4))
-        accessory_label = DirectLabel(text="Accessory", scale=WIDGET_SCALE)
+        accessory_label = DirectLabel(text="Accessory", scale=get_widget_scale())
         set_widget_pos(accessory_label, (label_x, 0, 0.2))
         accessory = DirectOptionMenu(
             text="Accessory",
             items=self.accessory_options,
             initialitem=0,
             command=self.set_accessory,
-            scale=WIDGET_SCALE,
+            scale=get_widget_scale(),
         )
         set_widget_pos(accessory, (control_x, 0, 0.2))
-        hp_label = DirectLabel(text="HP", scale=WIDGET_SCALE)
+        hp_label = DirectLabel(text="HP", scale=get_widget_scale())
         set_widget_pos(hp_label, (label_x, 0, 0.0))
         hp_slider = DirectSlider(
             range=(0, self.total_points),
             value=0,
-            scale=WIDGET_SCALE * 5,
+            scale=get_widget_scale() * 5,
             command=self.on_slider_change,
             extraArgs=["hp"],
         )
         set_widget_pos(hp_slider, (control_x, 0, 0.0))
-        atk_label = DirectLabel(text="Attack", scale=WIDGET_SCALE)
+        atk_label = DirectLabel(text="Attack", scale=get_widget_scale())
         set_widget_pos(atk_label, (label_x, 0, -0.2))
         atk_slider = DirectSlider(
             range=(0, self.total_points),
             value=0,
-            scale=WIDGET_SCALE * 5,
+            scale=get_widget_scale() * 5,
             command=self.on_slider_change,
             extraArgs=["atk"],
         )
         set_widget_pos(atk_slider, (control_x, 0, -0.2))
-        def_label = DirectLabel(text="Defense", scale=WIDGET_SCALE)
+        def_label = DirectLabel(text="Defense", scale=get_widget_scale())
         set_widget_pos(def_label, (label_x, 0, -0.4))
         def_slider = DirectSlider(
             range=(0, self.total_points),
             value=0,
-            scale=WIDGET_SCALE * 5,
+            scale=get_widget_scale() * 5,
             command=self.on_slider_change,
             extraArgs=["defense"],
         )
@@ -170,18 +170,18 @@ class PlayerCreator(Scene):
             "atk": atk_slider,
             "defense": def_slider,
         }
-        self.remaining_label = DirectLabel(text=f"Points left: {self.total_points}", scale=WIDGET_SCALE)
+        self.remaining_label = DirectLabel(text=f"Points left: {self.total_points}", scale=get_widget_scale())
         set_widget_pos(self.remaining_label, (0, 0, -0.55))
         self.helper_label = DirectLabel(
             text="",
             frameColor=FRAME_COLOR,
             text_fg=TEXT_COLOR,
-            scale=WIDGET_SCALE,
+            scale=get_widget_scale(),
         )
         set_widget_pos(self.helper_label, (0, 0, -0.7))
-        confirm = DirectButton(text="Confirm", command=self.confirm, state="normal", scale=WIDGET_SCALE)
+        confirm = DirectButton(text="Confirm", command=self.confirm, state="normal", scale=get_widget_scale())
         set_widget_pos(confirm, (0, 0, -0.85))
-        cancel = DirectButton(text="Cancel", command=self.cancel, scale=WIDGET_SCALE)
+        cancel = DirectButton(text="Cancel", command=self.cancel, scale=get_widget_scale())
         set_widget_pos(cancel, (0, 0, -0.95))
         self.confirm_button = confirm
         for widget, msg in [


### PR DESCRIPTION
## Summary
- compute DirectGUI scale and normalized positions based on current window size and DPI
- update menus and gacha interfaces to use responsive scaling
- document responsive widget helpers for plugin authors

## Testing
- `uv run pytest`

------
https://chatgpt.com/codex/tasks/task_b_6892c8e5065c832c996993d06b0f0295