### PR TITLE
feat: add critical boost stacking effect

### DIFF
--- a/.codex/implementation/stats-and-effects.md
+++ b/.codex/implementation/stats-and-effects.md
@@ -46,3 +46,6 @@ adding the effect. The difference is clamped to zero and jittered by ±10%, and 
 - `on_action()` – triggers `on_action` hooks for effects that react when the target performs an action.
 
 Active effect names are mirrored in the `Stats` lists (`dots`, `hots`) for UI display. Plugins can extend base `DamageOverTime` and `HealingOverTime` classes to implement custom behavior or additional stat modifications.
+
+## Critical Boost
+Stackable effect granting +0.5% `crit_rate` and +5% `crit_damage` per stack. All stacks are removed when the affected unit takes damage.

--- a/backend/plugins/effects/critical_boost.py
+++ b/backend/plugins/effects/critical_boost.py
@@ -1,0 +1,33 @@
+from dataclasses import dataclass
+from dataclasses import field
+
+from autofighter.stats import BUS
+from autofighter.stats import Stats
+
+
+@dataclass
+class CriticalBoost:
+    plugin_type = "effects"
+    id = "critical_boost"
+
+    crit_rate_per_stack: float = 0.005
+    crit_damage_per_stack: float = 0.05
+    stacks: int = 0
+    target: Stats | None = field(default=None, init=False)
+
+    def apply(self, target: Stats) -> None:
+        if self.target is None:
+            self.target = target
+            BUS.subscribe("damage_taken", self._on_damage_taken)
+        self.stacks += 1
+        target.crit_rate += self.crit_rate_per_stack
+        target.crit_damage += self.crit_damage_per_stack
+
+    def _on_damage_taken(self, victim: Stats, *_: object) -> None:
+        if victim is not self.target or self.target is None or self.stacks == 0:
+            return
+        self.target.crit_rate -= self.crit_rate_per_stack * self.stacks
+        self.target.crit_damage -= self.crit_damage_per_stack * self.stacks
+        self.stacks = 0
+        BUS.unsubscribe("damage_taken", self._on_damage_taken)
+        self.target = None

--- a/backend/tests/test_critical_boost.py
+++ b/backend/tests/test_critical_boost.py
@@ -1,0 +1,37 @@
+import pytest
+from pathlib import Path
+
+from autofighter.stats import BUS
+from autofighter.stats import Stats
+from plugins.effects.critical_boost import CriticalBoost
+from plugins.plugin_loader import PluginLoader
+
+
+def test_critical_boost_stacking():
+    stats = Stats()
+    boost = CriticalBoost()
+    boost.apply(stats)
+    boost.apply(stats)
+    assert stats.crit_rate == pytest.approx(0.05 + 0.005 * 2)
+    assert stats.crit_damage == pytest.approx(2.0 + 0.05 * 2)
+    BUS.unsubscribe("damage_taken", boost._on_damage_taken)
+
+
+@pytest.mark.asyncio
+async def test_critical_boost_resets_on_hit():
+    stats = Stats()
+    boost = CriticalBoost()
+    boost.apply(stats)
+    boost.apply(stats)
+    await stats.apply_damage(10)
+    assert stats.crit_rate == pytest.approx(0.05)
+    assert stats.crit_damage == pytest.approx(2.0)
+    assert boost.stacks == 0
+
+
+def test_critical_boost_plugin_discovery():
+    loader = PluginLoader()
+    root = Path(__file__).resolve().parents[1] / "plugins" / "effects"
+    loader.discover(root)
+    plugins = loader.get_plugins("effects")
+    assert "critical_boost" in plugins


### PR DESCRIPTION
## Summary
- add stackable Critical Boost effect plugin
- document Critical Boost in stats-and-effects reference
- test Critical Boost stacking and discovery

## Testing
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a5f126b628832c840fadd8ebf5b400