### PR TITLE
[FIX] Improve XP leveling and party persistence

### DIFF
--- a/.codex/implementation/battle-room.md
+++ b/.codex/implementation/battle-room.md
@@ -2,6 +2,10 @@
 
 `BattleRoom` resolves turn-based encounters against scaled foes drawn from player plugins you haven't selected. Passives fire on room entry, battle start, and at the beginning and end of each turn. Combat continues until either every party member or the foe is defeated. All damage, healing, and regeneration helpers are awaitable, and each turn is padded to last at least 0.5 s to keep updates visible. The `EffectManager` applies damage-over-time and healing-over-time ticks on each combatant before actions take place, and the async loop yields control back to the event loop between steps so DoTs and HoTs remain non-blocking.
 
+The room deep-copies the run's party for combat. When the fight ends, remaining
+HP and accumulated experience are synced back so level-ups and damage persist
+into subsequent rooms.
+
 Each strike rolls the attacker's `effect_hit_rate` against the target's `effect_resistance`. The difference is clamped to zero, jittered by ±10%, and even a failed roll has a 1% floor chance to attach a damage-type-specific DoT scaled to the damage dealt.
 
 During the foe's turn, a target is chosen from living party members with a probability weight of `defense × mitigation`, making sturdier allies more likely to draw aggro.

--- a/.codex/implementation/stats-and-effects.md
+++ b/.codex/implementation/stats-and-effects.md
@@ -16,6 +16,11 @@ Characters with random base damage types store their first rolled element in the
 save database and reuse it on later loads so elements stay consistent across
 sessions.
 
+Experience feeds into `exp` and triggers a level-up when it meets or exceeds
+`exp_to_level`. Characters below level 1000 gain experience at ten times the
+normal rate to accelerate early progression. Level-ups increase core stats but
+no longer restore HP, preserving damage taken.
+
 `apply_damage()` and `apply_healing()` update `hp`, fire damage and healing hooks on the attacker and target damage types, and emit
 global `damage_taken`, `damage_dealt`, `heal_received`, and `heal` events on the repository-wide event bus.
 

--- a/.codex/tasks/done/e7206117-backend-exp-fixes.md
+++ b/.codex/tasks/done/e7206117-backend-exp-fixes.md
@@ -26,5 +26,7 @@ Investigate and address leveling and healing anomalies while updating docs to re
      - Document how battle resolution awards XP and levels to all party members.  
    - File: `.codex/implementation/stats-and-effects.md` line 5.  
      - Expand the Stats field overview with details on level-up behavior and the low-level XP multiplier.  
-   - File: `.codex/implementation/battle-room.md` line 11.  
+   - File: `.codex/implementation/battle-room.md` line 11.
      - Clarify that `BattleRoom` deep-copies the party for combat and syncs final stats (including XP) back to the run.
+
+Status: Need Review

--- a/README.md
+++ b/README.md
@@ -146,6 +146,10 @@ victory presents three unused cards of the appropriate star rank. Selecting one
 adds it to the party, and card and relic bonuses are applied at the start of the
 next battle.
 
+Defeated foes grant experience to every party member. Characters below level
+1000 receive a 10× boost to experience gained so early levels advance quickly.
+Level-ups apply immediately and sync back to the run along with remaining HP.
+
 ## Rest Room
 
 Pull for new characters, craft items, or rearrange the party before continuing a

--- a/backend/README.md
+++ b/backend/README.md
@@ -29,6 +29,10 @@ names. Run state is stored through the `SaveManager` in `backend/save.db` by
 default; `compose.yaml` bind-mounts the `backend/` directory so the database is
 persisted on the host.
 
+Battle resolution awards experience to all party members. Characters below
+level 1000 receive a 10× boost to earned experience, and level-ups are synced
+back to the run along with updated stats.
+
 `GET /gacha` returns the current pity counter, element-based upgrade items,
 owned characters with their duplicate stacks, and whether auto-crafting is
 enabled. `POST /gacha/pull` performs 1, 5, or 10 pulls, awarding 5★ or 6★

--- a/backend/autofighter/rooms.py
+++ b/backend/autofighter/rooms.py
@@ -201,11 +201,9 @@ class BattleRoom(Room):
         foe_effects = EffectManager(foe)
         party_effects = [EffectManager(m) for m in combat_party.members]
 
-        registry.trigger("room_enter", foe)
         registry.trigger("battle_start", foe)
         console.log(f"Battle start: {foe.id} vs {[m.id for m in combat_party.members]}")
         for member_effect, member in zip(party_effects, combat_party.members):
-            registry.trigger("room_enter", member)
             registry.trigger("battle_start", member)
 
         base_foe_atk = foe.atk
@@ -358,8 +356,8 @@ class BattleRoom(Room):
         for member in combat_party.members:
             registry.trigger("battle_end", member)
         for member, orig in zip(combat_party.members, party.members):
-            orig.hp = min(member.hp, orig.max_hp)
             orig.gain_exp(exp_reward)
+            orig.hp = min(member.hp, orig.max_hp)
             for f in fields(type(orig)):
                 setattr(member, f.name, getattr(orig, f.name))
 

--- a/backend/autofighter/stats.py
+++ b/backend/autofighter/stats.py
@@ -73,6 +73,8 @@ class Stats:
         self.defense += 3 * self.level
 
     def gain_exp(self, amount: int) -> None:
+        if self.level < 1000:
+            amount *= 10
         self.exp += int(amount * self.exp_multiplier * self.vitality)
         while self.exp >= self.exp_to_level():
             needed = self.exp_to_level()

--- a/backend/plugins/passives/room_heal.py
+++ b/backend/plugins/passives/room_heal.py
@@ -6,7 +6,7 @@ class RoomHeal:
     plugin_type = "passive"
     id = "room_heal"
     name = "Room Heal"
-    trigger = "room_enter"
+    trigger = "battle_end"
     amount = 1
 
     def apply(self, target) -> None:

--- a/backend/tests/test_exp_leveling.py
+++ b/backend/tests/test_exp_leveling.py
@@ -29,17 +29,41 @@ async def test_battle_room_awards_exp(monkeypatch):
     monkeypatch.setattr("autofighter.rooms._choose_foe", lambda p: foe)
     monkeypatch.setattr("autofighter.rooms._scale_stats", lambda *args, **kwargs: None)
     result = await room.resolve(party, {})
-    assert party.members[0].exp == 3 * 12 + 5 * 2
+    assert party.members[0].level == 3
+    assert party.members[0].exp == 160
     assert result["room_number"] == 2
     assert result["exp_reward"] == 3 * 12 + 5 * 2
+
+
+@pytest.mark.asyncio
+async def test_level_up_persists_hp(monkeypatch):
+    node = MapNode(room_id=0, room_type="battle", floor=1, index=2, loop=1, pressure=0)
+    room = BattleRoom(node)
+    player = player_mod.Player()
+    player.atk = 1000
+    player.hp = 500
+    party = Party(members=[player])
+
+    class DummyFoe(FoeBase):
+        id = "dummy"
+        name = "Dummy"
+
+    foe = DummyFoe()
+    foe.hp = 1
+    foe.level = 3
+    monkeypatch.setattr("autofighter.rooms._choose_foe", lambda p: foe)
+    monkeypatch.setattr("autofighter.rooms._scale_stats", lambda *args, **kwargs: None)
+    await room.resolve(party, {})
+    assert party.members[0].level > 1
+    assert party.members[0].hp == 500
 
 
 def test_gain_exp_and_level_up(monkeypatch):
     stats = Stats(hp=100, max_hp=100, atk=10, defense=5)
     monkeypatch.setattr(random, "uniform", lambda a, b: 0)
     stats.gain_exp(100)
-    assert stats.level == 2
-    assert stats.exp == 0
-    assert stats.max_hp == 120
-    assert stats.atk == 20
-    assert stats.defense == 11
+    assert stats.level == 4
+    assert stats.exp == 300
+    assert stats.max_hp == 190
+    assert stats.atk == 55
+    assert stats.defense == 32

--- a/backend/tests/test_passives.py
+++ b/backend/tests/test_passives.py
@@ -28,5 +28,5 @@ def test_room_heal_trigger():
     player = Player()
     player.hp = 900
     player.passives = ["room_heal"] * 10
-    registry.trigger("room_enter", player)
+    registry.trigger("battle_end", player)
     assert player.hp == 910


### PR DESCRIPTION
## Summary
- Boost low-level XP gain with a 10× multiplier
- Preserve party HP when syncing battle results and shift room heal passive to post-battle
- Document XP mechanics and party sync behavior

## Testing
- `uv run ruff check backend/autofighter/stats.py backend/autofighter/rooms.py backend/plugins/passives/room_heal.py backend/tests/test_passives.py backend/tests/test_exp_leveling.py`
- `uv run pytest tests/test_passives.py tests/test_exp_leveling.py`

------
https://chatgpt.com/codex/tasks/task_b_68a5e937acac832c9d3760bf69e3617f