### PR TITLE
[CI] add test and lint workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v3
+        with:
+          python-version: '3.12'
+      - uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest
+      - name: Install backend dependencies
+        working-directory: backend
+        run: uv sync
+      - name: Backend Tests
+        working-directory: backend
+        run: uv run pytest
+      - name: Backend Lint
+        run: uvx ruff check backend
+      - name: Install frontend dependencies
+        working-directory: frontend
+        run: bun install
+      - name: Frontend Tests
+        working-directory: frontend
+        run: bun test
+      - name: Frontend Lint
+        working-directory: frontend
+        run: ESLINT_USE_FLAT_CONFIG=false bunx eslint .

--- a/backend/tests/test_app.py
+++ b/backend/tests/test_app.py
@@ -1,7 +1,3 @@
-from pathlib import Path
-import importlib.util
-import json
-
 import json
 import importlib.util
 

--- a/backend/tests/test_player_stats.py
+++ b/backend/tests/test_player_stats.py
@@ -1,4 +1,3 @@
-from pathlib import Path
 import importlib.util
 
 from pathlib import Path

--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -1,0 +1,16 @@
+{
+  "env": {
+    "browser": true,
+    "es2021": true,
+    "node": true
+  },
+  "extends": ["eslint:recommended"],
+  "parserOptions": {
+    "ecmaVersion": "latest",
+    "sourceType": "module"
+  },
+  "ignorePatterns": ["tests/**"],
+  "rules": {
+    "no-unused-vars": ["error", { "argsIgnorePattern": "^_" }]
+  }
+}

--- a/frontend/src/lib/assetLoader.js
+++ b/frontend/src/lib/assetLoader.js
@@ -46,7 +46,7 @@ function getHourSeed() {
 }
 
 // Get random image from character folder or fallback
-export function getCharacterImage(characterId, isPlayer = false) {
+export function getCharacterImage(characterId, _isPlayer = false) {
   // Check if character has dedicated images
   if (characterAssets[characterId] && characterAssets[characterId].length > 0) {
     const images = characterAssets[characterId];

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,5 @@
+line-length = 88
+target-version = "py312"
+
+[lint]
+select = ["F"]


### PR DESCRIPTION
## Summary
- add CI workflow for Python tests/lint via uv and frontend tests/lint via bun
- add ruff and eslint configs
- clean up imports and unused parameters for lint

## Testing
- `uv run pytest`
- `uvx ruff check backend`
- `bun test`
- `ESLINT_USE_FLAT_CONFIG=false bunx eslint .`


------
https://chatgpt.com/codex/tasks/task_b_68a06327ed14832ca6d3f040dd1c5e42