### PR TITLE
[TASK] Guard against blown-up menus

### DIFF
--- a/.codex/planning/8a7d9c1e-panda3d-game-plan.md
+++ b/.codex/planning/8a7d9c1e-panda3d-game-plan.md
@@ -7,6 +7,7 @@ Fully remake the Pygame-based roguelike autofighter in Panda3D with 3D-ready arc
 - Redesign the main menu with a high-contrast grid of large icons inspired by Arknights.
 - Standardize on Lucide icons and provide clear labels for every menu item.
 - Audit Player and Settings menus for missing labels and verify UI scaling, font sizes, and DPI handling.
+ - Menus are currently rendering at an oversized scale; introduce a global DirectGUI scaling system and regression checks so layouts stay consistent across resolutions.
 
 ## 1. Project Setup
 1. Move current Pygame code into `legacy/`.
@@ -54,9 +55,10 @@ Fully remake the Pygame-based roguelike autofighter in Panda3D with 3D-ready arc
        - Present a 100-point stat pool; each point grants +1% to a chosen stat.
        - Clamp allocations so the total never exceeds the available points.
        - Spending 100 of each damage type's 4★ upgrade items buys one extra point.
-       - Attempting to spend bonus points without sufficient 4★ items shows a warning and prevents confirmation.
-       - Confirmation stays disabled until the 100 base points are allocated; bonus points can remain unspent.
+     - Attempting to spend bonus points without sufficient 4★ items shows a warning and prevents confirmation.
+     - Confirmation stays disabled until the 100 base points are allocated; bonus points can remain unspent.
    - Use DirectGUI and ensure keyboard/mouse navigation.
+   - Provide a centralized scaling helper so menus keep their intended size regardless of window resolution.
 3. **Options submenu**
    - Sound-effects volume.
    - Music volume.

--- a/.codex/tasks/ac8cbde0-panda3d-task-order.md
+++ b/.codex/tasks/ac8cbde0-panda3d-task-order.md
@@ -305,14 +305,14 @@ Coders must check in with the reviewer or task master before marking tasks compl
    - [ ] Perform smoke builds on supported platforms to catch cross-OS issues.
    - [ ] Document this feature in `.codex/implementation`.
    - [ ] Add unit tests covering success and failure cases.
-42. [ ] Main menu/New Run polish (`dc3d4f2e`) – audit DirectGUI scaling, fix New Run bugs, add a character picker and map route selection before the first fight, and remove placeholder code.
+42. [ ] Main menu/New Run polish (`dc3d4f2e`) – fix oversized menu scaling, audit DirectGUI values to prevent regressions, resolve New Run bugs, add a character picker and map route selection before the first fight, and remove placeholder code.
    - [ ] Reproduce and fix New Run menu bugs.
-   - [ ] Standardize DirectGUI scale values across all menus.
+   - [ ] Standardize DirectGUI scale values across all menus and implement a global scaling helper tied to window size so widgets never render blown up.
    - [ ] Show a character picker before runs start, even if no characters exist, letting players choose damage type and melee or spellcaster roles.
    - [ ] Display the floor map after setup so players can select a route instead of entering a fight immediately.
    - [ ] Remove placeholder or prototyping code from menu implementation.
    - [ ] Document this feature in `.codex/implementation`.
-   - [ ] Add unit tests covering success and failure cases.
+   - [ ] Add unit tests covering success and failure cases, including regression tests for menu scaling.
 
 43. [ ] Feedback menu button (`2a9e7f14`) – open a pre-filled GitHub issue from the in-game menu.
     - [x] Add a `Give Feedback` option to the main menu.


### PR DESCRIPTION
## Summary
- note Panda3D task order now calls for global DirectGUI scaling helper and regression tests to avoid oversized menus
- reflect menu scaling issue in Panda3D game plan and add centralized scaling helper requirement

## Testing
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_b_6894300bf99c832c84891f1aacf99129