### PR TITLE
[ENH] Make player creator responsive

### DIFF
--- a/.codex/instructions/player-creator.md
+++ b/.codex/instructions/player-creator.md
@@ -13,3 +13,6 @@ Distribute 100 points across HP, Attack, and Defense using sliders. Spending 100
 
 ## Saving
 Confirming writes the chosen appearance and stats to `player.json`, which is loaded when starting a new run.
+
+## Layout
+Widget positions and scales are computed from the current window size via `gui.get_normalized_scale_pos`.  Add new widgets to the `_responsive` list in `PlayerCreator` to keep them updating on resize.


### PR DESCRIPTION
## Summary
- make player creator widgets resize and reposition with window size
- document responsive layout approach for player creator

## Testing
- `uv run pytest`

------
https://chatgpt.com/codex/tasks/task_b_6892dd83175c832c9db4d7b2685cebb1