### PR TITLE
[FEAT] plugin-based card and relic systems

### DIFF
--- a/.codex/implementation/card-reward-system.md
+++ b/.codex/implementation/card-reward-system.md
@@ -3,6 +3,7 @@
 Battles grant unique cards that permanently boost party stats. Cards come in star
 ranks and only one copy of each can be owned. Victories present three unused
 cards of the appropriate star rank; choosing one adds it to the party's inventory.
+Cards are implemented as plugins under `plugins/cards/`, making new rewards easy to add.
 Card and relic bonuses now apply at the start of each combat rather than on
 acquisition so higher-star effects trigger correctly. Subsequent battles skip
 duplicates by rolling only from cards not yet collected.

--- a/.codex/implementation/plugin-system.md
+++ b/.codex/implementation/plugin-system.md
@@ -17,6 +17,8 @@ The following categories are bundled:
 - **DoTs** – damage-over-time effects such as `Bleed`【F:plugins/dots/bleed.py†L4-L15】
 - **HoTs** – healing-over-time effects such as `Regeneration`【F:plugins/hots/regeneration.py†L4-L9】
 - **Weapons** – attack implementations such as `SampleWeapon`【F:plugins/weapons/sample_weapon.py†L4-L8】
+- **Cards** – stat-boosting rewards like `MicroBlade`【F:backend/plugins/cards/a_micro_blade.py†L1-L12】
+- **Relics** – run-limited party buffs such as `BentDagger`【F:backend/plugins/relics/bent_dagger.py†L1-L9】
 - **Rooms** – scene definitions such as `SampleRoom`【F:plugins/rooms/sample_room.py†L1-L3】
 
 ## Plugin Class Requirements
@@ -39,4 +41,3 @@ The following categories are bundled:
 2. Implement the class with `plugin_type` and optional `id`.
 3. Write category-specific behaviour.
 4. Run `discover`; import failures are logged and reported without stopping other plugins【F:plugins/plugin_loader.py†L28-L44】.
-

--- a/.codex/implementation/relic-system.md
+++ b/.codex/implementation/relic-system.md
@@ -1,0 +1,9 @@
+# Relic System
+
+Relics grant bonuses for the duration of a run, applying at run start and during battles.
+New runs begin without relics or cards.
+Each relic is implemented as a plugin under `plugins/relics/`, allowing new relics
+to be added without touching core modules. Awarding the same relic multiple times stacks its effects for that run.
+
+## Testing
+- `uv run pytest backend/tests/test_relics.py`

--- a/.codex/tasks/ac8cbde0-web-task-order.md
+++ b/.codex/tasks/ac8cbde0-web-task-order.md
@@ -9,7 +9,7 @@ Ordered steps for moving Midori AI AutoFighter to a Svelte frontend and a Python
 
 ## Tasks
 ### To Do
-- [ ] [Implement relic system](388bd733-relic-system.md) (`388bd733`)
+ - [x] [Implement relic system](done/388bd733-relic-system.md) (`388bd733`)
 - [x] [Implement card reward system](done/c7fd49f5-card-reward-system.md) (`c7fd49f5`)
 - [ ] [Build gacha character recruitment](4d680dc8-gacha-recruitment.md) (`4d680dc8`)
 - [ ] [Add player character editor endpoint](6d267bac-player-character-editor-endpoint.md) (`6d267bac`)
@@ -32,6 +32,7 @@ Ordered steps for moving Midori AI AutoFighter to a Svelte frontend and a Python
  - [x] [Provide player stat screen endpoint](done/9a1c88c4-stat-screen-endpoint.md) (`9a1c88c4`)
  - [x] [Track shop purchases in shared party inventory](done/df5abccd-shop-inventory-tracking.md) (`df5abccd`)
  - [x] [Implement card reward system](done/c7fd49f5-card-reward-system.md) (`c7fd49f5`)
+ - [x] [Implement relic system](done/388bd733-relic-system.md) (`388bd733`)
 
 ## Context
 Switching from Panda3D to a web-based GUI with a Quart backend managed via Docker Compose.

--- a/.codex/tasks/done/388bd733-relic-system.md
+++ b/.codex/tasks/done/388bd733-relic-system.md
@@ -1,0 +1,3 @@
+# Implement relic system
+Relics load through plugins and grant run-limited stacking stat bonuses. The Bent Dagger example applies attack boosts, and tests verify relic effects.
+

--- a/backend/plugins/cards/__init__.py
+++ b/backend/plugins/cards/__init__.py
@@ -1,0 +1,2 @@
+"""Card plugins."""
+

--- a/backend/plugins/cards/_base.py
+++ b/backend/plugins/cards/_base.py
@@ -1,0 +1,27 @@
+from dataclasses import dataclass
+from dataclasses import field
+
+from autofighter.party import Party
+
+
+@dataclass
+class CardBase:
+    plugin_type = "card"
+
+    id: str = ""
+    name: str = ""
+    stars: int = 1
+    effects: dict[str, float] = field(default_factory=dict)
+
+    def apply(self, party: Party) -> None:
+        for member in party.members:
+            for attr, pct in self.effects.items():
+                if attr == "max_hp":
+                    member.max_hp = type(member.max_hp)(member.max_hp * (1 + pct))
+                    member.hp = type(member.hp)(member.hp * (1 + pct))
+                else:
+                    value = getattr(member, attr, None)
+                    if value is None:
+                        continue
+                    new_value = type(value)(value * (1 + pct))
+                    setattr(member, attr, new_value)

--- a/backend/plugins/cards/a_micro_blade.py
+++ b/backend/plugins/cards/a_micro_blade.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+from dataclasses import field
+
+from plugins.cards._base import CardBase
+
+
+@dataclass
+class MicroBlade(CardBase):
+    id: str = "micro_blade"
+    name: str = "Micro Blade"
+    stars: int = 1
+    effects: dict[str, float] = field(default_factory=lambda: {"atk": 0.03})

--- a/backend/plugins/cards/balanced_diet.py
+++ b/backend/plugins/cards/balanced_diet.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+from dataclasses import field
+
+from plugins.cards._base import CardBase
+
+
+@dataclass
+class BalancedDiet(CardBase):
+    id: str = "balanced_diet"
+    name: str = "Balanced Diet"
+    stars: int = 1
+    effects: dict[str, float] = field(default_factory=lambda: {"max_hp": 0.03, "defense": 0.03})

--- a/backend/plugins/cards/calm_beads.py
+++ b/backend/plugins/cards/calm_beads.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+from dataclasses import field
+
+from plugins.cards._base import CardBase
+
+
+@dataclass
+class CalmBeads(CardBase):
+    id: str = "calm_beads"
+    name: str = "Calm Beads"
+    stars: int = 1
+    effects: dict[str, float] = field(default_factory=lambda: {"effect_resistance": 0.03})

--- a/backend/plugins/cards/energizing_tea.py
+++ b/backend/plugins/cards/energizing_tea.py
@@ -1,0 +1,13 @@
+from dataclasses import dataclass
+from dataclasses import field
+
+from plugins.cards._base import CardBase
+
+
+@dataclass
+class EnergizingTea(CardBase):
+    id: str = "energizing_tea"
+    name: str = "Energizing Tea"
+    stars: int = 1
+    effects: dict[str, float] = field(default_factory=lambda: {"regain": 0.03})
+

--- a/backend/plugins/cards/lucky_coin.py
+++ b/backend/plugins/cards/lucky_coin.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+from dataclasses import field
+
+from plugins.cards._base import CardBase
+
+
+@dataclass
+class LuckyCoin(CardBase):
+    id: str = "lucky_coin"
+    name: str = "Lucky Coin"
+    stars: int = 1
+    effects: dict[str, float] = field(default_factory=lambda: {"crit_rate": 0.03})

--- a/backend/plugins/cards/mindful_tassel.py
+++ b/backend/plugins/cards/mindful_tassel.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+from dataclasses import field
+
+from plugins.cards._base import CardBase
+
+
+@dataclass
+class MindfulTassel(CardBase):
+    id: str = "mindful_tassel"
+    name: str = "Mindful Tassel"
+    stars: int = 1
+    effects: dict[str, float] = field(default_factory=lambda: {"effect_hit_rate": 0.03})

--- a/backend/plugins/cards/polished_shield.py
+++ b/backend/plugins/cards/polished_shield.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+from dataclasses import field
+
+from plugins.cards._base import CardBase
+
+
+@dataclass
+class PolishedShield(CardBase):
+    id: str = "polished_shield"
+    name: str = "Polished Shield"
+    stars: int = 1
+    effects: dict[str, float] = field(default_factory=lambda: {"defense": 0.03})

--- a/backend/plugins/cards/sharpening_stone.py
+++ b/backend/plugins/cards/sharpening_stone.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+from dataclasses import field
+
+from plugins.cards._base import CardBase
+
+
+@dataclass
+class SharpeningStone(CardBase):
+    id: str = "sharpening_stone"
+    name: str = "Sharpening Stone"
+    stars: int = 1
+    effects: dict[str, float] = field(default_factory=lambda: {"crit_damage": 0.03})

--- a/backend/plugins/cards/sturdy_vest.py
+++ b/backend/plugins/cards/sturdy_vest.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+from dataclasses import field
+
+from plugins.cards._base import CardBase
+
+
+@dataclass
+class SturdyVest(CardBase):
+    id: str = "sturdy_vest"
+    name: str = "Sturdy Vest"
+    stars: int = 1
+    effects: dict[str, float] = field(default_factory=lambda: {"max_hp": 0.03})

--- a/backend/plugins/cards/thick_skin.py
+++ b/backend/plugins/cards/thick_skin.py
@@ -1,0 +1,13 @@
+from dataclasses import dataclass
+from dataclasses import field
+
+from plugins.cards._base import CardBase
+
+
+@dataclass
+class ThickSkin(CardBase):
+    id: str = "thick_skin"
+    name: str = "Thick Skin"
+    stars: int = 1
+    effects: dict[str, float] = field(default_factory=lambda: {"bleed_resist": 0.03})
+

--- a/backend/plugins/relics/__init__.py
+++ b/backend/plugins/relics/__init__.py
@@ -1,0 +1,2 @@
+"""Relic plugins."""
+

--- a/backend/plugins/relics/_base.py
+++ b/backend/plugins/relics/_base.py
@@ -1,0 +1,22 @@
+from dataclasses import dataclass
+from dataclasses import field
+
+from autofighter.party import Party
+
+
+@dataclass
+class RelicBase:
+    plugin_type = "relic"
+
+    id: str = ""
+    name: str = ""
+    effects: dict[str, float] = field(default_factory=dict)
+
+    def apply(self, party: Party) -> None:
+        for member in party.members:
+            for attr, pct in self.effects.items():
+                value = getattr(member, attr, None)
+                if value is None:
+                    continue
+                new_value = type(value)(value * (1 + pct))
+                setattr(member, attr, new_value)

--- a/backend/plugins/relics/bent_dagger.py
+++ b/backend/plugins/relics/bent_dagger.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+from dataclasses import field
+
+from plugins.relics._base import RelicBase
+
+
+@dataclass
+class BentDagger(RelicBase):
+    id: str = "bent_dagger"
+    name: str = "Bent Dagger"
+    effects: dict[str, float] = field(default_factory=lambda: {"atk": 0.03})
+

--- a/backend/plugins/templates/card_plugin.py
+++ b/backend/plugins/templates/card_plugin.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+from dataclasses import field
+
+from plugins.cards._base import CardBase
+
+
+@dataclass
+class SampleCard(CardBase):
+    id: str = "sample_card"
+    name: str = "Sample Card"
+    stars: int = 1
+    effects: dict[str, float] = field(default_factory=dict)

--- a/backend/plugins/templates/relic_plugin.py
+++ b/backend/plugins/templates/relic_plugin.py
@@ -1,0 +1,11 @@
+from dataclasses import dataclass
+from dataclasses import field
+
+from plugins.relics._base import RelicBase
+
+
+@dataclass
+class SampleRelic(RelicBase):
+    id: str = "sample_relic"
+    name: str = "Sample Relic"
+    effects: dict[str, float] = field(default_factory=dict)

--- a/backend/tests/test_relics.py
+++ b/backend/tests/test_relics.py
@@ -1,0 +1,16 @@
+from autofighter.party import Party
+from autofighter.relics import apply_relics
+from autofighter.relics import award_relic
+from plugins.players._base import PlayerBase
+
+
+def test_award_relics_stack():
+    party = Party()
+    member = PlayerBase()
+    member.atk = 100
+    party.members.append(member)
+    assert award_relic(party, "bent_dagger") is not None
+    assert award_relic(party, "bent_dagger") is not None
+    apply_relics(party)
+    assert party.relics == ["bent_dagger", "bent_dagger"]
+    assert party.members[0].atk == int(100 * 1.03 * 1.03)


### PR DESCRIPTION
## Summary
- allow relic awards to stack by removing the uniqueness check in `award_relic`
- document that relic effects stack and update test to verify duplicate awards compound their bonuses

## Testing
- `uv pip install -e backend` *(fails: Multiple top-level packages discovered in a flat-layout)*
- `PYTHONPATH=. uv run pytest` *(fails: ModuleNotFoundError: No module named 'sqlcipher3')*
- `PYTHONPATH=backend uv run pytest backend/tests/test_relics.py`
- `PYTHONPATH=backend uv run pytest backend/tests/test_card_rewards.py` *(fails: ModuleNotFoundError: No module named 'sqlcipher3')*

------
https://chatgpt.com/codex/tasks/task_b_689cbe509bd4832c9d02e8007fe9e2d1