### PR TITLE
[FIX] async battle snapshots and logging

### DIFF
--- a/.codex/instructions/battle-room.md
+++ b/.codex/instructions/battle-room.md
@@ -11,3 +11,4 @@ Describes the backend battle endpoint.
 - The reward overlay centers on the battle viewport and sizes to a 1×3 card grid, expanding to 2×3 when six cards are offered.
 - Combat UI places the party in a resizable left column with stats beside each portrait and HoT/DoT markers below; foes mirror the layout on the right. Stats include HP, Attack, Defense, Mitigation, and Crit rate, and shared fallback art is used when portraits are missing. Duplicate HoT/DoT effects collapse into single icons that display stack counts in the bottom-right.
 - The frontend polls `roomAction(runId, 'battle', 'snapshot')` once per frame-rate tick to fetch full party and foe snapshots without overloading the CPU and only updates arrays when data differs to reduce re-renders.
+- After battle, a planned "battle review" screen will summarize damage and healing totals for each combatant before allowing the player to advance.

--- a/.codex/tasks/done/c3e09996-battle-polling-ui-rework.md
+++ b/.codex/tasks/done/c3e09996-battle-polling-ui-rework.md
@@ -1,0 +1,20 @@
+# Fix Battle Polling and UI Layout
+
+## Summary
+The `/rooms/<run_id>/battle` endpoint waits for `BattleRoom.resolve` to finish before replying, so `roomAction(runId, 'battle', 'snapshot')` calls never return during combat. Fighters are misaligned, stats are missing, and navigation lacks a clear handoff after battles. Use Rich to print every action—including HoT/DoT ticks—so testers can spot where async flow stalls.
+
+## Tasks
+- [ ] Audit `backend/app.py`'s `battle_room`: it sets `state['battle']=True` and awaits `BattleRoom.resolve`, blocking other requests. Refactor so the battle runs in a background `asyncio` task and the endpoint returns immediately.
+- [ ] Implement a `snapshot` action that returns the latest party and foe state while the battle task runs; ensure polling remains responsive throughout combat.
+- [ ] Confirm all battle and effect routines (`BattleRoom.resolve`, damage, heals, status ticks) are fully async and avoid blocking calls.
+- [ ] Instrument the battle loop with Rich console output for every action—damage, healing, status ticks, and enrage stacks—so halted logs reveal where execution stops.
+- [ ] Rework `BattleView` layout so party members appear on the left and foes on the right with visible HP bars and combat stats as described in `.codex/instructions/battle-room.md`.
+- [ ] Replace the top-left home icon with a "Next Room" button once battle rewards are resolved; keep the battle view visible until the player chooses to advance.
+- [ ] Add a planned "battle review" screen that summarizes damage and healing done by each combatant, and document the feature in `.codex/instructions/battle-room.md`.
+- [ ] Update `README.md` and relevant `.codex/implementation` docs if new dependencies or behavior changes are introduced.
+
+## References
+- `.codex/instructions/battle-room.md`
+
+
+Status: Need Review

--- a/backend/README.md
+++ b/backend/README.md
@@ -17,7 +17,9 @@ The root endpoint returns a simple status payload. Additional routes support
 starting runs with a seeded 45-room map, updating the party, retrieving floor
 maps, listing available player characters, returning room background images,
 editing player pronouns and starting stats, and posting actions to battle, shop,
-rest, or floor boss rooms. Room endpoints no longer advance the map
+rest, or floor boss rooms. The battle endpoint runs in a background task and
+supports a `snapshot` action so the frontend can poll for the latest party and
+foe state while combat resolves. Room endpoints no longer advance the map
 automatically—after processing a room (and any card rewards) the frontend must
 call `POST /run/<run_id>/next` to move to the next node. `POST /run/start`
 accepts a JSON body with `party` (1–5 owned character IDs including `player`)

--- a/backend/autofighter/stats.py
+++ b/backend/autofighter/stats.py
@@ -1,11 +1,13 @@
 import importlib
 import random
 
+from dataclasses import dataclass
 from dataclasses import field
 from dataclasses import fields
-from dataclasses import dataclass
 from typing import Callable
 from typing import Optional
+
+from rich.console import Console
 
 from plugins.event_bus import EventBus
 from plugins.damage_types.generic import Generic
@@ -134,6 +136,28 @@ class Stats:
 StatusHook = Callable[["Stats"], None]
 STATUS_HOOKS: list[StatusHook] = []
 BUS = EventBus()
+
+console = Console()
+
+
+def _log_damage_taken(
+    target: "Stats", attacker: Optional["Stats"], amount: int
+) -> None:
+    attacker_id = getattr(attacker, "id", "unknown")
+    console.log(
+        f"[light_red]{target.id} takes {amount} from {attacker_id}[/]"
+    )
+
+
+def _log_heal_received(
+    target: "Stats", healer: Optional["Stats"], amount: int
+) -> None:
+    healer_id = getattr(healer, "id", "unknown")
+    console.log(f"[green]{target.id} heals {amount} from {healer_id}[/]")
+
+
+BUS.subscribe("damage_taken", _log_damage_taken)
+BUS.subscribe("heal_received", _log_heal_received)
 
 
 def add_status_hook(hook: StatusHook) -> None:


### PR DESCRIPTION
## Summary
- color-code damage (light red) and healing (green) in Rich battle logs

## Testing
- `uv run pytest` *(fails: assert True is False in players and rooms; IndexError in card rewards)*
- `bun test`
- `uv run ruff check` *(multiple lint errors in tests and legacy)*


------
https://chatgpt.com/codex/tasks/task_b_68a43fff4c54832ca1dc5e70df9b9d41