### PR TITLE
[FEAT] Scale main menu dynamically

### DIFF
--- a/autofighter/gui.py
+++ b/autofighter/gui.py
@@ -1,9 +1,37 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from direct.showbase.ShowBase import ShowBase
+
 WIDGET_SCALE = 0.1
 SLIDER_SCALE = WIDGET_SCALE * 3
 FRAME_COLOR = (0, 0, 0, 0.6)
 TEXT_COLOR = (1, 1, 1, 1)
+
+
+def get_aspect(app: ShowBase | object) -> float:
+    """Return the application's window aspect ratio."""
+    if hasattr(app, "getAspectRatio"):
+        try:
+            return float(app.getAspectRatio())
+        except Exception:
+            pass
+    if hasattr(app, "win"):
+        try:
+            w = app.win.getXSize()
+            h = app.win.getYSize()
+        except Exception:
+            return 1.0
+        return w / h if h else 1.0
+    return 1.0
+
+
+def scale_ui(app: ShowBase | object, value: float) -> float:
+    """Scale a UI value based on the window aspect ratio."""
+    aspect = get_aspect(app)
+    return value / max(aspect, 1.0)
 
 
 def set_widget_pos(widget, pos: tuple[float, float, float]) -> None:

--- a/autofighter/menu.py
+++ b/autofighter/menu.py
@@ -71,9 +71,10 @@ except Exception:  # pragma: no cover - fallback for headless tests
         def getDefault() -> object:
             return object()
 
+from autofighter.gui import scale_ui
+from autofighter.gui import TEXT_COLOR
 from autofighter.gui import FRAME_COLOR
 from autofighter.gui import SLIDER_SCALE
-from autofighter.gui import TEXT_COLOR
 from autofighter.gui import WIDGET_SCALE
 from autofighter.gui import set_widget_pos
 from autofighter.save import load_player
@@ -116,9 +117,6 @@ class MainMenu(Scene):
         self.index = 0
         self.bg = None
 
-    BUTTON_SPACING_X = 0.6
-    BUTTON_SPACING_Y = 0.4
-
     def setup(self) -> None:
         if hasattr(self.app, "disableMouse"):
             try:
@@ -158,7 +156,11 @@ class MainMenu(Scene):
             ("Give Feedback", "icon_message_square", self.give_feedback),
             ("Quit", "icon_power", self.app.userExit),
         ]
+        spacing_x = scale_ui(self.app, 0.6)
+        spacing_y = scale_ui(self.app, 0.4)
+        img_scale = scale_ui(self.app, WIDGET_SCALE)
         cols = 2
+        rows = math.ceil(len(buttons) / cols)
         for i, (label, icon_name, cmd) in enumerate(buttons):
             img = ASSETS.load("textures", icon_name)
             button = DirectButton(
@@ -168,13 +170,13 @@ class MainMenu(Scene):
                 frameColor=FRAME_COLOR,
                 text_fg=TEXT_COLOR,
                 image=img,
-                image_scale=WIDGET_SCALE,
+                image_scale=img_scale,
                 text_pos=(0, -0.12),
             )
             col = i % cols
             row = i // cols
-            x = (col - (cols - 1) / 2) * self.BUTTON_SPACING_X
-            y = ((len(buttons) // cols - 1) / 2 - row) * self.BUTTON_SPACING_Y
+            x = (col - (cols - 1) / 2) * spacing_x
+            y = ((rows - 1) / 2 - row) * spacing_y
             set_widget_pos(button, (x, 0, y))
             add_tooltip(button, label)
             self.buttons.append(button)


### PR DESCRIPTION
## Summary
- adjust main menu layout and icon scaling using a window-aware utility

## Testing
- `uv run pytest`

## Checklist
- [ ] Updated player roster and foe docs if adding or modifying fighters or enemies

------
https://chatgpt.com/codex/tasks/task_b_6892c8ed33d8832cb4430b3d22fa1e05