### PR TITLE
[FEAT] expand 1★ card roster

### DIFF
--- a/.codex/implementation/card-inventory.md
+++ b/.codex/implementation/card-inventory.md
@@ -6,3 +6,39 @@ when no cards are owned.
 
 ## Testing
 - `bun test`
+## 1★ Cards
+- Micro Blade – +3% ATK
+- Polished Shield – +3% DEF
+- Sturdy Vest – +3% HP
+- Lucky Coin – +3% Crit Rate
+- Sharpening Stone – +3% Crit Damage
+- Mindful Tassel – +3% Effect Hit Rate
+- Calm Beads – +3% Effect Res
+- Energizing Tea – +3% Regain
+- Thick Skin – +3% Bleed Resist
+- Balanced Diet – +3% HP & +3% DEF
+- Lightweight Boots – +3% Dodge Odds
+- Expert Manual – +3% EXP Gain
+- Steel Bangles – +3% Mitigation
+- Enduring Charm – +3% Vitality
+- Keen Goggles – +3% Crit Rate & +3% Effect Hit Rate
+- Honed Point – +4% ATK
+- Fortified Plating – +4% DEF
+- Rejuvenating Tonic – +4% Regain
+- Adamantine Band – +4% HP
+- Precision Sights – +4% Crit Damage
+- Inspiring Banner – +2% ATK & +2% DEF
+- Tactical Kit – +2% ATK & +2% HP
+- Bulwark Totem – +2% DEF & +2% HP
+- Farsight Scope – +3% Crit Rate
+- Steady Grip – +3% ATK & +3% Dodge Odds
+- Coated Armor – +3% Mitigation & +3% DEF
+- Guiding Compass – +3% EXP Gain & +3% Effect Hit Rate
+- Swift Bandanna – +3% Crit Rate & +3% Dodge Odds
+- Reinforced Cloak – +3% DEF & +3% Effect Res
+- Vital Core – +3% Vitality & +3% HP
+- Enduring Will – +3% Mitigation & +3% Vitality
+- Battle Meditation – +3% EXP Gain & +3% Vitality
+- Guardian Shard – +2% DEF & +2% Mitigation
+- Sturdy Boots – +3% Dodge Odds & +3% DEF
+- Spiked Shield – +3% ATK & +3% DEF

--- a/.codex/planning/726d03ae-card-plan.md
+++ b/.codex/planning/726d03ae-card-plan.md
@@ -19,6 +19,31 @@ Parent: [Web Game Plan](8a7d9c1e-web-game-plan.md)
 - **Energizing Tea** – +3% Energy Regeneration.
 - **Thick Skin** – +3% Bleed Resist.
 - **Balanced Diet** – +3% HP & +3% DEF.
+- **Lightweight Boots** – +3% Dodge Odds.
+- **Expert Manual** – +3% EXP Gain.
+- **Steel Bangles** – +3% Mitigation.
+- **Enduring Charm** – +3% Vitality.
+- **Keen Goggles** – +3% Crit Rate & +3% Effect Hit Rate.
+- **Honed Point** – +4% ATK.
+- **Fortified Plating** – +4% DEF.
+- **Rejuvenating Tonic** – +4% Regain.
+- **Adamantine Band** – +4% HP.
+- **Precision Sights** – +4% Crit Damage.
+- **Inspiring Banner** – +2% ATK & +2% DEF.
+- **Tactical Kit** – +2% ATK & +2% HP.
+- **Bulwark Totem** – +2% DEF & +2% HP.
+- **Farsight Scope** – +3% Crit Rate.
+- **Steady Grip** – +3% ATK & +3% Dodge Odds.
+- **Coated Armor** – +3% Mitigation & +3% DEF.
+- **Guiding Compass** – +3% EXP Gain & +3% Effect Hit Rate.
+- **Swift Bandanna** – +3% Crit Rate & +3% Dodge Odds.
+- **Reinforced Cloak** – +3% DEF & +3% Effect Res.
+- **Vital Core** – +3% Vitality & +3% HP.
+- **Enduring Will** – +3% Mitigation & +3% Vitality.
+- **Battle Meditation** – +3% EXP Gain & +3% Vitality.
+- **Guardian Shard** – +2% DEF & +2% Mitigation.
+- **Sturdy Boots** – +3% Dodge Odds & +3% DEF.
+- **Spiked Shield** – +3% ATK & +3% DEF.
 
 ## 2★ Cards
 - **Critical Focus** – Grants +55% ATK. At the start of each ally's turn they gain 1 stack of *Critical Boost*. *Critical Boost* stacks indefinitely, granting +0.5% Crit Rate and +5% Crit Damage per stack but vanishes when the unit is hit.

--- a/backend/plugins/cards/adamantine_band.py
+++ b/backend/plugins/cards/adamantine_band.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+from dataclasses import field
+
+from plugins.cards._base import CardBase
+
+
+@dataclass
+class AdamantineBand(CardBase):
+    id: str = "adamantine_band"
+    name: str = "Adamantine Band"
+    stars: int = 1
+    effects: dict[str, float] = field(default_factory=lambda: {"max_hp": 0.04})

--- a/backend/plugins/cards/battle_meditation.py
+++ b/backend/plugins/cards/battle_meditation.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+from dataclasses import field
+
+from plugins.cards._base import CardBase
+
+
+@dataclass
+class BattleMeditation(CardBase):
+    id: str = "battle_meditation"
+    name: str = "Battle Meditation"
+    stars: int = 1
+    effects: dict[str, float] = field(default_factory=lambda: {"exp_multiplier": 0.03, "vitality": 0.03})

--- a/backend/plugins/cards/bulwark_totem.py
+++ b/backend/plugins/cards/bulwark_totem.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+from dataclasses import field
+
+from plugins.cards._base import CardBase
+
+
+@dataclass
+class BulwarkTotem(CardBase):
+    id: str = "bulwark_totem"
+    name: str = "Bulwark Totem"
+    stars: int = 1
+    effects: dict[str, float] = field(default_factory=lambda: {"defense": 0.02, "max_hp": 0.02})

--- a/backend/plugins/cards/coated_armor.py
+++ b/backend/plugins/cards/coated_armor.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+from dataclasses import field
+
+from plugins.cards._base import CardBase
+
+
+@dataclass
+class CoatedArmor(CardBase):
+    id: str = "coated_armor"
+    name: str = "Coated Armor"
+    stars: int = 1
+    effects: dict[str, float] = field(default_factory=lambda: {"mitigation": 0.03, "defense": 0.03})

--- a/backend/plugins/cards/enduring_charm.py
+++ b/backend/plugins/cards/enduring_charm.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+from dataclasses import field
+
+from plugins.cards._base import CardBase
+
+
+@dataclass
+class EnduringCharm(CardBase):
+    id: str = "enduring_charm"
+    name: str = "Enduring Charm"
+    stars: int = 1
+    effects: dict[str, float] = field(default_factory=lambda: {"vitality": 0.03})

--- a/backend/plugins/cards/enduring_will.py
+++ b/backend/plugins/cards/enduring_will.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+from dataclasses import field
+
+from plugins.cards._base import CardBase
+
+
+@dataclass
+class EnduringWill(CardBase):
+    id: str = "enduring_will"
+    name: str = "Enduring Will"
+    stars: int = 1
+    effects: dict[str, float] = field(default_factory=lambda: {"mitigation": 0.03, "vitality": 0.03})

--- a/backend/plugins/cards/expert_manual.py
+++ b/backend/plugins/cards/expert_manual.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+from dataclasses import field
+
+from plugins.cards._base import CardBase
+
+
+@dataclass
+class ExpertManual(CardBase):
+    id: str = "expert_manual"
+    name: str = "Expert Manual"
+    stars: int = 1
+    effects: dict[str, float] = field(default_factory=lambda: {"exp_multiplier": 0.03})

--- a/backend/plugins/cards/farsight_scope.py
+++ b/backend/plugins/cards/farsight_scope.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+from dataclasses import field
+
+from plugins.cards._base import CardBase
+
+
+@dataclass
+class FarsightScope(CardBase):
+    id: str = "farsight_scope"
+    name: str = "Farsight Scope"
+    stars: int = 1
+    effects: dict[str, float] = field(default_factory=lambda: {"crit_rate": 0.03})

--- a/backend/plugins/cards/fortified_plating.py
+++ b/backend/plugins/cards/fortified_plating.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+from dataclasses import field
+
+from plugins.cards._base import CardBase
+
+
+@dataclass
+class FortifiedPlating(CardBase):
+    id: str = "fortified_plating"
+    name: str = "Fortified Plating"
+    stars: int = 1
+    effects: dict[str, float] = field(default_factory=lambda: {"defense": 0.04})

--- a/backend/plugins/cards/guardian_shard.py
+++ b/backend/plugins/cards/guardian_shard.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+from dataclasses import field
+
+from plugins.cards._base import CardBase
+
+
+@dataclass
+class GuardianShard(CardBase):
+    id: str = "guardian_shard"
+    name: str = "Guardian Shard"
+    stars: int = 1
+    effects: dict[str, float] = field(default_factory=lambda: {"defense": 0.02, "mitigation": 0.02})

--- a/backend/plugins/cards/guiding_compass.py
+++ b/backend/plugins/cards/guiding_compass.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+from dataclasses import field
+
+from plugins.cards._base import CardBase
+
+
+@dataclass
+class GuidingCompass(CardBase):
+    id: str = "guiding_compass"
+    name: str = "Guiding Compass"
+    stars: int = 1
+    effects: dict[str, float] = field(default_factory=lambda: {"exp_multiplier": 0.03, "effect_hit_rate": 0.03})

--- a/backend/plugins/cards/honed_point.py
+++ b/backend/plugins/cards/honed_point.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+from dataclasses import field
+
+from plugins.cards._base import CardBase
+
+
+@dataclass
+class HonedPoint(CardBase):
+    id: str = "honed_point"
+    name: str = "Honed Point"
+    stars: int = 1
+    effects: dict[str, float] = field(default_factory=lambda: {"atk": 0.04})

--- a/backend/plugins/cards/inspiring_banner.py
+++ b/backend/plugins/cards/inspiring_banner.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+from dataclasses import field
+
+from plugins.cards._base import CardBase
+
+
+@dataclass
+class InspiringBanner(CardBase):
+    id: str = "inspiring_banner"
+    name: str = "Inspiring Banner"
+    stars: int = 1
+    effects: dict[str, float] = field(default_factory=lambda: {"atk": 0.02, "defense": 0.02})

--- a/backend/plugins/cards/keen_goggles.py
+++ b/backend/plugins/cards/keen_goggles.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+from dataclasses import field
+
+from plugins.cards._base import CardBase
+
+
+@dataclass
+class KeenGoggles(CardBase):
+    id: str = "keen_goggles"
+    name: str = "Keen Goggles"
+    stars: int = 1
+    effects: dict[str, float] = field(default_factory=lambda: {"crit_rate": 0.03, "effect_hit_rate": 0.03})

--- a/backend/plugins/cards/lightweight_boots.py
+++ b/backend/plugins/cards/lightweight_boots.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+from dataclasses import field
+
+from plugins.cards._base import CardBase
+
+
+@dataclass
+class LightweightBoots(CardBase):
+    id: str = "lightweight_boots"
+    name: str = "Lightweight Boots"
+    stars: int = 1
+    effects: dict[str, float] = field(default_factory=lambda: {"dodge_odds": 0.03})

--- a/backend/plugins/cards/precision_sights.py
+++ b/backend/plugins/cards/precision_sights.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+from dataclasses import field
+
+from plugins.cards._base import CardBase
+
+
+@dataclass
+class PrecisionSights(CardBase):
+    id: str = "precision_sights"
+    name: str = "Precision Sights"
+    stars: int = 1
+    effects: dict[str, float] = field(default_factory=lambda: {"crit_damage": 0.04})

--- a/backend/plugins/cards/reinforced_cloak.py
+++ b/backend/plugins/cards/reinforced_cloak.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+from dataclasses import field
+
+from plugins.cards._base import CardBase
+
+
+@dataclass
+class ReinforcedCloak(CardBase):
+    id: str = "reinforced_cloak"
+    name: str = "Reinforced Cloak"
+    stars: int = 1
+    effects: dict[str, float] = field(default_factory=lambda: {"defense": 0.03, "effect_resistance": 0.03})

--- a/backend/plugins/cards/rejuvenating_tonic.py
+++ b/backend/plugins/cards/rejuvenating_tonic.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+from dataclasses import field
+
+from plugins.cards._base import CardBase
+
+
+@dataclass
+class RejuvenatingTonic(CardBase):
+    id: str = "rejuvenating_tonic"
+    name: str = "Rejuvenating Tonic"
+    stars: int = 1
+    effects: dict[str, float] = field(default_factory=lambda: {"regain": 0.04})

--- a/backend/plugins/cards/spiked_shield.py
+++ b/backend/plugins/cards/spiked_shield.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+from dataclasses import field
+
+from plugins.cards._base import CardBase
+
+
+@dataclass
+class SpikedShield(CardBase):
+    id: str = "spiked_shield"
+    name: str = "Spiked Shield"
+    stars: int = 1
+    effects: dict[str, float] = field(default_factory=lambda: {"atk": 0.03, "defense": 0.03})

--- a/backend/plugins/cards/steady_grip.py
+++ b/backend/plugins/cards/steady_grip.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+from dataclasses import field
+
+from plugins.cards._base import CardBase
+
+
+@dataclass
+class SteadyGrip(CardBase):
+    id: str = "steady_grip"
+    name: str = "Steady Grip"
+    stars: int = 1
+    effects: dict[str, float] = field(default_factory=lambda: {"atk": 0.03, "dodge_odds": 0.03})

--- a/backend/plugins/cards/steel_bangles.py
+++ b/backend/plugins/cards/steel_bangles.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+from dataclasses import field
+
+from plugins.cards._base import CardBase
+
+
+@dataclass
+class SteelBangles(CardBase):
+    id: str = "steel_bangles"
+    name: str = "Steel Bangles"
+    stars: int = 1
+    effects: dict[str, float] = field(default_factory=lambda: {"mitigation": 0.03})

--- a/backend/plugins/cards/sturdy_boots.py
+++ b/backend/plugins/cards/sturdy_boots.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+from dataclasses import field
+
+from plugins.cards._base import CardBase
+
+
+@dataclass
+class SturdyBoots(CardBase):
+    id: str = "sturdy_boots"
+    name: str = "Sturdy Boots"
+    stars: int = 1
+    effects: dict[str, float] = field(default_factory=lambda: {"dodge_odds": 0.03, "defense": 0.03})

--- a/backend/plugins/cards/swift_bandanna.py
+++ b/backend/plugins/cards/swift_bandanna.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+from dataclasses import field
+
+from plugins.cards._base import CardBase
+
+
+@dataclass
+class SwiftBandanna(CardBase):
+    id: str = "swift_bandanna"
+    name: str = "Swift Bandanna"
+    stars: int = 1
+    effects: dict[str, float] = field(default_factory=lambda: {"crit_rate": 0.03, "dodge_odds": 0.03})

--- a/backend/plugins/cards/tactical_kit.py
+++ b/backend/plugins/cards/tactical_kit.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+from dataclasses import field
+
+from plugins.cards._base import CardBase
+
+
+@dataclass
+class TacticalKit(CardBase):
+    id: str = "tactical_kit"
+    name: str = "Tactical Kit"
+    stars: int = 1
+    effects: dict[str, float] = field(default_factory=lambda: {"atk": 0.02, "max_hp": 0.02})

--- a/backend/plugins/cards/vital_core.py
+++ b/backend/plugins/cards/vital_core.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+from dataclasses import field
+
+from plugins.cards._base import CardBase
+
+
+@dataclass
+class VitalCore(CardBase):
+    id: str = "vital_core"
+    name: str = "Vital Core"
+    stars: int = 1
+    effects: dict[str, float] = field(default_factory=lambda: {"vitality": 0.03, "max_hp": 0.03})

--- a/backend/tests/test_card_rewards.py
+++ b/backend/tests/test_card_rewards.py
@@ -1,6 +1,5 @@
 import json
 import importlib.util
-
 import pytest
 import sqlcipher3
 
@@ -11,6 +10,34 @@ from pathlib import Path
 from autofighter.cards import award_card
 from autofighter.party import Party
 from autofighter.stats import Stats
+
+NEW_CARDS: list[tuple[str, dict[str, float]]] = [
+    ("lightweight_boots", {"dodge_odds": 0.03}),
+    ("expert_manual", {"exp_multiplier": 0.03}),
+    ("steel_bangles", {"mitigation": 0.03}),
+    ("enduring_charm", {"vitality": 0.03}),
+    ("keen_goggles", {"crit_rate": 0.03, "effect_hit_rate": 0.03}),
+    ("honed_point", {"atk": 0.04}),
+    ("fortified_plating", {"defense": 0.04}),
+    ("rejuvenating_tonic", {"regain": 0.04}),
+    ("adamantine_band", {"max_hp": 0.04}),
+    ("precision_sights", {"crit_damage": 0.04}),
+    ("inspiring_banner", {"atk": 0.02, "defense": 0.02}),
+    ("tactical_kit", {"atk": 0.02, "max_hp": 0.02}),
+    ("bulwark_totem", {"defense": 0.02, "max_hp": 0.02}),
+    ("farsight_scope", {"crit_rate": 0.03}),
+    ("steady_grip", {"atk": 0.03, "dodge_odds": 0.03}),
+    ("coated_armor", {"mitigation": 0.03, "defense": 0.03}),
+    ("guiding_compass", {"exp_multiplier": 0.03, "effect_hit_rate": 0.03}),
+    ("swift_bandanna", {"crit_rate": 0.03, "dodge_odds": 0.03}),
+    ("reinforced_cloak", {"defense": 0.03, "effect_resistance": 0.03}),
+    ("vital_core", {"vitality": 0.03, "max_hp": 0.03}),
+    ("enduring_will", {"mitigation": 0.03, "vitality": 0.03}),
+    ("battle_meditation", {"exp_multiplier": 0.03, "vitality": 0.03}),
+    ("guardian_shard", {"defense": 0.02, "mitigation": 0.02}),
+    ("sturdy_boots", {"dodge_odds": 0.03, "defense": 0.03}),
+    ("spiked_shield", {"atk": 0.03, "defense": 0.03}),
+]
 
 @pytest.fixture()
 def app_with_db(tmp_path, monkeypatch):
@@ -85,3 +112,19 @@ async def test_battle_offers_choices_and_applies_effect(app_with_db, monkeypatch
     row = conn.execute("SELECT party FROM runs WHERE id = ?", (run_id,)).fetchone()
     saved = json.loads(row[0])
     assert chosen in saved["cards"]
+
+
+@pytest.mark.parametrize("card_id,effects", NEW_CARDS)
+def test_award_and_apply_new_cards(card_id, effects):
+    member = Stats()
+    member.id = "m1"
+    party = Party(members=[member])
+    baseline = {attr: getattr(member, attr) for attr in effects}
+    assert award_card(party, card_id) is not None
+    cards_module.apply_cards(party)
+    for attr, pct in effects.items():
+        value = getattr(member, attr)
+        expected = type(baseline[attr])(baseline[attr] * (1 + pct))
+        assert value == expected
+        if attr == "max_hp":
+            assert member.hp == expected


### PR DESCRIPTION
## Summary
- add 25 new 1★ card plugins
- document new cards in inventory and planning files
- test awarding and applying new 1★ cards

## Testing
- `uv run pytest` *(fails: tests/test_app.py::test_players_and_rooms, tests/test_card_rewards.py::test_battle_offers_choices_and_applies_effect, tests/test_enrage_stacking.py::test_enrage_stacks, tests/test_player_editor.py::test_player_editor_snapshot_during_run)*

------
https://chatgpt.com/codex/tasks/task_b_68a5f0bc083c832cb1330d03ed608ca2