### PR TITLE
[TASK] Reorder Panda3D task flow for early gameplay

### DIFF
--- a/.codex/planning/8a7d9c1e-panda3d-game-plan.md
+++ b/.codex/planning/8a7d9c1e-panda3d-game-plan.md
@@ -9,6 +9,15 @@ Fully remake the Pygame-based roguelike autofighter in Panda3D with 3D-ready arc
 - Audit Player and Settings menus for missing labels and verify UI scaling, font sizes, and DPI handling.
  - Menus are currently rendering at an oversized scale; introduce a global DirectGUI scaling system and regression checks so layouts stay consistent across resolutions.
 
+## Immediate Playable Flow
+1. Finalize the main menu so New Run can trigger the gameplay loop.
+2. Initialize a run when New Run is selected and show a basic floor map.
+3. Allow entering a single unthemed placeholder room from the map and returning afterward.
+4. Define character types: Type A (Masculine), Type B (Feminine), and Type C (Androgynous).
+5. Import all characters from the Pygame version and tag them with their type.
+6. Provide a party picker that lets the player choose four owned characters plus the player.
+7. Use the selected party to begin the run.
+
 ## 1. Project Setup
 1. Move current Pygame code into `legacy/`.
 2. Run `uv init` to create a fresh environment.
@@ -47,16 +56,20 @@ Fully remake the Pygame-based roguelike autofighter in Panda3D with 3D-ready arc
    - Anchor the grid near the bottom edge with generous spacing for touch targets.
    - Reserve space for a central banner showcasing events and a top bar with player avatar, name, and currencies.
    - Cluster quick-access icons (notifications, mail, settings) in corners without overlapping main content.
-   - Option stubs:
-     - *New Run* starts a fresh state.
-     - *Load Run* lists save slots.
-     - *Edit Player* opens customization.
-       - Offer three body types and selectable hair styles, colors, and accessories.
+     - Option stubs:
+     - *New Run* begins the run setup flow.
+        - Present a party picker for four owned characters plus the player.
+        - If fewer than four characters are owned, allow starting with one to five party members; the player is always included.
+        - After selection, display the floor map.
+        - Allow entering a single unthemed room and returning to the map.
+      - *Load Run* lists save slots.
+      - *Edit Player* opens customization.
+       - Offer Type A (Masculine), Type B (Feminine), and Type C (Androgynous) body types with selectable hair styles, colors, and accessories.
        - Present a 100-point stat pool; each point grants +1% to a chosen stat.
        - Clamp allocations so the total never exceeds the available points.
-       - Spending 100 of each damage type's 4★ upgrade items buys one extra point.
-     - Attempting to spend bonus points without sufficient 4★ items shows a warning and prevents confirmation.
-     - Confirmation stays disabled until the 100 base points are allocated; bonus points can remain unspent.
+       - Spending 100 of each non-Generic damage type's 4★ upgrade item (Light, Dark, Wind, Lightning, Fire, Ice) buys one extra point; players must buy or craft these items before they can be spent.
+      - Attempting to spend bonus points without sufficient 4★ items shows a warning and prevents confirmation.
+      - Confirmation stays disabled until all available points—including any bonus points—are allocated.
    - Use DirectGUI and ensure keyboard/mouse navigation.
    - Provide a centralized scaling helper so menus keep their intended size regardless of window resolution.
 3. **Options submenu**
@@ -152,6 +165,7 @@ Fully remake the Pygame-based roguelike autofighter in Panda3D with 3D-ready arc
 
 ## 6. Gacha Character Recruitment
 1. Between runs, players spend collected upgrade items on gacha pulls for recruitable characters and chatable allies.
+    - Each character is classified as Type A (Masculine), Type B (Feminine), or Type C (Androgynous).
    - Seed the pool with existing player plugins such as Ally, Becca, Bubbles, Carly, Chibi, Graygray, Hilander, Kboshi, Lady Darkness, Lady Echo, Lady Fire and Ice, Lady Light, Luna, Mezzy, and Mimic.
 2. Pull options: spend for exactly 1, 5, or 10 pulls; players cannot choose other batch sizes.
    - Play a pre-made video keyed to the highest rarity obtained (1★–6★); videos are skippable or fast-forwardable.
@@ -162,7 +176,8 @@ Fully remake the Pygame-based roguelike autofighter in Panda3D with 3D-ready arc
    - Before completing the 5★ roster: 25% chance to pull a duplicate, 75% new 5★.
    - After collecting all 5★ characters: 25% chance to get a duplicate of a heavily stacked 5★, 75% chance for a 5★ with few stacks; 6★ rolls remain extremely rare.
 5. Vitality bonus: first duplicate adds 0.01%; each additional stack adds 5% more than the previous increment (0.01%, 0.0105%, 0.011025%, ...). Vitality increases EXP gain and all other stats.
-6. Failed pulls give upgrade items (1★–4★) matching damage types; dual-type characters require both types.
+6. Failed pulls give upgrade items (1★–4★) for each damage type—Generic, Light, Dark, Wind, Lightning, Fire, and Ice; dual-type characters require both types.
+   - Player stat upgrades require collecting 4★ items from all non-Generic damage types to eventually choose a base damage type.
    - Costs: 1000×1★, 500×2★, 100×3★, or 20×4★ items per upgrade level.
    - 125 lower-star items combine into one higher star.
    - Trading 10×4★ items grants one additional pull.
@@ -174,6 +189,8 @@ Fully remake the Pygame-based roguelike autofighter in Panda3D with 3D-ready arc
     - Implement a `GachaManager` handling pity counts, roll tables, and reward serialization.
     - Define `UpgradeItem` and `Character` dataclasses to represent inventory pieces and recruitable units.
     - Store upgrade items and character stacks in the encrypted save database for cross-run persistence.
+11. Party picker lets players choose four owned characters plus the player before starting a run.
+
 
 ## 7. Encrypted Save System
 1. Store run and player data in SQLite secured with SQLCipher.

--- a/.codex/tasks/ac8cbde0-panda3d-task-order.md
+++ b/.codex/tasks/ac8cbde0-panda3d-task-order.md
@@ -75,7 +75,35 @@ Coders must check in with the reviewer or task master before marking tasks compl
     - [x] Stub actions: New Run starts new state, Load Run lists save slots, Edit Player opens customization.
     - [x] Document this feature in `.codex/implementation`.
     - [x] Add unit tests covering success and failure cases.
-9. [x] Options submenu (`8e57e5f2`) – sound-effects volume, music volume, and stat-screen pause toggle.
+9. [ ] Run start and map display (`dc3d4f2e`) – start a new run, show a basic map, and route to a placeholder room.
+   - [ ] Start a run state when New Run is selected.
+   - [ ] Display a simple floor map after initializing the run.
+   - [ ] Remove placeholder menu code and wire the scene manager.
+   - [ ] Document this feature in `.codex/implementation`.
+   - [ ] Add unit tests covering success and failure cases.
+10. [ ] Placeholder room (`344b9c4a`) – load a single unthemed battle room.
+   - [ ] Define a minimal room scene and enter it from the map.
+   - [ ] Return to the map when the room is cleared.
+   - [ ] Document this feature in `.codex/implementation`.
+   - [ ] Add unit tests covering success and failure cases.
+11. [ ] Character types (`f20caf99`) – Type A (Masculine), Type B (Feminine), Type C (Androgynous).
+   - [ ] Create an enum for the three body types.
+   - [ ] Tag player and plugin characters with their type.
+   - [ ] Document this feature in `.codex/implementation`.
+   - [ ] Add unit tests covering success and failure cases.
+12. [ ] Legacy character import (`7406afba`) – add all characters from the Pygame version.
+   - [ ] Port stats and abilities for Ally, Becca, Bubbles, Carly, Chibi, Graygray, Hilander, Kboshi, Lady Darkness, Lady Echo, Lady Fire and Ice, Lady Light, Luna, Mezzy, Mimic, and others.
+   - [ ] Recreate characters in the new architecture without reusing legacy code.
+   - [ ] Verify each character loads as a plugin.
+   - [ ] Document this feature in `.codex/implementation`.
+   - [ ] Add unit tests covering success and failure cases.
+13. [ ] Party picker (`f9c45e2e`) – choose four owned characters plus the player for each run.
+   - [ ] Build a selection UI listing owned characters with type icons.
+   - [ ] Allow runs to start with one to five party members, always including the player; cap at five.
+   - [ ] Persist the selected party into the new run state.
+   - [ ] Document this feature in `.codex/implementation`.
+   - [ ] Add unit tests covering success and failure cases.
+14. [x] Options submenu (`8e57e5f2`) – sound-effects volume, music volume, and stat-screen pause toggle.
    - [x] Implement sound-effects and music volume sliders tied to the audio system.
    - [x] Provide a toggle for pausing the stat screen during gameplay.
    - [x] Persist settings across sessions.
@@ -83,25 +111,25 @@ Coders must check in with the reviewer or task master before marking tasks compl
    - [x] Document control icons and labels in `.codex/instructions/options-menu.md`.
    - [x] Document this feature in `.codex/implementation`.
    - [x] Add unit tests covering success and failure cases.
-10. [ ] Player customization (`f8d277d7`) – body types, hair styles, colors, and accessories.
-   - [x] Allow players to choose among three body types.
+15. [ ] Player customization (`f8d277d7`) – body types, hair styles, colors, and accessories.
+   - [ ] Allow players to choose among Type A (Masculine), Type B (Feminine), and Type C (Androgynous) body types.
    - [x] Provide hair styles, colors, and accessory options.
    - [x] Save the chosen appearance for use in runs.
    - [x] Document this feature in `.codex/implementation`.
    - [x] Add unit tests covering success and failure cases.
-11. [x] Stat allocation (`4edfa4f8`) – 100‑point pool granting +1% increments per stat.
+16. [x] Stat allocation (`4edfa4f8`) – 100‑point pool granting +1% increments per stat.
    - [x] Provide UI for distributing points among core stats.
    - [x] Clamp allocations to remaining points and enforce the +1% rule.
-   - [x] Display remaining points and prevent confirmation until all are spent or saved.
+   - [x] Display remaining points and prevent confirmation until all available points, including any bonus points, are spent.
    - [x] Document this feature in `.codex/implementation`.
    - [x] Add unit tests covering success and failure cases.
-12. [x] Item bonus confirmation (`c0fd96e6`) – ensure upgrade-item points persist after player creation.
-   - [x] Track 4★ upgrade item spending and apply bonus stat points.
+17. [x] Item bonus confirmation (`c0fd96e6`) – ensure upgrade-item points persist after player creation.
+   - [x] Track spending of 4★ upgrade items—acquired via purchase or crafting—and apply bonus stat points as normal allocations.
    - [x] Warn when items are insufficient or bonuses exceed limits.
    - [x] Persist purchased bonuses to saves and the stat screen.
    - [x] Document this feature in `.codex/implementation`.
    - [x] Add unit tests covering success and failure cases.
-13. [x] Stat screen display (`58ea00c8`) – grouped stats, status effects, and relics.
+18. [x] Stat screen display (`58ea00c8`) – grouped stats, status effects, and relics.
    - [x] Display core stats: HP, Max HP, EXP, Level, EXP buff multiplier, Actions per Turn.
    - [x] Show offense stats: Attack, Crit Rate, Crit Damage, Effect Hit Rate, base damage type.
    - [x] Show defense stats: Defense, Mitigation, Regain, Dodge Odds, Effect Resistance.
@@ -112,13 +140,13 @@ Coders must check in with the reviewer or task master before marking tasks compl
    - [x] Expose hooks for plugins to append custom lines to the Status section.
    - [x] Document this feature in `.codex/implementation`.
    - [x] Add unit tests covering success and failure cases.
-14. [x] Stat screen refresh control (`5855e3fe`) – configurable update frequency.
+19. [x] Stat screen refresh control (`5855e3fe`) – configurable update frequency.
    - [x] Default refresh rate to every 5 frames.
    - [x] Let players choose a rate from 1 to 10 frames.
    - [x] Respect the pause setting from the Options menu.
    - [x] Document this feature in `.codex/implementation`.
    - [x] Add unit tests covering success and failure cases.
-15. [ ] Battle room core (`1bfd343f`) – combat scenes with stat-driven accuracy.
+20. [ ] Battle room core (`1bfd343f`) – combat scenes with stat-driven accuracy.
    - [x] Render player and foe models or placeholders using Panda3D node graphs.
    - [x] Implement turn-based logic using messenger events and the shared `Stats` dataclass for accuracy and damage.
    - [x] Scale foes according to floor, room, Pressure level, and loop count.
@@ -126,32 +154,32 @@ Coders must check in with the reviewer or task master before marking tasks compl
    - [x] Trigger overtime warnings after 100 turns (500 for floor bosses) with red/blue flashes and an `Enraged` buff.
    - [ ] Document this feature in `.codex/implementation`.
    - [ ] Add unit tests covering success and failure cases.
-16. [ ] Overtime warnings (`4e282a5d`) – flash room after 100 turns or 500 on floor bosses.
+21. [ ] Overtime warnings (`4e282a5d`) – flash room after 100 turns or 500 on floor bosses.
    - [ ] Count turns during battles and detect overtime thresholds.
    - [ ] Trigger visual or audio cues when overtime begins.
    - [ ] Reset the warning after combat ends.
    - [ ] Document this feature in `.codex/implementation`.
    - [ ] Add unit tests covering success and failure cases.
-17. [ ] Rest room features (`5109746a`) – healing or item trades with per-floor limits.
+22. [ ] Rest room features (`5109746a`) – healing or item trades with per-floor limits.
    - [x] Offer choices to heal or trade upgrade items for benefits.
    - [x] Animate a brief rest scene to communicate outcomes.
    - [x] Track rest usage per floor, ensuring at least two rest rooms appear on each floor.
    - [ ] Document this feature in `.codex/implementation`.
    - [ ] Add unit tests covering success and failure cases.
-18. [ ] Shop room features (`07c1ea52`) – sell upgrade items and cards with reroll costs.
+23. [ ] Shop room features (`07c1ea52`) – sell upgrade items and cards with reroll costs.
    - [x] Design a shop interface listing items with prices, star ratings, and limited stock.
    - [x] Implement purchasing logic that deducts gold, grants items, and supports rerolls for a small fee.
    - [x] Ensure at least two shop rooms appear per floor and inventory scales with difficulty.
    - [ ] Document this feature in `.codex/implementation`.
    - [ ] Add unit tests covering success and failure cases.
-19. [ ] Event room narrative (`cbf3a725`) – deterministic choice outcomes.
+24. [ ] Event room narrative (`cbf3a725`) – deterministic choice outcomes.
    - [x] Define an event framework with text prompts, selectable options, and seeded randomness.
    - [x] Implement chat rooms where players can send one message to an LLM character, limited to six chats per floor.
    - [x] Provide at least two sample events affecting player stats or items.
    - [x] Ensure events triggered after battles do not consume the floor's room count.
    - [ ] Document this feature in `.codex/implementation`.
    - [ ] Add unit tests covering success and failure cases.
-20. [ ] Map generator (`3b2858e1`) – 45-room floors and looping logic.
+25. [ ] Map generator (`3b2858e1`) – 45-room floors and looping logic.
    - [x] Generate 45-room floors containing rest, chat, battle-weak, battle-normal, battle-boss, battle-boss-floor, and shop nodes.
    - [x] Ensure each floor has at least two shops and two rest stops; chats occur after fights without consuming room count.
    - [x] Support Pressure Level selection that scales foes and adds rooms or bosses at specified intervals.
@@ -160,81 +188,82 @@ Coders must check in with the reviewer or task master before marking tasks compl
    - [x] Seed each floor from a run-specific base seed and forbid seed reuse.
    - [ ] Document this feature in `.codex/implementation`.
    - [ ] Add unit tests covering success and failure cases.
-21. [ ] Pressure level scaling (`6600e0fd`) – adjust foe stats, room counts, and extra bosses.
+26. [ ] Pressure level scaling (`6600e0fd`) – adjust foe stats, room counts, and extra bosses.
    - [ ] Scale foe stats proportionally to pressure.
    - [ ] Modify floor layouts to add rooms or branches as pressure increases.
    - [ ] Spawn extra bosses at high pressure thresholds.
    - [ ] Document this feature in `.codex/implementation`.
    - [ ] Add unit tests covering success and failure cases.
-22. [ ] Boss room encounters (`21f544d8`) – implement standard boss fights and fix `foe_attack` referencing an undefined `attack_button`.
+27. [ ] Boss room encounters (`21f544d8`) – implement standard boss fights and fix `foe_attack` referencing an undefined `attack_button`.
    - [ ] Load boss-specific scenes, assets, and music.
    - [ ] Define unique attack patterns and rewards for each boss.
    - [ ] Transition back to the map and grant loot after victory.
    - [ ] Ensure `foe_attack` logic does not reference missing UI elements like `attack_button`.
    - [ ] Document this feature in `.codex/implementation`.
    - [ ] Add unit tests covering success and failure cases.
-23. [ ] Floor boss escalation (`51a2c5da`) – handle difficulty spikes and rewards each loop.
+28. [ ] Floor boss escalation (`51a2c5da`) – handle difficulty spikes and rewards each loop.
    - [ ] Boost boss stats and mechanics after every loop.
    - [ ] Scale loot tables to match higher difficulty.
    - [ ] Sync escalation with pressure level progression.
    - [ ] Document this feature in `.codex/implementation`.
    - [ ] Add unit tests covering success and failure cases.
-24. [ ] Chat room interactions (`4185988d`) – one-message LLM chats after battles.
+29. [ ] Chat room interactions (`4185988d`) – one-message LLM chats after battles.
    - [ ] Load a chat scene that appears after combat.
    - [ ] Send the player's message to the configured LLM and display its response.
    - [ ] Provide a skip option to return to the map quickly.
    - [ ] Document this feature in `.codex/implementation`.
    - [ ] Add unit tests covering success and failure cases.
-25. [ ] Reward tables (`60af2878`) – define drops for normal, boss, and floor boss fights.
+30. [ ] Reward tables (`60af2878`) – define drops for normal, boss, and floor boss fights.
    - [ ] Create weighted reward pools for each fight type.
    - [ ] Include upgrade items, cards, and rare drops with probabilities.
    - [ ] Integrate reward tables into battle resolution.
    - [ ] Document this feature in `.codex/implementation`.
    - [ ] Add unit tests covering success and failure cases.
-26. [ ] Gacha pulls (`4289a6e2`) – spend upgrade items on character rolls.
+31. [ ] Gacha pulls (`4289a6e2`) – spend upgrade items on character rolls.
    - [ ] Seed the pull pool with existing player plugins and allow 1, 5, or 10 pulls.
    - [ ] Play a skippable video keyed to the highest rarity obtained and show a results menu afterward.
    - [ ] Apply pity logic starting at 0.001%, rising to ~5% at pull 159, and guaranteeing the featured character at 180 pulls.
    - [ ] Handle duplicate logic: 25% chance before completing the 5★ roster, weighted duplicates after the roster is full.
    - [ ] Grant upgrade items on failed pulls based on damage types, with item costs for upgrading and trading 10×4★ items for an extra pull.
+   - [ ] Provide upgrade items for each damage type—Generic, Light, Dark, Wind, Lightning, Fire, Ice—in 1★–4★ tiers; player stat upgrades require one 4★ item from every non-Generic type.
    - [ ] Implement Vitality bonus stacking for duplicates (0.01% first, each increment +5% more than the last).
    - [ ] Serialize rewards, pity counts, and character stacks for persistence.
    - [ ] Document this feature in `.codex/implementation`.
    - [ ] Add unit tests covering success and failure cases.
-27. [ ] Gacha pity system (`f3df3de8`) – raise odds until a featured character drops.
+32. [ ] Gacha pity system (`f3df3de8`) – raise odds until a featured character drops.
    - [ ] Track consecutive pulls without the featured character.
    - [ ] Raise drop rates according to the pity curve and guarantee at 180 pulls.
    - [ ] Reset pity after obtaining the featured character.
    - [ ] Document this feature in `.codex/implementation`.
    - [ ] Add unit tests covering success and failure cases.
-28. [x] Duplicate handling (`6e2558e7`) – enforce stack rules and apply stat bonuses, not just Vitality.
+33. [x] Duplicate handling (`6e2558e7`) – enforce stack rules and apply stat bonuses, not just Vitality.
    - [x] Detect duplicates and stack them per character.
    - [x] Grant Vitality bonuses with each duplicate according to rules.
    - [x] Apply duplicate stacks to relevant stats (e.g., increasing increments by 5% per stack) and enforce stacking behaviour.
    - [x] Update save data and roster displays after stacking.
    - [x] Document this feature in `.codex/implementation`.
    - [x] Add unit tests covering success and failure cases.
-29. [x] Gacha presentation (`a0f85dbd`) – implement `play_animation` and render a results menu after pulls.
+34. [x] Gacha presentation (`a0f85dbd`) – implement `play_animation` and render a results menu after pulls.
    - [x] Play a skippable animation tied to the highest rarity pulled.
    - [x] Display a results screen listing characters and rewards.
    - [x] Support single and multi-pull presentations.
    - [x] Implement `play_animation` to actually play the video clip.
    - [x] Document this feature in `.codex/implementation`.
    - [x] Add unit tests covering success and failure cases.
-30. [ ] Upgrade item crafting (`418f603a`) – combine lower-star items into higher ranks.
+35. [ ] Upgrade item crafting (`418f603a`) – combine lower-star items into higher ranks.
    - [ ] Allow conversion of 125×1★ to 1×2★, 125×2★ to 1×3★, and 125×3★ to 1×4★ items.
    - [ ] Support dual-type requirements for upgrading dual-element characters.
    - [ ] Permit trading 10×4★ items for an extra gacha pull.
    - [ ] Provide a UI panel for crafting and confirming conversions.
    - [ ] Document this feature in `.codex/implementation`.
    - [ ] Add unit tests covering success and failure cases.
-31. [ ] Item trade for pulls (`38fe381f`) – exchange 4★ items for gacha tickets.
+36. [ ] Item trade for pulls (`38fe381f`) – exchange 4★ items for gacha tickets.
    - [ ] Provide a trade interface within the gacha menu.
    - [ ] Deduct items and grant a ticket when the trade is confirmed.
    - [ ] Prevent trades when the player lacks sufficient items.
    - [ ] Document this feature in `.codex/implementation`.
    - [ ] Add unit tests covering success and failure cases.
-32. [ ] SQLCipher schema (`798aafd3`) – store run and player data securely.
+37. [ ] SQLCipher schema (`798aafd3`) – store run and player data securely.
    - [ ] Integrate SQLCipher to store run and player data with batched writes and compact schemas.
    - [ ] Derive encryption keys from a user-supplied salted password and store them in encrypted config with optional cloud backup.
    - [ ] Provide migration tooling for legacy saves using versioned scripts.
@@ -243,19 +272,19 @@ Coders must check in with the reviewer or task master before marking tasks compl
    - [ ] Document backup, recovery, and key management steps.
    - [ ] Document this feature in `.codex/implementation`.
    - [ ] Add unit tests covering success and failure cases.
-33. [ ] Save key management (`428e9823`) – derive and back up salted-password keys.
+38. [ ] Save key management (`428e9823`) – derive and back up salted-password keys.
    - [ ] Generate keys from a salted user password.
    - [ ] Store a backup copy in a secure location.
    - [ ] Rotate keys and re-encrypt saves when the password changes.
    - [ ] Document this feature in `.codex/implementation`.
    - [ ] Add unit tests covering success and failure cases.
-34. [ ] Migration tooling (`72fc9ac3`) – versioned scripts for forward-compatible saves.
+39. [ ] Migration tooling (`72fc9ac3`) – versioned scripts for forward-compatible saves.
    - [ ] Track schema versions and available migrations.
    - [ ] Apply migrations automatically when loading older saves.
    - [ ] Document how to add new migration steps.
    - [ ] Document this feature in `.codex/implementation`.
    - [ ] Add unit tests covering success and failure cases.
-35. [ ] Asset style research (`ad61da93`) – choose art direction and free model sources.
+40. [ ] Asset style research (`ad61da93`) – choose art direction and free model sources.
    - [ ] Research low-poly or pixelated 3D art styles and evaluate free/CC model sources for compatibility.
    - [ ] Establish a conversion workflow (e.g., Blender to `.bam`/`.egg`) with cached builds.
    - [ ] Maintain `assets/` structure for models, textures, and audio, and create an `assets.toml` manifest mapping keys to paths and hashes.
@@ -263,39 +292,39 @@ Coders must check in with the reviewer or task master before marking tasks compl
    - [ ] Document guidelines for artists to contribute compatible assets.
    - [ ] Document this feature in `.codex/implementation`.
    - [ ] Add unit tests covering success and failure cases.
-36. [ ] Conversion workflow (`10bd22da`) – build pipeline to Panda3D formats.
+41. [ ] Conversion workflow (`10bd22da`) – build pipeline to Panda3D formats.
    - [ ] Define steps to export models and textures to `.bam` or `.egg`.
    - [ ] Cache converted assets to avoid redundant work.
    - [ ] Integrate the conversion into the build pipeline.
    - [ ] Document this feature in `.codex/implementation`.
    - [ ] Add unit tests covering success and failure cases.
-37. [ ] AssetManager with manifest (`d5824730`) – load and cache assets via `assets.toml`.
+42. [ ] AssetManager with manifest (`d5824730`) – load and cache assets via `assets.toml`.
    - [x] Create an `assets.toml` mapping logical keys to file paths and hashes.
    - [x] Build an AssetManager to load and cache models, textures, and sounds.
    - [x] Expose a simple API for other systems to request assets by key.
    - [x] Document this feature in `.codex/implementation`.
    - [x] Add unit tests covering success and failure cases, including missing entries and cache reuse.
-38. [x] Audio system (`7f5c8c36`) – play music and effects with volume control.
+43. [x] Audio system (`7f5c8c36`) – play music and effects with volume control.
    - [x] Set up an audio manager for playing background music and sound effects with volume controls tied to settings.
    - [x] Implement cross-fades for boss themes and overtime warnings after long battles.
    - [x] Support toggling stat-screen pause behaviour for audio if needed.
    - [x] Document this feature in `.codex/implementation`.
    - [x] Add unit tests covering success and failure cases.
-39. [ ] UI polish and accessibility (`d6a657b0`) – dark glass theme, color-blind mode, keyboard navigation.
+44. [ ] UI polish and accessibility (`d6a657b0`) – dark glass theme, color-blind mode, keyboard navigation.
    - [ ] Implement dark, glassy theme with blurred gradient backgrounds, rounded panels, and accent highlights.
    - [ ] Provide color-blind friendly options and ensure star colors (1 gray, 2 blue, 3 green, 4 purple, 5 red, 6 gold) are readable.
    - [ ] Audit keyboard-only navigation and scalable layouts for desktop and mobile resolutions.
    - [ ] Offer settings to adjust or disable overtime warning colors and speed.
    - [ ] Document this feature in `.codex/implementation`.
    - [ ] Add unit tests covering success and failure cases.
-40. [ ] Documentation and contributor guidelines (`ca46e97e`) – update README and contributor docs for new structure.
+45. [ ] Documentation and contributor guidelines (`ca46e97e`) – update README and contributor docs for new structure.
    - [ ] Write developer setup steps for installing dependencies with `uv` and running `main.py`.
    - [ ] Outline coding style and directory conventions for the new `game/` package and `assets/` structure.
    - [ ] Warn contributors not to modify `legacy/` and explain plugin documentation expectations.
    - [ ] Provide guidelines for contributing plugins and assets, including the `Give Feedback` menu and issue links.
    - [ ] Document this feature in `.codex/implementation`.
    - [ ] Add unit tests covering success and failure cases.
-41. [ ] Testing and CI integration (`93a6a994`) – add headless tests, GitHub workflows, and run `uv run pytest` last.
+46. [ ] Testing and CI integration (`93a6a994`) – add headless tests, GitHub workflows, and run `uv run pytest` last.
    - [ ] Add unit tests for menus, stat screen, map navigation, gacha logic, and data wiring under `tests/`.
    - [ ] Configure headless Panda3D fixtures to run in CI.
    - [ ] Create a GitHub Actions workflow to run `uv run pytest` and lint on pushes and pull requests.
@@ -305,16 +334,7 @@ Coders must check in with the reviewer or task master before marking tasks compl
    - [ ] Perform smoke builds on supported platforms to catch cross-OS issues.
    - [ ] Document this feature in `.codex/implementation`.
    - [ ] Add unit tests covering success and failure cases.
-42. [ ] Main menu/New Run polish (`dc3d4f2e`) – fix oversized menu scaling, audit DirectGUI values to prevent regressions, resolve New Run bugs, add a character picker and map route selection before the first fight, and remove placeholder code.
-   - [ ] Reproduce and fix New Run menu bugs.
-   - [ ] Standardize DirectGUI scale values across all menus and implement a global scaling helper tied to window size so widgets never render blown up.
-   - [ ] Show a character picker before runs start, even if no characters exist, letting players choose damage type and melee or spellcaster roles.
-   - [ ] Display the floor map after setup so players can select a route instead of entering a fight immediately.
-   - [ ] Remove placeholder or prototyping code from menu implementation.
-   - [ ] Document this feature in `.codex/implementation`.
-   - [ ] Add unit tests covering success and failure cases, including regression tests for menu scaling.
-
-43. [ ] Feedback menu button (`2a9e7f14`) – open a pre-filled GitHub issue from the in-game menu.
+47. [ ] Feedback menu button (`2a9e7f14`) – open a pre-filled GitHub issue from the in-game menu.
     - [x] Add a `Give Feedback` option to the main menu.
     - [x] Launch the user's browser with a pre-filled GitHub issue template.
     - [x] Document this feature in `.codex/implementation`.


### PR DESCRIPTION
## Summary
- reorder Panda3D tasks to focus on main menu, run start, map, placeholder room, character types, legacy roster import, and party picker
- expand Panda3D game plan with immediate playable flow, menu run-setup notes, and character type classifications
- clarify that 4★ upgrade items must be bought or crafted and all stat points—including bonuses—must be spent

## Testing
- `uv run pytest`

## Checklist
- [ ] Updated player roster and foe docs if adding or modifying fighters or enemies


------
https://chatgpt.com/codex/tasks/task_b_689437882c34832caa08f9ab29b27d89