### PR TITLE
[DOC] Refine card and relic plans

### DIFF
--- a/.codex/planning/726d03ae-card-plan.md
+++ b/.codex/planning/726d03ae-card-plan.md
@@ -1,0 +1,44 @@
+# Card Design
+
+Parent: [Panda3D Game Remake Planning](8a7d9c1e-panda3d-game-plan.md)
+
+## Guiding Principles
+- Cards are unique rewards with a single copy each.
+- Strength scales by star rank: 1★ offers tiny bonuses, while 5★ radically changes how battles play out.
+
+## 1★ Cards
+- **Micro Blade** – +3% ATK.
+- **Polished Shield** – +3% DEF.
+- **Sturdy Vest** – +3% HP.
+- **Lucky Coin** – +3% Crit Rate.
+- **Sharpening Stone** – +3% Crit Damage.
+- **Mindful Tassel** – +3% Effect Hit Rate.
+- **Calm Beads** – +3% Effect Res.
+- **Energizing Tea** – +3% Energy Regeneration.
+- **Thick Skin** – +3% Bleed Resist.
+- **Balanced Diet** – +3% HP & +3% DEF.
+
+## 2★ Cards
+- **Critical Focus** – Grants +55% ATK. At the start of each ally's turn they gain 1 stack of *Critical Boost*. *Critical Boost* stacks indefinitely, granting +0.5% Crit Rate and +5% Crit Damage per stack but vanishes when the unit is hit.
+- **Critical Transfer** – When an ally uses their Ultimate, they inherit all *Critical Boost* stacks and gain +4% ATK per stack for that turn.
+- **Iron Guard** – +55% DEF; whenever an ally takes damage, all allies gain +10% DEF for 1 turn, stacking endlessly.
+- **Swift Footwork** – Allies take +1 action per turn; their first action each combat costs 0 Energy.
+- **Mystic Aegis** – +55% Effect Res; upon resisting a debuff, heal 5% Max HP.
+- **Vital Surge** – +55% Max HP; while below 50% HP, gain +55% ATK.
+- **Elemental Spark** – +55% ATK & +55% Effect Hit Rate; all debuffs a random ally applies gain +5% potency.
+
+## 3★ Cards
+- **Critical Overdrive** – While an ally has *Critical Boost*, their Crit Rate increases by 10%. Every 1% of excess Crit Rate converts to +2% Crit Damage. Grants +255% ATK.
+- **Iron Resurgence** – +200% DEF & +200% HP; the first time an ally dies, revive them with 10% HP. Effect recharges every 4 turns.
+- **Arc Lightning** – +255% ATK; every attack chains 50% damage to a random foe.
+
+## 4★ Cards
+- **Overclock** – +240% ATK & +240% Effect Hit Rate; at the start of each battle, all allies immediately take two actions back to back.
+- **Iron Resolve** – +240% DEF & +240% HP; the first time an ally dies, revive them at 30% HP. This effect refreshes every 3 turns.
+- **Arcane Repeater** – +240% ATK; each attack has a 30% chance to immediately repeat at 50% power.
+
+## 5★ Cards
+- **Phantom Ally** – +1500% ATK; on the first turn, summon a temporary copy of a random ally to fight for you.
+- **Temporal Shield** – +3000% DEF & +3000% HP; each turn has a 50% chance to grant 99% damage reduction for that turn.
+- **Reality Split** – +1500% ATK; at the start of each turn, a random ally gains +50% Crit Rate and their attacks leave an After Image that echoes 25% of the damage to all foes.
+

--- a/.codex/planning/8a7d9c1e-panda3d-game-plan.md
+++ b/.codex/planning/8a7d9c1e-panda3d-game-plan.md
@@ -48,6 +48,8 @@ Fully remake the Pygame-based roguelike autofighter in Panda3D with 3D-ready arc
 - [Player Stat Screen](a28124e9-player-stat-screen-plan.md)
 - [Map and Room Types](e158df1a-map-and-room-types-plan.md)
 - [Gacha Character Recruitment](82dc97b7-gacha-character-recruitment-plan.md)
+- [Card Design](726d03ae-card-plan.md)
+- [Relic Design](bd48a561-relic-plan.md)
 - [Encrypted Save System](43054f8b-encrypted-save-system-plan.md)
 - [Asset Pipeline](0c92aee1-asset-pipeline-plan.md)
 - [Testing and Iteration](0fc17c39-testing-and-iteration-plan.md)

--- a/.codex/planning/bd48a561-relic-plan.md
+++ b/.codex/planning/bd48a561-relic-plan.md
@@ -1,0 +1,46 @@
+# Relic Design
+
+Parent: [Panda3D Game Remake Planning](8a7d9c1e-panda3d-game-plan.md)
+
+## Guiding Principles
+- Relics are permanent passives that trigger automatically once obtained.
+- Multiple copies can be collected and their effects stack without cap.
+- Strength follows star rank just like cards: low stars give tiny boosts; high stars can reshape entire runs.
+- *Aftertaste* is a damage FX with a base pot of 25 and a random 0.1–1.5 modifier; several relics reference this effect.
+
+## 1★ Relics
+- **Rusty Buckle** – At the start of combat, the ally with the lowest Max HP gains a self-inflicted bleed for 1% of their Max HP plus 1% per stack. Every 10% HP lost triggers 5 hits of Aftertaste to all foes, each hit equal to 0.5% of the total HP lost. Each additional copy adds 3 hits.
+- **Threadbare Cloak** – Allies start battle with a shield equal to 3% Max HP; each copy adds another 3%.
+- **Lucky Button** – +3% Crit Rate; missed crits add +3% Crit Rate next turn.
+- **Bent Dagger** – +3% ATK; whenever a foe dies, gain +1% ATK for the rest of combat per stack.
+- **Old Coin** – +3% gold earned; first shop purchase costs 3% less plus 3% per stack.
+- **Shiny Pebble** – +3% DEF; the first time an ally is hit, they gain +3% mitigation for 1 turn.
+- **Herbal Charm** – Recover 0.5% HP per turn plus 0.5% per stack.
+- **Tattered Flag** – +3% party Max HP; when an ally falls, all survivors gain +3% ATK.
+- **Wooden Idol** – +3% Effect Res; resisting a debuff grants +1% Effect Res for the next turn per stack.
+- **Pocket Manual** – +3% damage; every 10th hit deals an extra 3% damage as Aftertaste.
+
+## 2★ Relics
+- **Vengeful Pendant** – Whenever an ally is hit, deal 15% of the damage taken back to the attacker, plus 15% per additional copy.
+- **Arcane Flask** – After an ally uses their Ultimate, grant a shield equal to 20% Max HP plus 20% per stack.
+- **Echo Bell** – The first action each ally takes every battle repeats at 15% power plus 15% per stack.
+- **Frost Sigil** – Each hit on a foe applies a chill that deals 5% ATK as one hit of Aftertaste plus one additional hit per stack.
+- **Ember Stone** – When an ally below 25% HP is hit, deal a burn equal to 50% ATK plus 50% per stack to the attacker.
+- **Guardian Charm** – At the start of combat, the ally with the lowest HP gains +20% DEF plus 20% per stack.
+- **Killer Instinct** – When an ally uses their Ultimate, they gain +75% ATK for that turn; if they kill a foe, they immediately take another turn.
+
+## 3★ Relics
+- **Greed Engine** – All characters lose 1% HP per turn plus 0.5% per stack. Earn 50% more gold plus 25% per stack and increase rare drop rate by 0.005% plus 0.001% per stack.
+- **Stellar Compass** – Critical hits grant +1.5% ATK and +1.5% gold for the rest of combat, stacking without limit.
+- **Echoing Drum** – The first attack an ally uses each battle repeats at 25% power plus 25% per stack.
+
+## 4★ Relics
+- **Null Lantern** – Shops and rest rooms no longer appear. All foes are buffed by 150% for each fight cleared while holding this relic. Every fight now drops 1 pull plus 1 per stack.
+- **Traveler's Charm** – When an ally is hit, they gain +25% DEF and +10% mitigation for the next turn plus 25% DEF and +10% mitigation per stack.
+- **Timekeeper's Hourglass** – At the start of each turn, there is a 10% chance plus 1% per stack for all allies to take an additional turn.
+
+## 5★ Relics
+- **Paradox Hourglass** – At the start of combat there is a 60% chance, reduced as allies are missing (0% if only one remains), to kill 1 random ally plus 1 per stack. Survivors gain 200% to all stats plus 100% per stack, and all foes lose 4× DEF plus 1× per stack down to a minimum of 100 total DEF.
+- **Soul Prism** – After combat and at the start of a new round, revive fallen allies at 1% HP but reduce their Max HP by 75% for the rest of the run; buff their DEF and mitigation by 5%. Each additional copy reduces the penalty by 5% and adds 2% to the buffs.
+- **Omega Core** – At the start of combat, all allies gain +500% to all stats; after 10 turns the party begins taking 1% HP damage each turn, increasing by 1% per extra turn. Each stack adds 2 turns before the damage begins.
+

--- a/myunderstanding.md
+++ b/myunderstanding.md
@@ -6,6 +6,8 @@ A stylized floor map fades in, showing branching paths of room icons. Hovering o
 
 In battle rooms my team automatically trades blows with the enemy while damage numbers and status icons pop up. Shop rooms display items with prices and star ratings, letting me spend gold or reroll the stock. Rest rooms offer a calm break where I can heal or trade items before heading back to the map.
 
+Along the way I collect cards and relics. Cards give small stat boosts or special perks, while relics provide stronger passive effects that persist through the run.
+
 Clearing room after room eventually brings me to a boss icon. Beating the boss finishes the floor and I return to the map or the main menu. Between runs I can roll the gacha for new characters and tweak my player appearance.
 
 This document reflects how the game currently plays and should be kept up to date as features evolve.


### PR DESCRIPTION
## Summary
- Replace Aftertaste with an After Image effect on the Reality Split 5★ card
- Clarify Aftertaste damage FX and tweak relics: slower Herbal Charm regen, Frost Sigil hit scaling, Ember Stone low-HP trigger, Timekeeper's Hourglass odds, and a lasting Omega Core buff

## Testing
- `uv sync`
- `uv run pytest` *(fails: widget scale constant pixels, widget scale zero height, load run menu navigation, main menu extra elements)*

------
https://chatgpt.com/codex/tasks/task_b_6894bb1ddbac832c9da542cf4bf02d79