### PR TITLE
Add Aftertaste effect plugin

### DIFF
--- a/.codex/implementation/stats-and-effects.md
+++ b/.codex/implementation/stats-and-effects.md
@@ -46,3 +46,8 @@ adding the effect. The difference is clamped to zero and jittered by ±10%, and 
 - `on_action()` – triggers `on_action` hooks for effects that react when the target performs an action.
 
 Active effect names are mirrored in the `Stats` lists (`dots`, `hots`) for UI display. Plugins can extend base `DamageOverTime` and `HealingOverTime` classes to implement custom behavior or additional stat modifications.
+
+## Aftertaste
+The Aftertaste effect deals direct damage based on a small potency roll. Each hit
+calculates `25 * random(0.1, 1.5)` and cards or relics may request multiple hits
+by creating the plugin with a `hits` value. Every hit rolls independently.

--- a/backend/plugins/effects/aftertaste.py
+++ b/backend/plugins/effects/aftertaste.py
@@ -1,0 +1,26 @@
+import random
+from dataclasses import dataclass
+from dataclasses import field
+from typing import List
+
+from autofighter.stats import Stats
+
+
+@dataclass
+class Aftertaste:
+    plugin_type = "effect"
+    id = "aftertaste"
+
+    hits: int = 1
+    base_pot: int = 25
+    rng: random.Random = field(default_factory=random.Random)
+
+    def rolls(self) -> List[int]:
+        return [int(self.base_pot * self.rng.uniform(0.1, 1.5)) for _ in range(self.hits)]
+
+    async def apply(self, attacker: Stats, target: Stats) -> List[int]:
+        results: List[int] = []
+        for amount in self.rolls():
+            dmg = await target.apply_damage(amount, attacker)
+            results.append(dmg)
+        return results

--- a/backend/tests/test_aftertaste.py
+++ b/backend/tests/test_aftertaste.py
@@ -1,0 +1,34 @@
+import pytest
+
+from autofighter.stats import Stats
+from plugins.effects.aftertaste import Aftertaste
+
+
+def test_aftertaste_damage_range(monkeypatch):
+    at = Aftertaste()
+    monkeypatch.setattr(at.rng, "uniform", lambda a, b: 0.1)
+    assert at.rolls() == [2]
+    monkeypatch.setattr(at.rng, "uniform", lambda a, b: 1.5)
+    assert at.rolls() == [37]
+
+
+@pytest.mark.asyncio
+async def test_aftertaste_multi_hit(monkeypatch):
+    seq = iter([0.1, 0.5, 1.5])
+    at = Aftertaste(hits=3)
+    monkeypatch.setattr(at.rng, "uniform", lambda a, b: next(seq))
+
+    applied = []
+
+    async def fake_apply_damage(self, amount, attacker=None):
+        applied.append(amount)
+        return amount
+
+    monkeypatch.setattr(Stats, "apply_damage", fake_apply_damage, raising=False)
+
+    attacker = Stats()
+    target = Stats()
+    result = await at.apply(attacker, target)
+
+    assert applied == [2, 12, 37]
+    assert result == [2, 12, 37]


### PR DESCRIPTION
## Summary
- implement Aftertaste effect plugin with random 0.1–1.5x multiplier per hit
- add tests for Aftertaste damage range and multi-hit handling
- document Aftertaste in stats and effects guide

## Testing
- `uv run pytest` *(fails: test_players_and_rooms, test_battle_offers_choices_and_applies_effect, test_enrage_stacks, test_player_editor_snapshot_during_run)*
- `uv run pytest tests/test_aftertaste.py`


------
https://chatgpt.com/codex/tasks/task_b_68a5f1724190832ca9c20231072727fe