### PR TITLE
Refactor room API to centralize actions and add error handling

### DIFF
--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -28,39 +28,13 @@ export async function getPlayers() {
   return res.json();
 }
 
-export async function battleRoom(runId, action = '') {
-  const res = await fetch(`${API_BASE}/rooms/${runId}/battle`, {
+export async function roomAction(runId, type, action = '') {
+  const res = await fetch(`${API_BASE}/rooms/${runId}/${type}`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ action })
   });
-  return res.json();
-}
-
-export async function shopRoom(runId, action = '') {
-  const res = await fetch(`${API_BASE}/rooms/${runId}/shop`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ action })
-  });
-  return res.json();
-}
-
-export async function restRoom(runId, action = '') {
-  const res = await fetch(`${API_BASE}/rooms/${runId}/rest`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ action })
-  });
-  return res.json();
-}
-
-export async function bossRoom(runId, action = '') {
-  const res = await fetch(`${API_BASE}/rooms/${runId}/boss`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ action })
-  });
+  if (!res.ok) throw new Error(`HTTP error ${res.status}`);
   return res.json();
 }
 

--- a/frontend/src/lib/index.js
+++ b/frontend/src/lib/index.js
@@ -19,9 +19,6 @@ export {
   startRun,
   updateParty,
   fetchMap,
-  battleRoom,
-  shopRoom,
-  restRoom,
-  bossRoom,
+  roomAction,
   chooseCard
 } from './api.js';

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -15,10 +15,7 @@
     fetchMap,
     getPlayerConfig,
     savePlayerConfig,
-    battleRoom,
-    shopRoom,
-    restRoom,
-    bossRoom,
+    roomAction,
     chooseCard
   } from '$lib/api.js';
 
@@ -112,14 +109,14 @@
     let data;
     if (room.includes('battle')) {
       battleActive = true;
-      data = await battleRoom(runId);
+      data = await roomAction(runId, 'battle');
     } else if (room.includes('shop')) {
-      data = await shopRoom(runId);
+      data = await roomAction(runId, 'shop');
     } else if (room.includes('rest')) {
-      data = await restRoom(runId);
+      data = await roomAction(runId, 'rest');
     } else if (room.includes('boss')) {
       battleActive = true;
-      data = await bossRoom(runId);
+      data = await roomAction(runId, 'boss');
     } else {
       return;
     }

--- a/frontend/tests/api.test.js
+++ b/frontend/tests/api.test.js
@@ -4,10 +4,7 @@ import {
   updateParty,
   fetchMap,
   getPlayers,
-  battleRoom,
-  shopRoom,
-  restRoom,
-  bossRoom,
+  roomAction,
   getPlayerConfig,
   savePlayerConfig,
   getGacha,
@@ -17,8 +14,8 @@ import {
 } from '../src/lib/api.js';
 
 // Helper to mock fetch
-function createFetch(response) {
-  return mock(async () => ({ json: async () => response }));
+function createFetch(response, ok = true, status = 200) {
+  return mock(async () => ({ ok, status, json: async () => response }));
 }
 
 describe('api calls', () => {
@@ -47,28 +44,15 @@ describe('api calls', () => {
     expect(result).toEqual({ players: [{ id: 'sample_player', owned: true }] });
   });
 
-  test('battleRoom posts action', async () => {
+  test('roomAction posts action', async () => {
     global.fetch = createFetch({ result: 'battle', party: [], foes: [] });
-    const result = await battleRoom('abc', 'attack');
+    const result = await roomAction('abc', 'battle', 'attack');
     expect(result).toEqual({ result: 'battle', party: [], foes: [] });
   });
 
-  test('shopRoom posts action', async () => {
-    global.fetch = createFetch({ result: 'shop', party: [], foes: [] });
-    const result = await shopRoom('abc', 'buy');
-    expect(result).toEqual({ result: 'shop', party: [], foes: [] });
-  });
-
-  test('restRoom posts action', async () => {
-    global.fetch = createFetch({ result: 'rest', party: [], foes: [] });
-    const result = await restRoom('abc', 'sleep');
-    expect(result).toEqual({ result: 'rest', party: [], foes: [] });
-  });
-
-  test('bossRoom posts action', async () => {
-    global.fetch = createFetch({ result: 'boss', party: [], foes: [] });
-    const result = await bossRoom('abc', 'attack');
-    expect(result).toEqual({ result: 'boss', party: [], foes: [] });
+  test('roomAction throws on HTTP error', async () => {
+    global.fetch = createFetch({}, false, 500);
+    await expect(roomAction('abc', 'battle', 'attack')).rejects.toThrow('HTTP error 500');
   });
 
   test('getPlayerConfig fetches editor data', async () => {


### PR DESCRIPTION
## Summary
- replace battle/shop/rest/boss helpers with unified `roomAction`
- export and use `roomAction` across frontend routing
- validate HTTP responses and test both success and failure paths

## Testing
- `bun install`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_b_68a063268f68832c81dc6ad9f2e92ae0