### PR TITLE
fix: persist frontend framerate setting

### DIFF
--- a/.codex/implementation/settings-menu.md
+++ b/.codex/implementation/settings-menu.md
@@ -6,7 +6,7 @@ labels, and tooltips for **SFX Volume**, **Music Volume**, **Voice Volume**,
 the game viewport's top-right corner to access this menu. Controls are grouped
 under **Audio**, **System**, and **Gameplay** headings for clarity.
 
-The selected framerate is saved in local storage so server polling limits persist across sessions.
+The selected framerate is saved as a number and merged with existing settings in local storage so server polling limits persist across sessions.
 
 ## Testing
 - `bun test`

--- a/frontend/src/lib/GameViewport.svelte
+++ b/frontend/src/lib/GameViewport.svelte
@@ -41,7 +41,7 @@
     if (saved.sfxVolume !== undefined) sfxVolume = saved.sfxVolume;
     if (saved.musicVolume !== undefined) musicVolume = saved.musicVolume;
     if (saved.voiceVolume !== undefined) voiceVolume = saved.voiceVolume;
-    if (saved.framerate !== undefined) framerate = saved.framerate;
+    if (saved.framerate !== undefined) framerate = Number(saved.framerate);
     if (saved.autocraft !== undefined) autocraft = saved.autocraft;
   });
   export let selected = [];

--- a/frontend/src/lib/SettingsMenu.svelte
+++ b/frontend/src/lib/SettingsMenu.svelte
@@ -75,9 +75,9 @@
       <div class="control" title="Limit server polling frequency.">
         <label>Framerate</label>
         <select bind:value={framerate}>
-          <option value="30">30</option>
-          <option value="60">60</option>
-          <option value="120">120</option>
+          <option value={30}>30</option>
+          <option value={60}>60</option>
+          <option value={120}>120</option>
         </select>
       </div>
       <div class="control" title="Clear all save data.">

--- a/frontend/src/lib/settingsStorage.js
+++ b/frontend/src/lib/settingsStorage.js
@@ -3,7 +3,10 @@ const SETTINGS_KEY = 'autofighter_settings';
 export function loadSettings() {
   try {
     const raw = localStorage.getItem(SETTINGS_KEY);
-    return raw ? JSON.parse(raw) : {};
+    if (!raw) return {};
+    const data = JSON.parse(raw);
+    if (data.framerate !== undefined) data.framerate = Number(data.framerate);
+    return data;
   } catch {
     return {};
   }
@@ -11,7 +14,9 @@ export function loadSettings() {
 
 export function saveSettings(settings) {
   try {
-    localStorage.setItem(SETTINGS_KEY, JSON.stringify(settings));
+    const current = loadSettings();
+    const merged = { ...current, ...settings };
+    localStorage.setItem(SETTINGS_KEY, JSON.stringify(merged));
   } catch {
     // ignore write errors
   }

--- a/frontend/tests/settingsStorage.test.js
+++ b/frontend/tests/settingsStorage.test.js
@@ -25,4 +25,14 @@ describe('settings storage', () => {
     const result = loadSettings();
     expect(result.framerate).toBe(30);
   });
+
+  test('merges settings and normalizes numeric values', () => {
+    saveSettings({ musicVolume: 10, framerate: '60' });
+    saveSettings({ sfxVolume: 20 });
+    const result = loadSettings();
+    expect(result.musicVolume).toBe(10);
+    expect(result.sfxVolume).toBe(20);
+    expect(result.framerate).toBe(60);
+    expect(typeof result.framerate).toBe('number');
+  });
 });


### PR DESCRIPTION
## Summary
- keep saved framerate when revisiting settings by merging stored values and normalizing numbers
- read numeric framerate on load and use numeric options in SettingsMenu
- document framerate persistence and expand tests for settings storage

## Testing
- `bun test`
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a108d8c964832cac8adb5195307233