### PR TITLE
Add modular popup window and character prompt fields

### DIFF
--- a/.codex/implementation/player-foe-reference.md
+++ b/.codex/implementation/player-foe-reference.md
@@ -9,6 +9,8 @@ for remaining values.
 
 Player plugins also include a `gacha_rarity` field so the gacha system can
 automatically discover 5★ and 6★ recruits.
+Each player and foe defines `prompt` and `about` strings with placeholder text
+to support future character-specific prompts.
 
 - **Ally** (B, random) – applies `ally_passive` on load to grant ally-specific bonuses.
 - **Becca** (B, random) – builds high attack but takes more damage from lower defense.

--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ uv run pytest
 The game auto-discovers classes under `plugins/` and `mods/` by `plugin_type`
 and wires them to a shared event bus. See
 `.codex/implementation/plugin-system.md` for loader details and examples.
+Player and foe plugins also expose `prompt` and `about` strings with
+placeholder text for future character customization.
 
 ## Player Creator
 

--- a/backend/plugins/foes/_base.py
+++ b/backend/plugins/foes/_base.py
@@ -19,6 +19,8 @@ class FoeBase(Stats):
     defense: int = 50
     gold: int = 1
     char_type: CharacterType = CharacterType.C
+    prompt: str = "Foe prompt placeholder"
+    about: str = "Foe description placeholder"
 
     exp: int = 1
     level: int = 1

--- a/backend/plugins/foes/slime.py
+++ b/backend/plugins/foes/slime.py
@@ -8,6 +8,8 @@ from plugins.foes._base import FoeBase
 class Slime(FoeBase):
     id = "slime"
     name = "Slime"
+    prompt: str = "Foe prompt placeholder"
+    about: str = "Foe description placeholder"
 
     def __post_init__(self) -> None:  # noqa: D401 - short init
         super().__post_init__()

--- a/backend/plugins/players/_base.py
+++ b/backend/plugins/players/_base.py
@@ -17,6 +17,8 @@ class PlayerBase(Stats):
     atk: int = 100
     defense: int = 50
     char_type: CharacterType = CharacterType.C
+    prompt: str = "Player prompt placeholder"
+    about: str = "Player description placeholder"
 
     exp: int = 1
     level: int = 1

--- a/backend/plugins/players/player.py
+++ b/backend/plugins/players/player.py
@@ -9,3 +9,5 @@ class Player(PlayerBase):
     name = "Player"
     char_type = CharacterType.C
     base_damage_type: str = "Fire"
+    prompt: str = "Player prompt placeholder"
+    about: str = "Player description placeholder"

--- a/frontend/src/lib/GameViewport.svelte
+++ b/frontend/src/lib/GameViewport.svelte
@@ -4,6 +4,7 @@
   import PartyPicker from './PartyPicker.svelte';
   import SettingsMenu from './SettingsMenu.svelte';
   import OverlaySurface from './OverlaySurface.svelte';
+  import PopupWindow from './PopupWindow.svelte';
   import MapDisplay from './MapDisplay.svelte';
   import PullsMenu from './PullsMenu.svelte';
   import CraftingMenu from './CraftingMenu.svelte';
@@ -273,12 +274,12 @@
           </OverlaySurface>
         {/if}
         {#if viewMode === 'stats'}
-          <OverlaySurface>
-            <StatsPanel on:close={() => dispatch('back')} />
-          </OverlaySurface>
+          <PopupWindow title="Stats" padding="0.75rem" on:close={() => dispatch('back')}>
+            <StatsPanel />
+          </PopupWindow>
         {/if}
         {#if viewMode === 'settings'}
-          <OverlaySurface>
+          <PopupWindow title="Settings" on:close={() => dispatch('back')}>
             <SettingsMenu
               {sfxVolume}
               {musicVolume}
@@ -291,9 +292,8 @@
                 saveSettings({ sfxVolume, musicVolume, voiceVolume, framerate, autocraft });
                 dispatch('back');
               }}
-              on:close={() => dispatch('back')}
             />
-          </OverlaySurface>
+          </PopupWindow>
         {/if}
         {#if roomData && roomData.card_choices && roomData.card_choices.length > 0}
           <OverlaySurface>

--- a/frontend/src/lib/PopupWindow.svelte
+++ b/frontend/src/lib/PopupWindow.svelte
@@ -1,0 +1,52 @@
+<script>
+  import { createEventDispatcher } from 'svelte';
+  import OverlaySurface from './OverlaySurface.svelte';
+  import MenuPanel from './MenuPanel.svelte';
+
+  const dispatch = createEventDispatcher();
+
+  export let title = '';
+  export let padding = '0.5rem';
+
+  function close() {
+    dispatch('close');
+  }
+</script>
+
+<OverlaySurface>
+  <MenuPanel {padding}>
+    {#if title}
+      <header class="head">
+        <h3>{title}</h3>
+        <button class="mini" title="Close" on:click={close}>✕</button>
+      </header>
+    {/if}
+    <slot />
+  </MenuPanel>
+</OverlaySurface>
+
+<style>
+  .head {
+    display: flex;
+    align-items: center;
+    margin-bottom: 0.5rem;
+  }
+
+  .head h3 {
+    margin: 0;
+    font-size: 1rem;
+  }
+
+  .head .mini {
+    margin-left: auto;
+  }
+
+  .mini {
+    border: 1px solid #fff;
+    background: #111;
+    color: #fff;
+    font-size: 0.7rem;
+    padding: 0.25rem 0.45rem;
+    cursor: pointer;
+  }
+</style>

--- a/frontend/src/lib/SettingsMenu.svelte
+++ b/frontend/src/lib/SettingsMenu.svelte
@@ -1,5 +1,4 @@
 <script>
-  import MenuPanel from './MenuPanel.svelte';
   import { createEventDispatcher } from 'svelte';
   import { Volume2, Music, Mic, Power, Trash2, Download, Upload } from 'lucide-svelte';
   import { endRun, wipeData, exportSave, importSave } from './api.js';
@@ -22,9 +21,6 @@
     });
   }
 
-  function close() {
-    dispatch('close');
-  }
 
   async function handleEndRun() {
     if (runId) {
@@ -54,8 +50,7 @@
   }
 </script>
 
-<MenuPanel data-testid="settings-menu">
-  <h3>Settings</h3>
+<div data-testid="settings-menu">
   <div class="cols">
     <div class="col">
       <h4>Audio</h4>
@@ -116,9 +111,8 @@
   </div>
   <div class="actions">
     <button on:click={save}>Save</button>
-    <button on:click={close}>Close</button>
   </div>
-</MenuPanel>
+</div>
 
 <style>
   .cols {

--- a/frontend/src/lib/StatsPanel.svelte
+++ b/frontend/src/lib/StatsPanel.svelte
@@ -1,33 +1,19 @@
 <script>
-	import { createEventDispatcher } from 'svelte';
-	import MenuPanel from './MenuPanel.svelte';
-	const dispatch = createEventDispatcher();
         export let stats = { hp: 1000, def: 50, vitality: 1, regain: 1, exp: 1 };
-	function close() { dispatch('close'); }
 </script>
 
-<MenuPanel data-testid="stats-panel" padding="0.75rem">
-	<div class="stats-root">
-		<header class="head">
-			<h3>Stats</h3>
-			<button class="mini" title="Close" on:click={close}>✕</button>
-		</header>
-		<div class="stats-grid">
-			<div><span>HP</span><span>{stats.hp}</span></div>
-			<div><span>DEF</span><span>{stats.def}</span></div>
-			<div><span>Vitality</span><span>{stats.vitality}</span></div>
-			<div><span>Regain</span><span>{stats.regain}</span></div>
-			<div><span>EXP</span><span>{stats.exp}</span></div>
-		</div>
-	</div>
-</MenuPanel>
+<div class="stats-root" data-testid="stats-panel">
+        <div class="stats-grid">
+                <div><span>HP</span><span>{stats.hp}</span></div>
+                <div><span>DEF</span><span>{stats.def}</span></div>
+                <div><span>Vitality</span><span>{stats.vitality}</span></div>
+                <div><span>Regain</span><span>{stats.regain}</span></div>
+                <div><span>EXP</span><span>{stats.exp}</span></div>
+        </div>
+</div>
 
 <style>
-	.stats-root { display:flex; flex-direction:column; gap:0.8rem; }
-	.head { display:flex; align-items:center; }
-	.head h3 { margin:0; font-size:1rem; }
-	.head .mini { margin-left:auto; }
-	.mini { border:1px solid #fff; background:#111; color:#fff; font-size:0.7rem; padding:0.25rem 0.45rem; cursor:pointer; }
-	.stats-grid { display:grid; grid-template-columns: repeat(auto-fill,minmax(120px,1fr)); gap:0.4rem 0.8rem; }
-	.stats-grid > div { display:flex; justify-content:space-between; background:rgba(255,255,255,0.05); padding:0.35rem 0.55rem; font-size:0.75rem; border:1px solid rgba(255,255,255,0.08); }
+        .stats-root { display:flex; flex-direction:column; gap:0.8rem; }
+        .stats-grid { display:grid; grid-template-columns: repeat(auto-fill,minmax(120px,1fr)); gap:0.4rem 0.8rem; }
+        .stats-grid > div { display:flex; justify-content:space-between; background:rgba(255,255,255,0.05); padding:0.35rem 0.55rem; font-size:0.75rem; border:1px solid rgba(255,255,255,0.08); }
 </style>

--- a/frontend/src/lib/index.js
+++ b/frontend/src/lib/index.js
@@ -14,6 +14,7 @@ export { default as RestRoom } from './RestRoom.svelte';
 export { default as ShopMenu } from './ShopMenu.svelte';
 export { default as CraftingMenu } from './CraftingMenu.svelte';
 export { default as RewardOverlay } from './RewardOverlay.svelte';
+export { default as PopupWindow } from './PopupWindow.svelte';
 export { layoutForWidth } from './layout.js';
 export {
   startRun,


### PR DESCRIPTION
## Summary
- add prompt and about placeholders to player and foe plugins
- introduce reusable PopupWindow component and refactor settings/stats overlays
- document new character metadata fields
- centralize popup headers and close logic so settings and stats panels share common framing

## Testing
- [ ] Backend tests (hang: KeyboardInterrupt after two tests)
- [x] Frontend tests `bun test`
- [x] Linting `uv run ruff check backend frontend`
- [ ] Doc sync updates (README and `.codex/implementation` docs)


------
https://chatgpt.com/codex/tasks/task_b_68a0fd1bc8a8832c82d2a2496cbbda00