### PR TITLE
[FEAT] enable player foes

### DIFF
--- a/.codex/implementation/player-foe-reference.md
+++ b/.codex/implementation/player-foe-reference.md
@@ -36,24 +36,19 @@ and reuse that element in future sessions.
 ## Foe Generation
 Foe plugins inherit from `FoeBase`, which mirrors `PlayerBase` stats. To keep
 encounters from stalling, foes regain health at one hundredth the player rate.
-They are procedurally named by pairing an adjective from `themed_ajt` with a
-themed name from `themed_names` in `themedstuff.py`. After naming,
-`foe_passive_builder.build_foe_stats` applies stat modifiers:
+They are procedurally named by prefixing a randomly selected adjective plugin
+from `plugins/themedadj` to a player name. Adjective plugins are
+auto-discovered based on files in that directory, so adding a new adjective
+requires only dropping a file into the folder. Each adjective class applies its own
+stat changes derived from the legacy project—for example, **Atrocious** boosts
+max HP by 90% and attack by 10%.
 
-1. `_apply_high_level_lady` boosts high-level foes with *Lady* in their names,
-   scaling stats by variant (Light, Dark, Fire, or Ice).
-2. `_apply_themed_name_modifiers` adjusts stats based on the themed name
-   (e.g., "Luna" favors dodge and defense, while "Carly" gains massive
-   mitigation).
-3. `_apply_themed_adj_modifiers` tweaks stats depending on the adjective
-   (e.g., "Atrocious" increases attack).
-4. `player_stat_picker` selects a stat tier using the themed name, influencing
-   base stat scaling.
-
-Example: **Atrocious Luna** receives dodge and defense from the "Luna" portion
-and an attack boost from "Atrocious", producing a foe whose name directly
-translates into combat bonuses.
+Example: **Atrocious Luna** applies the adjective's stat bonuses to the base
+player stats and prefixes the foe's name, yielding a combatant whose title
+reflects its enhanced abilities.
 
 Development builds include a `Slime` foe plugin that reduces all baseline stats
 by 90% for simple battle testing. Standard battles may also spawn random player
-characters that are not currently in the party.
+characters that are not currently in the party. These player foes are wrapped in
+`FoeBase` at load time, granting them foe-specific behaviors such as periodic
+HP regeneration via `maybe_regain`.

--- a/README.md
+++ b/README.md
@@ -137,10 +137,15 @@ out encounters.
 ## Battle Room
 
 Start a run in a battle scene that renders placeholder models, triggers party
-passives, and runs event-driven stat-based attacks against a `Slime` scaled by
-floor, room, Pressure level, and loop count. Foes inherit from a dedicated
-`FoeBase` that mirrors player stats; the default `Slime` reduces them by 90%
-on spawn. The scene shows floating damage numbers and status icons and flashes
+passives, and runs event-driven stat-based attacks against a `Slime` or any
+non-party player character scaled by floor, room, Pressure level, and loop
+count. Foes are procedurally named by prefixing a themed adjective plugin to a
+player name. Adjective plugins are auto-discovered from files in
+`plugins/themedadj`, allowing new adjectives to be added without modifying
+package code. Foes inherit from a dedicated `FoeBase` that mirrors player stats;
+the default `Slime` reduces them by 90% on spawn, while player-derived foes gain
+`FoeBase` behaviors like turn-based regeneration. The scene shows floating
+damage numbers and status icons and flashes
 red and blue with an Enraged buff after 100 turns (500 for floor bosses). Each
 victory presents three unused cards of the appropriate star rank. Selecting one
 adds it to the party, and card and relic bonuses are applied at the start of the

--- a/backend/autofighter/rooms.py
+++ b/backend/autofighter/rooms.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-import copy
 import time
+import copy
 import random
 import asyncio
 
@@ -9,18 +9,19 @@ from dataclasses import asdict
 from dataclasses import dataclass
 from dataclasses import fields
 from typing import Any
-from typing import Awaitable
 from typing import Callable
+from typing import Awaitable
 
 from rich.console import Console
 
 from .party import Party
 from .stats import Stats
 from .mapgen import MapNode
+from .passives import PassiveRegistry
+from plugins import foes as foe_plugins
+from plugins import players as player_plugins
 from plugins.foes._base import FoeBase
 from plugins.damage_types import get_damage_type
-from plugins import foes as foe_plugins
-from .passives import PassiveRegistry
 from autofighter.cards import apply_cards
 from autofighter.cards import card_choices
 from autofighter.relics import apply_relics
@@ -136,6 +137,13 @@ def _choose_foe(party: Party) -> FoeBase:
         for name in getattr(foe_plugins, "__all__", [])
         if getattr(foe_plugins, name).id not in party_ids
     ]
+    for name in getattr(player_plugins, "__all__", []):
+        player_cls = getattr(player_plugins, name)
+        if player_cls.id in party_ids:
+            continue
+        foe_cls = foe_plugins.PLAYER_FOES.get(player_cls.id)
+        if foe_cls and foe_cls not in candidates:
+            candidates.append(foe_cls)
     if not candidates:
         candidates = [foe_plugins.Slime]
     foe_cls = random.choice(candidates)

--- a/backend/plugins/foes/__init__.py
+++ b/backend/plugins/foes/__init__.py
@@ -1,3 +1,45 @@
-from .slime import Slime
+from __future__ import annotations
 
-__all__ = ["Slime"]
+import random
+
+from .slime import Slime
+from ._base import FoeBase
+from plugins import themedadj as adj_plugins
+from plugins import players as player_plugins
+
+ADJ_CLASSES = [
+    getattr(adj_plugins, name)
+    for name in getattr(adj_plugins, "__all__", [])
+]
+
+
+def _wrap_player(cls: type) -> type[FoeBase]:
+    class Wrapped(cls, FoeBase):
+        plugin_type = "foe"
+
+        def __post_init__(self) -> None:
+            getattr(cls, "__post_init__", lambda self: None)(self)
+            FoeBase.__post_init__(self)
+            self.plugin_type = "foe"
+            try:
+                adj_cls = random.choice(ADJ_CLASSES)
+                adj = adj_cls()
+                adj.apply(self)
+                self.name = f"{adj.name} {self.name}"
+            except Exception:
+                pass
+
+    Wrapped.__name__ = f"{cls.__name__}Foe"
+    return Wrapped
+
+
+PLAYER_FOES: dict[str, type[FoeBase]] = {}
+for name in getattr(player_plugins, "__all__", []):
+    cls = getattr(player_plugins, name)
+    foe_cls = _wrap_player(cls)
+    PLAYER_FOES[cls.id] = foe_cls
+    globals()[foe_cls.__name__] = foe_cls
+
+
+__all__ = ["Slime", *[cls.__name__ for cls in PLAYER_FOES.values()]]
+

--- a/backend/plugins/themedadj/__init__.py
+++ b/backend/plugins/themedadj/__init__.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from plugins import PluginLoader
+
+
+loader = PluginLoader()
+loader.discover(str(Path(__file__).resolve().parent))
+_plugins = loader.get_plugins("themedadj")
+
+for cls in _plugins.values():
+    globals()[cls.__name__] = cls
+
+__all__ = sorted(cls.__name__ for cls in _plugins.values())
+

--- a/backend/plugins/themedadj/atrocious.py
+++ b/backend/plugins/themedadj/atrocious.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Atrocious:
+    plugin_type = "themedadj"
+    id = "atrocious"
+    name = "Atrocious"
+
+    def apply(self, target) -> None:
+        target.max_hp = int(target.max_hp * 1.9)
+        target.atk = int(target.atk * 1.1)

--- a/backend/plugins/themedadj/baneful.py
+++ b/backend/plugins/themedadj/baneful.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Baneful:
+    plugin_type = "themedadj"
+    id = "baneful"
+    name = "Baneful"
+
+    def apply(self, target) -> None:
+        target.atk = int(target.atk * 1.95)
+        target.crit_damage = target.crit_damage * 1.05

--- a/backend/plugins/themedadj/barbaric.py
+++ b/backend/plugins/themedadj/barbaric.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Barbaric:
+    plugin_type = "themedadj"
+    id = "barbaric"
+    name = "Barbaric"
+
+    def apply(self, target) -> None:
+        target.max_hp = int(target.max_hp * 1.1)
+        target.defense = int(target.defense * 1.9)

--- a/backend/plugins/themedadj/beastly.py
+++ b/backend/plugins/themedadj/beastly.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Beastly:
+    plugin_type = "themedadj"
+    id = "beastly"
+    name = "Beastly"
+
+    def apply(self, target) -> None:
+        target.max_hp = int(target.max_hp * 1.05)
+        target.atk = int(target.atk * 1.05)

--- a/backend/plugins/themedadj/belligerent.py
+++ b/backend/plugins/themedadj/belligerent.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Belligerent:
+    plugin_type = "themedadj"
+    id = "belligerent"
+    name = "Belligerent"
+
+    def apply(self, target) -> None:
+        target.dodge_odds = target.dodge_odds * 1.9
+        target.atk = int(target.atk * 1.1)

--- a/backend/plugins/themedadj/bloodthirsty.py
+++ b/backend/plugins/themedadj/bloodthirsty.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Bloodthirsty:
+    plugin_type = "themedadj"
+    id = "bloodthirsty"
+    name = "Bloodthirsty"
+
+    def apply(self, target) -> None:
+        target.max_hp = int(target.max_hp - (target.max_hp * 0.1))
+        target.atk = int(target.atk + (target.atk * 0.2))

--- a/backend/plugins/themedadj/brutal.py
+++ b/backend/plugins/themedadj/brutal.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Brutal:
+    plugin_type = "themedadj"
+    id = "brutal"
+    name = "Brutal"
+
+    def apply(self, target) -> None:
+        target.crit_rate = target.crit_rate + 0.1
+        target.dodge_odds = target.dodge_odds * 1.9

--- a/backend/plugins/themedadj/callous.py
+++ b/backend/plugins/themedadj/callous.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Callous:
+    plugin_type = "themedadj"
+    id = "callous"
+    name = "Callous"
+
+    def apply(self, target) -> None:
+        target.defense = int(target.defense * 1.1)
+        target.dodge_odds = target.dodge_odds * 1.9

--- a/backend/plugins/themedadj/cannibalistic.py
+++ b/backend/plugins/themedadj/cannibalistic.py
@@ -1,0 +1,11 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Cannibalistic:
+    plugin_type = "themedadj"
+    id = "cannibalistic"
+    name = "Cannibalistic"
+
+    def apply(self, target) -> None:
+        target.max_hp = int(target.max_hp + (target.max_hp * 0.05))

--- a/backend/plugins/themedadj/cowardly.py
+++ b/backend/plugins/themedadj/cowardly.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Cowardly:
+    plugin_type = "themedadj"
+    id = "cowardly"
+    name = "Cowardly"
+
+    def apply(self, target) -> None:
+        target.max_hp = int(target.max_hp * 1.2)
+        target.atk = int(target.atk * 0.8)

--- a/backend/plugins/themedadj/cruel.py
+++ b/backend/plugins/themedadj/cruel.py
@@ -1,0 +1,11 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Cruel:
+    plugin_type = "themedadj"
+    id = "cruel"
+    name = "Cruel"
+
+    def apply(self, target) -> None:
+        target.crit_damage = target.crit_damage * 1.05

--- a/backend/plugins/themedadj/cunning.py
+++ b/backend/plugins/themedadj/cunning.py
@@ -1,0 +1,11 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Cunning:
+    plugin_type = "themedadj"
+    id = "cunning"
+    name = "Cunning"
+
+    def apply(self, target) -> None:
+        target.dodge_odds = target.dodge_odds * 1.1

--- a/backend/plugins/themedadj/dangerous.py
+++ b/backend/plugins/themedadj/dangerous.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Dangerous:
+    plugin_type = "themedadj"
+    id = "dangerous"
+    name = "Dangerous"
+
+    def apply(self, target) -> None:
+        target.atk = int(target.atk * 1.05)
+        target.crit_rate = target.crit_rate + 0.05

--- a/backend/plugins/themedadj/demonic.py
+++ b/backend/plugins/themedadj/demonic.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Demonic:
+    plugin_type = "themedadj"
+    id = "demonic"
+    name = "Demonic"
+
+    def apply(self, target) -> None:
+        target.max_hp = int(target.max_hp * 1.9)
+        target.atk = int(target.atk * 1.15)

--- a/backend/plugins/themedadj/depraved.py
+++ b/backend/plugins/themedadj/depraved.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Depraved:
+    plugin_type = "themedadj"
+    id = "depraved"
+    name = "Depraved"
+
+    def apply(self, target) -> None:
+        target.defense = int(target.defense - (target.defense * 0.1))
+        target.atk = int(target.atk + (target.atk * 0.1))

--- a/backend/plugins/themedadj/destructive.py
+++ b/backend/plugins/themedadj/destructive.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Destructive:
+    plugin_type = "themedadj"
+    id = "destructive"
+    name = "Destructive"
+
+    def apply(self, target) -> None:
+        target.atk = int(target.atk * 1.1)
+        target.crit_rate = target.crit_rate + 0.05

--- a/backend/plugins/themedadj/diabolical.py
+++ b/backend/plugins/themedadj/diabolical.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Diabolical:
+    plugin_type = "themedadj"
+    id = "diabolical"
+    name = "Diabolical"
+
+    def apply(self, target) -> None:
+        target.atk = int(target.atk * 1.1)
+        target.dodge_odds = target.dodge_odds * 1.9

--- a/backend/plugins/themedadj/disgusting.py
+++ b/backend/plugins/themedadj/disgusting.py
@@ -1,0 +1,11 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Disgusting:
+    plugin_type = "themedadj"
+    id = "disgusting"
+    name = "Disgusting"
+
+    def apply(self, target) -> None:
+        target.defense = int(target.defense * 1.9)

--- a/backend/plugins/themedadj/dishonorable.py
+++ b/backend/plugins/themedadj/dishonorable.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Dishonorable:
+    plugin_type = "themedadj"
+    id = "dishonorable"
+    name = "Dishonorable"
+
+    def apply(self, target) -> None:
+        target.atk = int(target.atk * 1.05)
+        target.defense = int(target.defense * 1.95)

--- a/backend/plugins/themedadj/dreadful.py
+++ b/backend/plugins/themedadj/dreadful.py
@@ -1,0 +1,11 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Dreadful:
+    plugin_type = "themedadj"
+    id = "dreadful"
+    name = "Dreadful"
+
+    def apply(self, target) -> None:
+        target.atk = int(target.atk * 1.05)

--- a/backend/plugins/themedadj/eerie.py
+++ b/backend/plugins/themedadj/eerie.py
@@ -1,0 +1,11 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Eerie:
+    plugin_type = "themedadj"
+    id = "eerie"
+    name = "Eerie"
+
+    def apply(self, target) -> None:
+        target.dodge_odds = target.dodge_odds * 1.05

--- a/backend/plugins/themedadj/evil.py
+++ b/backend/plugins/themedadj/evil.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Evil:
+    plugin_type = "themedadj"
+    id = "evil"
+    name = "Evil"
+
+    def apply(self, target) -> None:
+        target.max_hp = int(target.max_hp * 1.95)
+        target.atk = int(target.atk * 1.05)

--- a/backend/plugins/themedadj/execrable.py
+++ b/backend/plugins/themedadj/execrable.py
@@ -1,0 +1,11 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Execrable:
+    plugin_type = "themedadj"
+    id = "execrable"
+    name = "Execrable"
+
+    def apply(self, target) -> None:
+        target.max_hp = int(target.max_hp * 1.9)

--- a/backend/plugins/themedadj/fiendish.py
+++ b/backend/plugins/themedadj/fiendish.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Fiendish:
+    plugin_type = "themedadj"
+    id = "fiendish"
+    name = "Fiendish"
+
+    def apply(self, target) -> None:
+        target.dodge_odds = target.dodge_odds * 1.9
+        target.crit_rate = target.crit_rate + 0.1

--- a/backend/plugins/themedadj/filthy.py
+++ b/backend/plugins/themedadj/filthy.py
@@ -1,0 +1,11 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Filthy:
+    plugin_type = "themedadj"
+    id = "filthy"
+    name = "Filthy"
+
+    def apply(self, target) -> None:
+        target.defense = int(target.defense * 1.95)

--- a/backend/plugins/themedadj/foul.py
+++ b/backend/plugins/themedadj/foul.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Foul:
+    plugin_type = "themedadj"
+    id = "foul"
+    name = "Foul"
+
+    def apply(self, target) -> None:
+        target.defense = int(target.defense * 1.95)
+        target.dodge_odds = target.dodge_odds * 1.95

--- a/backend/plugins/themedadj/frightening.py
+++ b/backend/plugins/themedadj/frightening.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Frightening:
+    plugin_type = "themedadj"
+    id = "frightening"
+    name = "Frightening"
+
+    def apply(self, target) -> None:
+        target.atk = int(target.atk * 1.05)
+        target.dodge_odds = target.dodge_odds * 1.95

--- a/backend/plugins/themedadj/ghastly.py
+++ b/backend/plugins/themedadj/ghastly.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Ghastly:
+    plugin_type = "themedadj"
+    id = "ghastly"
+    name = "Ghastly"
+
+    def apply(self, target) -> None:
+        target.max_hp = int(target.max_hp * 1.95)
+        target.dodge_odds = target.dodge_odds * 1.05

--- a/backend/plugins/themedadj/ghoulish.py
+++ b/backend/plugins/themedadj/ghoulish.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Ghoulish:
+    plugin_type = "themedadj"
+    id = "ghoulish"
+    name = "Ghoulish"
+
+    def apply(self, target) -> None:
+        target.max_hp = int(target.max_hp * 1.95)
+        target.atk = int(target.atk * 1.05)

--- a/backend/plugins/themedadj/gruesome.py
+++ b/backend/plugins/themedadj/gruesome.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Gruesome:
+    plugin_type = "themedadj"
+    id = "gruesome"
+    name = "Gruesome"
+
+    def apply(self, target) -> None:
+        target.atk = int(target.atk * 1.05)
+        target.crit_damage = target.crit_damage * 1.05

--- a/backend/plugins/themedadj/heinous.py
+++ b/backend/plugins/themedadj/heinous.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Heinous:
+    plugin_type = "themedadj"
+    id = "heinous"
+    name = "Heinous"
+
+    def apply(self, target) -> None:
+        target.atk = int(target.atk * 1.1)
+        target.crit_damage = target.crit_damage * 1.1

--- a/backend/plugins/themedadj/hideous.py
+++ b/backend/plugins/themedadj/hideous.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Hideous:
+    plugin_type = "themedadj"
+    id = "hideous"
+    name = "Hideous"
+
+    def apply(self, target) -> None:
+        target.defense = int(target.defense * 1.9)
+        target.max_hp = int(target.max_hp * 1.1)

--- a/backend/plugins/themedadj/homicidal.py
+++ b/backend/plugins/themedadj/homicidal.py
@@ -1,0 +1,11 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Homicidal:
+    plugin_type = "themedadj"
+    id = "homicidal"
+    name = "Homicidal"
+
+    def apply(self, target) -> None:
+        target.atk = int(target.atk * 1.15)

--- a/backend/plugins/themedadj/horrible.py
+++ b/backend/plugins/themedadj/horrible.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Horrible:
+    plugin_type = "themedadj"
+    id = "horrible"
+    name = "Horrible"
+
+    def apply(self, target) -> None:
+        target.atk = int(target.atk * 1.02)
+        target.crit_rate = target.crit_rate + 0.02

--- a/backend/plugins/themedadj/hostile.py
+++ b/backend/plugins/themedadj/hostile.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Hostile:
+    plugin_type = "themedadj"
+    id = "hostile"
+    name = "Hostile"
+
+    def apply(self, target) -> None:
+        target.atk = int(target.atk * 1.05)
+        target.defense = int(target.defense * 1.95)

--- a/backend/plugins/themedadj/inhumane.py
+++ b/backend/plugins/themedadj/inhumane.py
@@ -1,0 +1,11 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Inhumane:
+    plugin_type = "themedadj"
+    id = "inhumane"
+    name = "Inhumane"
+
+    def apply(self, target) -> None:
+        target.crit_damage = target.crit_damage * 1.1

--- a/backend/plugins/themedadj/insidious.py
+++ b/backend/plugins/themedadj/insidious.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Insidious:
+    plugin_type = "themedadj"
+    id = "insidious"
+    name = "Insidious"
+
+    def apply(self, target) -> None:
+        target.atk = int(target.atk * 1.05)
+        target.dodge_odds = target.dodge_odds * 1.05

--- a/backend/plugins/themedadj/intimidating.py
+++ b/backend/plugins/themedadj/intimidating.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Intimidating:
+    plugin_type = "themedadj"
+    id = "intimidating"
+    name = "Intimidating"
+
+    def apply(self, target) -> None:
+        target.atk = int(target.atk * 1.95)
+        target.defense = int(target.defense * 1.05)

--- a/backend/plugins/themedadj/malevolent.py
+++ b/backend/plugins/themedadj/malevolent.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Malevolent:
+    plugin_type = "themedadj"
+    id = "malevolent"
+    name = "Malevolent"
+
+    def apply(self, target) -> None:
+        target.crit_damage = target.crit_damage * 1.05
+        target.dodge_odds = target.dodge_odds * 1.95

--- a/backend/plugins/themedadj/malicious.py
+++ b/backend/plugins/themedadj/malicious.py
@@ -1,0 +1,11 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Malicious:
+    plugin_type = "themedadj"
+    id = "malicious"
+    name = "Malicious"
+
+    def apply(self, target) -> None:
+        target.atk = int(target.atk * 1.07)

--- a/backend/plugins/themedadj/monstrous.py
+++ b/backend/plugins/themedadj/monstrous.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Monstrous:
+    plugin_type = "themedadj"
+    id = "monstrous"
+    name = "Monstrous"
+
+    def apply(self, target) -> None:
+        target.max_hp = int(target.max_hp * 1.1)
+        target.atk = int(target.atk * 1.1)

--- a/backend/plugins/themedadj/murderous.py
+++ b/backend/plugins/themedadj/murderous.py
@@ -1,0 +1,11 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Murderous:
+    plugin_type = "themedadj"
+    id = "murderous"
+    name = "Murderous"
+
+    def apply(self, target) -> None:
+        target.crit_rate = target.crit_rate + 0.15

--- a/backend/plugins/themedadj/nasty.py
+++ b/backend/plugins/themedadj/nasty.py
@@ -1,0 +1,13 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Nasty:
+    plugin_type = "themedadj"
+    id = "nasty"
+    name = "Nasty"
+
+    def apply(self, target) -> None:
+        target.atk = int(target.atk * 1.05)
+        target.defense = int(target.defense * 1.95)
+        target.dodge_odds = target.dodge_odds * 1.95

--- a/backend/plugins/themedadj/nefarious.py
+++ b/backend/plugins/themedadj/nefarious.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Nefarious:
+    plugin_type = "themedadj"
+    id = "nefarious"
+    name = "Nefarious"
+
+    def apply(self, target) -> None:
+        target.crit_rate = target.crit_rate + 0.05
+        target.crit_damage = target.crit_damage * 1.05

--- a/backend/plugins/themedadj/noxious.py
+++ b/backend/plugins/themedadj/noxious.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Noxious:
+    plugin_type = "themedadj"
+    id = "noxious"
+    name = "Noxious"
+
+    def apply(self, target) -> None:
+        target.atk = int(target.atk * 1.05)
+        target.max_hp = int(target.max_hp * 1.95)

--- a/backend/plugins/themedadj/obscene.py
+++ b/backend/plugins/themedadj/obscene.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Obscene:
+    plugin_type = "themedadj"
+    id = "obscene"
+    name = "Obscene"
+
+    def apply(self, target) -> None:
+        target.defense = int(target.defense * 1.9)
+        target.dodge_odds = target.dodge_odds * 1.9

--- a/backend/plugins/themedadj/odious.py
+++ b/backend/plugins/themedadj/odious.py
@@ -1,0 +1,11 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Odious:
+    plugin_type = "themedadj"
+    id = "odious"
+    name = "Odious"
+
+    def apply(self, target) -> None:
+        target.defense = int(target.defense * 1.95)

--- a/backend/plugins/themedadj/ominous.py
+++ b/backend/plugins/themedadj/ominous.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Ominous:
+    plugin_type = "themedadj"
+    id = "ominous"
+    name = "Ominous"
+
+    def apply(self, target) -> None:
+        target.crit_rate = target.crit_rate + 0.02
+        target.crit_damage = target.crit_damage * 1.03

--- a/backend/plugins/themedadj/pernicious.py
+++ b/backend/plugins/themedadj/pernicious.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Pernicious:
+    plugin_type = "themedadj"
+    id = "pernicious"
+    name = "Pernicious"
+
+    def apply(self, target) -> None:
+        target.max_hp = int(target.max_hp * 1.95)
+        target.crit_rate = target.crit_rate + 0.05

--- a/backend/plugins/themedadj/perverted.py
+++ b/backend/plugins/themedadj/perverted.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Perverted:
+    plugin_type = "themedadj"
+    id = "perverted"
+    name = "Perverted"
+
+    def apply(self, target) -> None:
+        target.defense = int(target.defense * 1.9)
+        target.dodge_odds = target.dodge_odds * 1.1

--- a/backend/plugins/themedadj/poisonous.py
+++ b/backend/plugins/themedadj/poisonous.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Poisonous:
+    plugin_type = "themedadj"
+    id = "poisonous"
+    name = "Poisonous"
+
+    def apply(self, target) -> None:
+        target.atk = int(target.atk * 1.07)
+        target.max_hp = int(target.max_hp * 1.93)

--- a/backend/plugins/themedadj/predatory.py
+++ b/backend/plugins/themedadj/predatory.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Predatory:
+    plugin_type = "themedadj"
+    id = "predatory"
+    name = "Predatory"
+
+    def apply(self, target) -> None:
+        target.dodge_odds = target.dodge_odds * 1.1
+        target.crit_rate = target.crit_rate + 0.05

--- a/backend/plugins/themedadj/premeditated.py
+++ b/backend/plugins/themedadj/premeditated.py
@@ -1,0 +1,11 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Premeditated:
+    plugin_type = "themedadj"
+    id = "premeditated"
+    name = "Premeditated"
+
+    def apply(self, target) -> None:
+        target.crit_rate = target.crit_rate + 0.1

--- a/backend/plugins/themedadj/primal.py
+++ b/backend/plugins/themedadj/primal.py
@@ -1,0 +1,13 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Primal:
+    plugin_type = "themedadj"
+    id = "primal"
+    name = "Primal"
+
+    def apply(self, target) -> None:
+        target.atk = int(target.atk * 1.05)
+        target.defense = int(target.defense * 1.95)
+        target.max_hp = int(target.max_hp * 1.05)

--- a/backend/plugins/themedadj/primitive.py
+++ b/backend/plugins/themedadj/primitive.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Primitive:
+    plugin_type = "themedadj"
+    id = "primitive"
+    name = "Primitive"
+
+    def apply(self, target) -> None:
+        target.atk = int(target.atk * 1.05)
+        target.defense = int(target.defense * 1.95)

--- a/backend/plugins/themedadj/profane.py
+++ b/backend/plugins/themedadj/profane.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Profane:
+    plugin_type = "themedadj"
+    id = "profane"
+    name = "Profane"
+
+    def apply(self, target) -> None:
+        target.max_hp = int(target.max_hp * 1.9)
+        target.crit_damage = target.crit_damage * 1.1

--- a/backend/plugins/themedadj/psychopathic.py
+++ b/backend/plugins/themedadj/psychopathic.py
@@ -1,0 +1,13 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Psychopathic:
+    plugin_type = "themedadj"
+    id = "psychopathic"
+    name = "Psychopathic"
+
+    def apply(self, target) -> None:
+        target.dodge_odds = target.dodge_odds * 1.9
+        target.atk = int(target.atk * 1.1)
+        target.crit_damage = target.crit_damage * 1.1

--- a/backend/plugins/themedadj/rabid.py
+++ b/backend/plugins/themedadj/rabid.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Rabid:
+    plugin_type = "themedadj"
+    id = "rabid"
+    name = "Rabid"
+
+    def apply(self, target) -> None:
+        target.atk = int(target.atk * 1.1)
+        target.defense = int(target.defense * 1.9)

--- a/backend/plugins/themedadj/relentless.py
+++ b/backend/plugins/themedadj/relentless.py
@@ -1,0 +1,13 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Relentless:
+    plugin_type = "themedadj"
+    id = "relentless"
+    name = "Relentless"
+
+    def apply(self, target) -> None:
+        target.dodge_odds = target.dodge_odds * 1.9
+        target.atk = int(target.atk * 1.05)
+        target.crit_rate = target.crit_rate + 0.05

--- a/backend/plugins/themedadj/repulsive.py
+++ b/backend/plugins/themedadj/repulsive.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Repulsive:
+    plugin_type = "themedadj"
+    id = "repulsive"
+    name = "Repulsive"
+
+    def apply(self, target) -> None:
+        target.defense = int(target.defense * 1.9)
+        target.dodge_odds = target.dodge_odds * 1.1

--- a/backend/plugins/themedadj/ruthless.py
+++ b/backend/plugins/themedadj/ruthless.py
@@ -1,0 +1,11 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Ruthless:
+    plugin_type = "themedadj"
+    id = "ruthless"
+    name = "Ruthless"
+
+    def apply(self, target) -> None:
+        target.crit_damage = target.crit_damage * 1.15

--- a/backend/plugins/themedadj/sadistic.py
+++ b/backend/plugins/themedadj/sadistic.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Sadistic:
+    plugin_type = "themedadj"
+    id = "sadistic"
+    name = "Sadistic"
+
+    def apply(self, target) -> None:
+        target.atk = int(target.atk * 1.02)
+        target.crit_damage = target.crit_damage * 1.08

--- a/backend/plugins/themedadj/savage.py
+++ b/backend/plugins/themedadj/savage.py
@@ -1,0 +1,13 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Savage:
+    plugin_type = "themedadj"
+    id = "savage"
+    name = "Savage"
+
+    def apply(self, target) -> None:
+        target.atk = int(target.atk * 1.1)
+        target.defense = int(target.defense * 1.9)
+        target.max_hp = int(target.max_hp * 1.1)

--- a/backend/plugins/themedadj/scary.py
+++ b/backend/plugins/themedadj/scary.py
@@ -1,0 +1,13 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Scary:
+    plugin_type = "themedadj"
+    id = "scary"
+    name = "Scary"
+
+    def apply(self, target) -> None:
+        target.atk = int(target.atk * 1.95)
+        target.dodge_odds = target.dodge_odds * 1.05
+        target.crit_damage = target.crit_damage * 1.05

--- a/backend/plugins/themedadj/sinister.py
+++ b/backend/plugins/themedadj/sinister.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Sinister:
+    plugin_type = "themedadj"
+    id = "sinister"
+    name = "Sinister"
+
+    def apply(self, target) -> None:
+        target.dodge_odds = target.dodge_odds * 1.05
+        target.crit_damage = target.crit_damage * 1.05

--- a/backend/plugins/themedadj/sociopathic.py
+++ b/backend/plugins/themedadj/sociopathic.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Sociopathic:
+    plugin_type = "themedadj"
+    id = "sociopathic"
+    name = "Sociopathic"
+
+    def apply(self, target) -> None:
+        target.dodge_odds = target.dodge_odds * 1.9
+        target.atk = int(target.atk * 1.15)

--- a/backend/plugins/themedadj/spiteful.py
+++ b/backend/plugins/themedadj/spiteful.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Spiteful:
+    plugin_type = "themedadj"
+    id = "spiteful"
+    name = "Spiteful"
+
+    def apply(self, target) -> None:
+        target.atk = int(target.atk * 1.07)
+        target.max_hp = int(target.max_hp * 1.93)

--- a/backend/plugins/themedadj/squalid.py
+++ b/backend/plugins/themedadj/squalid.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Squalid:
+    plugin_type = "themedadj"
+    id = "squalid"
+    name = "Squalid"
+
+    def apply(self, target) -> None:
+        target.defense = int(target.defense * 1.95)
+        target.max_hp = int(target.max_hp * 1.05)

--- a/backend/plugins/themedadj/terrifying.py
+++ b/backend/plugins/themedadj/terrifying.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Terrifying:
+    plugin_type = "themedadj"
+    id = "terrifying"
+    name = "Terrifying"
+
+    def apply(self, target) -> None:
+        target.atk = int(target.atk * 1.9)
+        target.defense = int(target.defense * 1.1)

--- a/backend/plugins/themedadj/threatening.py
+++ b/backend/plugins/themedadj/threatening.py
@@ -1,0 +1,13 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Threatening:
+    plugin_type = "themedadj"
+    id = "threatening"
+    name = "Threatening"
+
+    def apply(self, target) -> None:
+        target.atk = int(target.atk * 1.05)
+        target.defense = int(target.defense * 1.95)
+        target.dodge_odds = target.dodge_odds * 1.95

--- a/backend/plugins/themedadj/treacherous.py
+++ b/backend/plugins/themedadj/treacherous.py
@@ -1,0 +1,13 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Treacherous:
+    plugin_type = "themedadj"
+    id = "treacherous"
+    name = "Treacherous"
+
+    def apply(self, target) -> None:
+        target.atk = int(target.atk * 1.05)
+        target.dodge_odds = target.dodge_odds * 1.05
+        target.crit_rate = target.crit_rate + 0.05

--- a/backend/plugins/themedadj/ugly.py
+++ b/backend/plugins/themedadj/ugly.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Ugly:
+    plugin_type = "themedadj"
+    id = "ugly"
+    name = "Ugly"
+
+    def apply(self, target) -> None:
+        target.defense = int(target.defense * 1.1)
+        target.max_hp = int(target.max_hp * 1.9)

--- a/backend/plugins/themedadj/unholy.py
+++ b/backend/plugins/themedadj/unholy.py
@@ -1,0 +1,13 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Unholy:
+    plugin_type = "themedadj"
+    id = "unholy"
+    name = "Unholy"
+
+    def apply(self, target) -> None:
+        target.max_hp = int(target.max_hp * 5)
+        target.atk = int(target.atk * 2)
+        target.crit_damage = target.crit_damage * 0.8

--- a/backend/plugins/themedadj/venomous.py
+++ b/backend/plugins/themedadj/venomous.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Venomous:
+    plugin_type = "themedadj"
+    id = "venomous"
+    name = "Venomous"
+
+    def apply(self, target) -> None:
+        target.atk = int(target.atk * 1.1)
+        target.max_hp = int(target.max_hp * 1.9)

--- a/backend/plugins/themedadj/vicious.py
+++ b/backend/plugins/themedadj/vicious.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Vicious:
+    plugin_type = "themedadj"
+    id = "vicious"
+    name = "Vicious"
+
+    def apply(self, target) -> None:
+        target.atk = int(target.atk * 1.1)
+        target.crit_rate = target.crit_rate + 0.05

--- a/backend/plugins/themedadj/villainous.py
+++ b/backend/plugins/themedadj/villainous.py
@@ -1,0 +1,13 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Villainous:
+    plugin_type = "themedadj"
+    id = "villainous"
+    name = "Villainous"
+
+    def apply(self, target) -> None:
+        target.atk = int(target.atk * 1.05)
+        target.dodge_odds = target.dodge_odds * 1.95
+        target.crit_rate = target.crit_rate + 0.05

--- a/backend/plugins/themedadj/violent.py
+++ b/backend/plugins/themedadj/violent.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Violent:
+    plugin_type = "themedadj"
+    id = "violent"
+    name = "Violent"
+
+    def apply(self, target) -> None:
+        target.atk = int(target.atk * 1.15)
+        target.defense = int(target.defense * 0.85)

--- a/backend/plugins/themedadj/wicked.py
+++ b/backend/plugins/themedadj/wicked.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Wicked:
+    plugin_type = "themedadj"
+    id = "wicked"
+    name = "Wicked"
+
+    def apply(self, target) -> None:
+        target.atk = int(target.atk * 1.08)
+        target.crit_damage = target.crit_damage * 1.02

--- a/backend/plugins/themedadj/wrongful.py
+++ b/backend/plugins/themedadj/wrongful.py
@@ -1,0 +1,13 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Wrongful:
+    plugin_type = "themedadj"
+    id = "wrongful"
+    name = "Wrongful"
+
+    def apply(self, target) -> None:
+        target.atk = int(target.atk * 1.05)
+        target.defense = int(target.defense * 1.95)
+        target.crit_damage = target.crit_damage * 1.05

--- a/backend/plugins/themedadj/xenophobic.py
+++ b/backend/plugins/themedadj/xenophobic.py
@@ -1,0 +1,11 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Xenophobic:
+    plugin_type = "themedadj"
+    id = "xenophobic"
+    name = "Xenophobic"
+
+    def apply(self, target) -> None:
+        target.defense = int(target.defense * 1.1)

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -13,7 +13,6 @@ dependencies = [
     "pytest-asyncio>=0.23.0",
     "cryptography>=41.0.0",
 ]
-
 [build-system]
 requires = ["setuptools>=68", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/backend/tests/test_random_player_foes.py
+++ b/backend/tests/test_random_player_foes.py
@@ -1,0 +1,26 @@
+import sys
+import random
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from plugins import players
+from plugins import themedadj
+from autofighter.party import Party
+from plugins.players import Player
+from autofighter.rooms import _choose_foe
+
+
+def test_random_player_foes() -> None:
+    random.seed(0)
+    party = Party(members=[Player()])
+    player_ids = {
+        getattr(getattr(players, name), "id") for name in getattr(players, "__all__", [])
+    }
+    seen = [_choose_foe(party) for _ in range(20)]
+    ids = {foe.id for foe in seen}
+    assert any(fid in player_ids and fid != "slime" for fid in ids)
+    player_foes = [foe for foe in seen if foe.id != "slime"]
+    if player_foes:
+        foe_name = player_foes[0].name
+        assert any(adj.title() in foe_name for adj in themedadj.__all__)


### PR DESCRIPTION
## Summary
- convert legacy adjective list into `themedadj` plugins that apply stat bonuses
- wrap player foes with a random adjective plugin for stat-modified names
- drop obsolete `themedstuff` module and tidy backend pyproject
- document adjective-based foe naming and update player foe test
- auto-discover themed adjective plugins so new files require no `__init__` edits

## Testing
- `uv run ruff check .` (fails: F401 unused imports, F811 redefinitions)
- `uv run pytest` (fails: `test_app::test_players_and_rooms`, `test_card_rewards::test_battle_offers_choices_and_applies_effect`, `test_enrage_stacking::test_enrage_stacks`, `test_player_editor::test_player_editor_snapshot_during_run`)


------
https://chatgpt.com/codex/tasks/task_b_68a5f2d034e4832ca0d9f2b9f008d850