### PR TITLE
feat: add debounced settings autosave

### DIFF
--- a/.codex/implementation/settings-menu.md
+++ b/.codex/implementation/settings-menu.md
@@ -8,6 +8,8 @@ labels, and tooltips for **SFX Volume**, **Music Volume**, **Voice Volume**,
 The selected framerate is saved as a number and merged with existing settings in local storage so server polling limits persist across sessions.
 `frameratePersistence.test.js` verifies the viewport loads this saved value on startup.
 
+Settings auto-save when sliders, checkboxes, or selects change. A debounced `save()` helper persists the latest values via `saveSettings` and briefly displays a "Saved" indicator.
+
 Choosing **Wipe Save Data** prompts for confirmation. If accepted, the app calls the `/save/wipe` endpoint with error handling.
 On success it deletes runs, options, and damage type records from the backend database, clears stored settings, resets menu values
 to defaults, and displays a status message confirming the wipe. Errors surface a failure message.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -17,7 +17,7 @@ backend and lets you add or remove allies with a single button. Portraits
 use four equal columns so each image scales to 25% of the roster width, and
 no confirm action is required. The **Run** icon posts the selected party to
 `/run/start` and reveals the generated floor map. The **Settings** icon opens a
-similar overlay with sliders for sound effects, music, and voice. An upcoming **Edit Player** panel will use
+similar overlay with sliders for sound effects, music, and voice that auto-save changes and briefly show a "Saved" status. An upcoming **Edit Player** panel will use
 `/player/editor` to save pronouns, starting damage type, and stat allocations,
 boosting HP, Attack, and Defense by 1% per point.
 The **Pulls** icon calls `/gacha/pull` so players can recruit 5★ or 6★ characters or

--- a/frontend/tests/settingsmenu.test.js
+++ b/frontend/tests/settingsmenu.test.js
@@ -16,6 +16,8 @@ describe('SettingsMenu component', () => {
     expect(content).toContain('Import Save Data');
     expect(content).toContain('End Run');
     expect(content).toContain('data-testid="wipe-status"');
+    expect(content).toContain('data-testid="save-status"');
+    expect(content).not.toContain('Save</button>');
     expect(content).not.toContain('alert(');
   });
 });


### PR DESCRIPTION
## Summary
- add debounced autosave with saved indicator to settings menu
- document new autosave behavior

## Testing
- [ ] Backend tests (fail: `test_players_and_rooms`, `test_battle_offers_choices_and_applies_effect`)
- [x] Frontend tests
- [ ] Linting (ruff reported 30 errors in unrelated files)
- [x] Doc sync updates (README and `.codex/implementation` docs; link tasks below)

## Checklist
- [ ] Linked or updated relevant `.codex/tasks` entries
- [ ] Updated player roster and foe docs if adding or modifying fighters or enemies

------
https://chatgpt.com/codex/tasks/task_b_68a4ee396bd4832ca7f421af90c6eefd