### PR TITLE
Fix asset loader import.meta.glob usage

### DIFF
--- a/frontend/src/lib/assetLoader.js
+++ b/frontend/src/lib/assetLoader.js
@@ -3,10 +3,30 @@
 import { Flame, Snowflake, Zap, Sun, Moon, Wind, Circle } from 'lucide-svelte';
 
 // Load all character images (including folders and fallbacks)
-const glob = typeof import.meta?.glob === 'function' ? import.meta.glob : () => ({});
-const characterModules = glob('./assets/characters/**/*.png', { eager: true, import: 'default', query: '?url' });
-const fallbackModules = glob('./assets/characters/fallbacks/*.png', { eager: true, import: 'default', query: '?url' });
-const backgroundModules = glob('./assets/backgrounds/*.png', { eager: true, import: 'default', query: '?url' });
+const characterModules =
+  typeof import.meta.glob === 'function'
+    ? import.meta.glob('./assets/characters/**/*.png', {
+        eager: true,
+        import: 'default',
+        query: '?url'
+      })
+    : {};
+const fallbackModules =
+  typeof import.meta.glob === 'function'
+    ? import.meta.glob('./assets/characters/fallbacks/*.png', {
+        eager: true,
+        import: 'default',
+        query: '?url'
+      })
+    : {};
+const backgroundModules =
+  typeof import.meta.glob === 'function'
+    ? import.meta.glob('./assets/backgrounds/*.png', {
+        eager: true,
+        import: 'default',
+        query: '?url'
+      })
+    : {};
 
 const ELEMENT_ICONS = {
   fire: Flame,


### PR DESCRIPTION
## Summary
- reference `import.meta.glob` directly in asset loader to satisfy Vite's static replacement

## Testing
- `bun test tests`
- `uv run pytest` *(fails: KeyboardInterrupt)*
- `uv run ruff check .` *(fails: unused imports in legacy files)*

------
https://chatgpt.com/codex/tasks/task_b_68a1ee554cf8832cbe60af4291bb86c4