### PR TITLE
Add Give Feedback button to main menu

### DIFF
--- a/.codex/tasks/1a2b3c4d-give-feedback-button.md
+++ b/.codex/tasks/1a2b3c4d-give-feedback-button.md
@@ -1,0 +1,12 @@
+# Give Feedback button (`1a2b3c4d`)
+
+## Summary
+Adds a main menu **Give Feedback** button that opens a pre-filled GitHub issue.
+
+## Tasks
+- [ ] Link button to `FEEDBACK_URL` in the main menu grid
+- [ ] Display `MessageSquare` icon from `lucide-svelte`
+
+## Assets & Usage
+- `frontend/src/lib/constants.js` defines `FEEDBACK_URL`
+- Menu item uses `MessageSquare` icon and label "Feedback" to launch the issue form

--- a/frontend/src/lib/constants.js
+++ b/frontend/src/lib/constants.js
@@ -1,0 +1,1 @@
+export const FEEDBACK_URL = 'https://github.com/Midori-AI/Midori-AI-AutoFighter/issues/new?title=Feedback&body=...';

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -7,7 +7,8 @@
     Settings,
     SquareChartGantt,
     PackageOpen,
-    Hammer
+    Hammer,
+    MessageSquare
   } from 'lucide-svelte';
   import GameViewport from '$lib/GameViewport.svelte';
   import {
@@ -21,6 +22,7 @@
     bossRoom,
     chooseCard
   } from '$lib/api.js';
+  import { FEEDBACK_URL } from '$lib/constants.js';
 
   let runId = '';
   let currentMap = [];
@@ -101,6 +103,10 @@
     setView('craft');
   }
 
+  function openFeedback() {
+    window.open(FEEDBACK_URL, '_blank');
+  }
+
   async function handleTarget() {
     if (await checkBattle()) return;
     setView('stats');
@@ -148,6 +154,7 @@
       action: () => setView('settings'),
       disabled: false
     },
+    { icon: MessageSquare, label: 'Feedback', action: openFeedback, disabled: false },
     { icon: SquareChartGantt, label: 'Stats', action: handleTarget, disabled: battleActive }
   ];
 

--- a/frontend/tests/layout.test.js
+++ b/frontend/tests/layout.test.js
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import { layoutForWidth } from '../src/lib/layout.js';
+import { FEEDBACK_URL } from '../src/lib/constants.js';
 
 describe('layoutForWidth', () => {
   test('detects desktop', () => {
@@ -12,5 +13,11 @@ describe('layoutForWidth', () => {
 
   test('detects phone', () => {
     expect(layoutForWidth(400)).toBe('phone');
+  });
+
+  test('feedback URL points to repository issues', () => {
+    expect(FEEDBACK_URL).toBe(
+      'https://github.com/Midori-AI/Midori-AI-AutoFighter/issues/new?title=Feedback&body=...'
+    );
   });
 });


### PR DESCRIPTION
## Summary
- add Give Feedback button with link to pre-filled GitHub issue
- expose FEEDBACK_URL constant and cover with test
- document the button and icon usage

## Testing
- `bun install`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_b_68a0632594fc832c9509e5d613f36d24