### PR TITLE
[FIX] Resolve asset URLs with fallback

### DIFF
--- a/.codex/implementation/asset-loader.md
+++ b/.codex/implementation/asset-loader.md
@@ -2,8 +2,8 @@
 
 `assetLoader.js` centralizes character portraits, backgrounds, and damage type assets for the frontend.
 
-- Character portraits are loaded from `frontend/src/lib/assets/characters` with fallbacks when a portrait is missing.
-- Backgrounds rotate hourly using a seeded random selector.
+- Character portraits are loaded from `frontend/src/lib/assets/characters` and resolved to absolute URLs. When `import.meta.glob` isn't available (e.g., during tests) the loader scans the filesystem. Missing portraits fall back to the repository logo.
+- Backgrounds rotate hourly using a seeded random selector and fall back to the repository logo when none are available.
 - `getElementIcon` and `getElementColor` expose consistent damage type icons and colors for Fire, Ice, Lightning, Light, Dark, Wind, and Generic types.
 
 The loader is shared by the party picker, map display, and battle view so character images and type colors stay in sync across the UI.

--- a/frontend/src/lib/CraftingMenu.svelte
+++ b/frontend/src/lib/CraftingMenu.svelte
@@ -5,11 +5,14 @@
   import MenuPanel from './MenuPanel.svelte';
   import { stackItems, formatName } from './craftingUtils.js';
 
-  const iconModules = import.meta.glob('./assets/items/*/*.png', {
+  const rawIconModules = import.meta.glob('./assets/items/*/*.png', {
     eager: true,
     import: 'default',
     query: '?url'
   });
+  const iconModules = Object.fromEntries(
+    Object.entries(rawIconModules).map(([path, src]) => [path, new URL(src, import.meta.url).href])
+  );
   const fallbackIcon = new URL('./assets/cards/fallback/placeholder.png', import.meta.url).href;
 
   const starColors = {

--- a/frontend/src/lib/rewardLoader.js
+++ b/frontend/src/lib/rewardLoader.js
@@ -6,7 +6,7 @@ function prepare(mods) {
   const assets = {};
   for (const path in mods) {
     const name = path.split('/').pop().replace('.png', '');
-    assets[name] = mods[path];
+    assets[name] = new URL(mods[path], import.meta.url).href;
   }
   const values = Object.values(assets);
   if (values.length) {

--- a/frontend/tests/assetloader.test.js
+++ b/frontend/tests/assetloader.test.js
@@ -1,10 +1,18 @@
 import { describe, expect, test } from 'bun:test';
+import fs from 'fs';
 import { getCharacterImage, getElementColor, getElementIcon } from '../src/lib/assetLoader.js';
 
 describe('asset loader', () => {
-  test('returns string or null for unknown character', () => {
+  test('returns fallback string for unknown character', () => {
     const img = getCharacterImage('nonexistent');
-    expect(img === null || typeof img === 'string').toBe(true);
+    expect(typeof img).toBe('string');
+  });
+
+  test('resolves existing character portrait', () => {
+    const url = getCharacterImage('becca');
+    expect(url).toContain('becca');
+    const filePath = new URL(url);
+    expect(fs.existsSync(filePath)).toBe(true);
   });
 
   test('provides damage type color and icon', () => {


### PR DESCRIPTION
## Summary
- resolve imported asset paths to absolute URLs
- add repository-logo fallback when an image is missing
- add filesystem fallback in asset loader and test portrait resolution
- document asset loader behavior

## Testing
- `cd frontend && bun test`
- `cd frontend && bun run build` *(fails to exit: repeated warnings)*

------
https://chatgpt.com/codex/tasks/task_b_68a1fe5d0728832cb7e17a61eb230335