### PR TITLE
[DOC] expand PR template checks

### DIFF
--- a/.codex/instructions/doc-sync-process.md
+++ b/.codex/instructions/doc-sync-process.md
@@ -5,4 +5,4 @@ Keep player and foe documentation aligned with code changes.
 - Update `README.md` whenever the player roster or enemy generation rules change.
 - Mirror those updates in `.codex/implementation/player-foe-reference.md`.
 - Include details on new modifiers or abilities so other contributors can reference them.
-- Pull requests should confirm that these docs were refreshed.
+- Pull requests should confirm that these docs were refreshed and link or update relevant `.codex/tasks` entries.

--- a/.codex/tasks/5e6f7a8b-pr-template-expansion.md
+++ b/.codex/tasks/5e6f7a8b-pr-template-expansion.md
@@ -1,0 +1,12 @@
+# Expand PR template test checklist (`5e6f7a8b`)
+
+## Summary
+Ensure pull requests track backend/frontend tests, linting, doc sync, and link `.codex/tasks` entries.
+
+## Tasks
+- [ ] Add checkboxes for backend tests, frontend tests, linting, and doc sync updates to the PR template.
+- [ ] Remind contributors to link or update relevant `.codex/tasks` entries.
+- [ ] Extend doc sync instructions to mention the tasks reminder.
+
+## Context
+Current template lacks explicit verification steps for testing and documentation.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,11 @@
 -
 
 ## Testing
--
+- [ ] Backend tests
+- [ ] Frontend tests
+- [ ] Linting
+- [ ] Doc sync updates
 
 ## Checklist
 - [ ] Updated player roster and foe docs if adding or modifying fighters or enemies
+- [ ] Linked or updated relevant `.codex/tasks` entries


### PR DESCRIPTION
## Summary
- add test and lint checkboxes to PR template
- note `.codex/tasks` links in doc sync guide
- record task for PR template expansion

## Testing
- `uv run pytest` *(fails: KeyboardInterrupt)*
- `uv run ruff check .` *(fails: redefinition errors)*
- `bun test`
- `bun run lint` *(fails: script not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a063287eb8832ca5e01f4188f24344