### PR TITLE
[FEATURE] add rare drop rate

### DIFF
--- a/.codex/implementation/relic-inventory.md
+++ b/.codex/implementation/relic-inventory.md
@@ -21,7 +21,7 @@ relics are held, the menu reports an empty inventory.
 - 2★ Ember Stone – Below 25% HP, allies burn their attacker for 50% ATK.
 - 2★ Guardian Charm – Lowest-HP ally gains +20% DEF at battle start.
 - 2★ Killer Instinct – Ultimates grant +75% ATK for the turn; kills grant another turn.
-- 3★ Greed Engine – Party loses 1% HP per turn but gains extra gold and drops.
+- 3★ Greed Engine – Party loses 1% HP per turn, gains +50% gold, and raises rare drop rate by 0.5% plus 0.1% per extra stack.
 - 3★ Stellar Compass – Critical hits grant permanent +1.5% ATK and gold rate.
 - 3★ Echoing Drum – First attack each battle repeats at 25% power.
 - 4★ Null Lantern – Removes shops/rests; fights drop additional pulls.

--- a/.codex/implementation/stats-and-effects.md
+++ b/.codex/implementation/stats-and-effects.md
@@ -10,6 +10,7 @@ The `Stats` dataclass stores core attributes for both players and foes:
 - **Defense:** `defense`, `mitigation`, `regain`, `dodge_odds`, `effect_resistance`
 - **Vitality & Advanced:** `vitality`, `action_points`, `damage_taken`, `damage_dealt`, `kills`
 - **Status Lists:** `passives`, `dots`, `hots`, `damage_types`, `relics`
+- **Party:** `gold`, `rdr` – run-wide currency and rare drop rate multiplier applied to gold, upgrade item counts, relic odds, pull ticket chances, and (at extreme values) can roll to raise relic and card star ranks
 
 `base_damage_type` is a `DamageType` plugin instance (default `Generic`) instead of a string, allowing damage hooks.
 Characters with random base damage types store their first rolled element in the

--- a/.codex/planning/bd48a561-relic-plan.md
+++ b/.codex/planning/bd48a561-relic-plan.md
@@ -31,7 +31,7 @@ Parent: [Web Game Plan](8a7d9c1e-web-game-plan.md)
  - [x] **Killer Instinct** – When an ally uses their Ultimate, they gain +75% ATK for that turn; if they kill a foe, they immediately take another turn.
 
 ## 3★ Relics
- - [ ] **Greed Engine** – All characters lose 1% HP per turn plus 0.5% per stack. Earn 50% more gold plus 25% per stack and increase rare drop rate by 0.005% plus 0.001% per stack.
+ - [ ] **Greed Engine** – All characters lose 1% HP per turn plus 0.5% per stack. Earn 50% more gold plus 25% per stack and increase rare drop rate by 0.5% plus 0.1% per additional stack.
  - [ ] **Stellar Compass** – Critical hits grant +1.5% ATK and +1.5% gold for the rest of combat, stacking without limit.
  - [ ] **Echoing Drum** – The first attack an ally uses each battle repeats at 25% power plus 25% per stack.
 

--- a/.codex/planning/e158df1a-map-and-room-types-plan.md
+++ b/.codex/planning/e158df1a-map-and-room-types-plan.md
@@ -22,9 +22,10 @@
 8. Fights that exceed 100 turns (500 for floor bosses) trigger a slow red/blue flash on the room to warn of drawn-out battles.
    - Each turn after the flash begins grants foes a +40% Attack `Enraged` buff.
 9. Rewards:
-   - Normal fights: 5% chance to drop a relic (98% of which are 1★), grant gold = 5 × (loop number × random float 1.01–1.25), drop 1–2★ upgrade items scaled by floor/room/Pressure, and award a 1–2★ card.
-   - Bosses: 25% chance to drop a relic with 1–5★ ranks, grant extra gold = 20 × (loop number × random float 1.53–2.25), drop 1–3★ upgrade items scaled by difficulty, and award a 1–5★ card.
-   - Floor bosses: guaranteed relic drops (3★ at 98% odds), largest gold bonus = 200 × (loop number × random float 2.05–4.25), drop 3–4★ upgrade items scaled by difficulty, award 3–5★ cards, and grant pull tickets that scale with Pressure/loop up to 5 per floor boss.
+   - **Rare drop rate (`rdr`)** multiplies gold payouts, relic drop odds, upgrade item counts, and pull ticket chances. At extreme values it also boosts relic and card star ranks (3★→4★ at 1000% `rdr`, 4★→5★ at 1,000,000%).
+   - Normal fights: 10% × `rdr` chance to drop a relic (70% 1★, 20% 2★, 10% 3★), grant gold = 5 × loop × rand(1.01–1.25) × `rdr`, drop 1–2★ upgrade items based on floor/room/Pressure (capped at 4★) with quantity scaled by `rdr`, and award a 1–2★ card.
+   - Bosses: 50% × `rdr` chance to drop a relic (60% 3★, 30% 4★, 10% 5★), grant gold = 20 × loop × rand(1.53–2.25) × `rdr`, drop 1–3★ upgrade items scaled by difficulty (max 4★) with quantity scaled by `rdr`, and award a 1–5★ card.
+   - Floor bosses: guaranteed relic drop (60% 3★, 30% 4★, 10% 5★), largest gold bonus = 200 × loop × rand(2.05–4.25) × `rdr`, drop 3–4★ upgrade items scaled by difficulty (max 4★) with quantity scaled by `rdr`, award 3–5★ cards, and roll a 10% × `rdr` chance for one pull ticket.
    - Relics come in 1–5★ ranks using the shared star-color scheme; stacks have no cap and drop tables favor relics the player lacks.
    - Cards are unique collectibles with one copy each; design ~100 cards per combat theme (DoT, melee, etc.), with 1★ effects providing minor perks (e.g., heal 1% when dealing DoT) and 5★ effects offering major boons (e.g., temporary ally joins the party).
 10. Code structure:

--- a/README.md
+++ b/README.md
@@ -103,6 +103,19 @@ cd backend
 uv run pytest
 ```
 
+## Loot and Rare Drop Rate
+
+Battles award gold, relic choices, upgrade items, and occasionally pull tickets.
+Gold equals a base value of 5/20/200 for normal, boss, and floor-boss rooms,
+multiplied by the loop, a random range, and the party's rare drop rate (`rdr`).
+Relics drop with `10% × rdr` odds in normal fights or `50% × rdr` in boss rooms.
+Upgrade items use the foe's element, cap at 4★, and their quantity scales with
+`rdr`—fractions have a matching chance to grant an extra item. Each battle also
+rolls a `10% × rdr` chance for a pull ticket. `rdr` improves drop quantity and
+odds and can even upgrade relic or card star ranks with lucky rolls at extreme
+values: climbing from 3★ to 4★ requires 1000% `rdr`, while 5★ demands a
+colossal 1,000,000%.
+
 ## Plugins
 
 The game auto-discovers classes under `plugins/` and `mods/` by `plugin_type`
@@ -150,6 +163,12 @@ red and blue with an Enraged buff after 100 turns (500 for floor bosses). Each
 victory presents three unused cards of the appropriate star rank. Selecting one
 adds it to the party, and card and relic bonuses are applied at the start of the
 next battle.
+
+Parties also track a rare drop rate (`rdr`) that boosts relic drops, gold
+rewards, upgrade item counts, and pull ticket chances. At extreme values it can
+roll to raise relic and card star ranks (3★→4★ at 1000% `rdr`, 4★→5★ at
+1,000,000%), but even huge `rdr` never guarantees success. The 3★ Greed Engine
+relic raises `rdr` while draining HP each turn.
 
 Defeated foes grant experience to every party member. Characters below level
 1000 receive a 10× boost to experience gained so early levels advance quickly.

--- a/backend/.codex/implementation/loot-tables.md
+++ b/backend/.codex/implementation/loot-tables.md
@@ -1,0 +1,47 @@
+# Loot Tables
+
+Battle rewards include gold, relic choices, upgrade items, and pull tickets. Gold
+and item drops scale with room difficulty and the party's rare drop rate (`rdr`).
+
+## Gold
+- **Normal battles:** `5 × loop × rand(1.01–1.25)`
+- **Boss battles:** `20 × loop × rand(1.53–2.25)`
+- **Floor bosses:** `200 × loop × rand(2.05–4.25)`
+
+The result is multiplied by `rdr` before being added to the party. The same
+amount is emitted on the `gold_earned` event so relics can modify the final
+reward.
+
+## Relics
+- **Normal battles:** `10% × rdr` chance for a relic (70% 1★, 20% 2★, 10% 3★)
+- **Boss or floor bosses:** `50% × rdr` chance for a relic (60% 3★, 30% 4★, 10% 5★)
+
+`rdr` scales the drop chance and, at very high values, can roll to upgrade relic
+star rank. Every additional star requires 1000× more `rdr` than the last:
+moving from 3★ to 4★ takes 1000% `rdr`, and 5★ demands 1,000,000%, but even at
+those values success isn't guaranteed.
+
+## Upgrade Items
+- **Normal battles:** 1–2★ items
+- **Boss battles:** 1–3★ items
+- **Floor bosses:** 3–4★ items
+
+The band determines the maximum star rank; the minimum starts at the lower
+value and rises with floor, loop count, and Pressure. Results are capped at 4★
+and use the foe's element at random. Each battle drops one item by default and
+multiplies that quantity by the party's rare drop rate (`rdr`). Fractional results
+have a matching chance to award one extra item.
+
+If auto-crafting is enabled, 125 lower-star items combine into the next tier up
+to 4★, and sets of ten 4★ items convert into a gacha ticket. `rdr` only affects
+how many items appear—it never upgrades their star level.
+
+## Pull Tickets
+Each battle rolls a `10% × rdr` chance to drop a pull ticket in addition to
+other rewards.
+
+## RDR Effects
+`rdr` multiplies gold rewards, upgrade item counts, relic drop odds, and pull
+ticket chances. It can also roll to raise relic and card star ranks when `rdr`
+is extraordinarily high (3★→4★ at 1000%, 4★→5★ at 1,000,000%) but never
+upgrades item stars.

--- a/backend/README.md
+++ b/backend/README.md
@@ -33,6 +33,17 @@ Battle resolution awards experience to all party members. Characters below
 level 1000 receive a 10× boost to earned experience, and level-ups are synced
 back to the run along with updated stats.
 
+Victories grant gold, relic choices, upgrade items, and a small chance at pull
+tickets. Gold equals a base value (5 for normal battles, 20 for bosses, 200 for
+floor bosses) multiplied by the loop, a random range, and the party's rare drop
+rate (`rdr`). Relic drops roll `10% × rdr` in normal fights or `50% × rdr` in
+boss and floor-boss rooms. Upgrade items use the foe's element at random, cap at
+4★, and their quantity scales with `rdr` with fractional amounts having a
+matching chance to yield an extra item. Each fight also rolls a `10% × rdr`
+chance to award a pull ticket. `rdr` boosts drop quantity and odds and, at
+extreme values, can roll to upgrade relic and card star ranks (3★→4★ at 1000%
+`rdr`, 4★→5★ at 1,000,000%) though success is never guaranteed.
+
 `GET /gacha` returns the current pity counter, element-based upgrade items,
 owned characters with their duplicate stacks, and whether auto-crafting is
 enabled. `POST /gacha/pull` performs 1, 5, or 10 pulls, awarding 5★ or 6★

--- a/backend/autofighter/gacha.py
+++ b/backend/autofighter/gacha.py
@@ -104,8 +104,16 @@ class GachaManager:
             )
 
     def _auto_craft(self, items: dict[str, int]) -> None:
+        """Convert excess upgrade items into higher tiers or tickets.
+
+        Crafting never creates items above 4★. Any surplus 4★ items are
+        exchanged for gacha tickets rather than upgrading to a nonexistent 5★
+        tier. This keeps rare drop rate bonuses from indirectly raising star
+        level beyond the intended cap.
+        """
+
         for element in ELEMENTS:
-            for star in (1, 2, 3):
+            for star in range(1, 4):
                 lower = f"{element}_{star}"
                 higher = f"{element}_{star + 1}"
                 while items.get(lower, 0) >= 125:

--- a/backend/autofighter/party.py
+++ b/backend/autofighter/party.py
@@ -10,3 +10,4 @@ class Party:
     gold: int = 0
     relics: list[str] = field(default_factory=list)
     cards: list[str] = field(default_factory=list)
+    rdr: float = 1.0

--- a/backend/plugins/relics/greed_engine.py
+++ b/backend/plugins/relics/greed_engine.py
@@ -20,11 +20,13 @@ class GreedEngine(RelicBase):
         stacks = party.relics.count(self.id)
         gold_bonus = 0.5 + 0.25 * (stacks - 1)
         hp_loss = 0.01 + 0.005 * (stacks - 1)
+        rdr_bonus = 0.005 + 0.001 * (stacks - 1)
 
         state = getattr(party, "_greed_engine_state", None)
         if state is None:
-            state = {"gold": gold_bonus, "loss": hp_loss}
+            state = {"gold": gold_bonus, "loss": hp_loss, "rdr": rdr_bonus}
             party._greed_engine_state = state
+            party.rdr += state["rdr"]
 
             def _gold(amount: int) -> None:
                 party.gold += int(amount * state["gold"])
@@ -36,5 +38,8 @@ class GreedEngine(RelicBase):
             BUS.subscribe("gold_earned", _gold)
             BUS.subscribe("turn_start", _drain)
         else:
+            party.rdr -= state.get("rdr", 0)
             state["gold"] = gold_bonus
             state["loss"] = hp_loss
+            state["rdr"] = rdr_bonus
+            party.rdr += state["rdr"]

--- a/backend/tests/test_loot_summary.py
+++ b/backend/tests/test_loot_summary.py
@@ -1,8 +1,10 @@
 import pytest
+
 import autofighter.rooms as rooms_module
-from autofighter.mapgen import MapNode
 from autofighter.party import Party
 from autofighter.stats import Stats
+from autofighter.mapgen import MapNode
+from plugins.damage_types import ALL_DAMAGE_TYPES
 
 
 @pytest.mark.asyncio
@@ -12,8 +14,32 @@ async def test_battle_returns_loot_summary(monkeypatch):
     member = Stats()
     member.id = "p1"
     party = Party(members=[member])
-    monkeypatch.setattr(rooms_module.random, "random", lambda: 1.0)
+    monkeypatch.setattr(rooms_module.random, "random", lambda: 0.5)
+    monkeypatch.setattr(rooms_module.random, "choice", lambda seq: seq[0])
     monkeypatch.setattr(rooms_module, "card_choices", lambda *a, **k: [])
     result = await room.resolve(party, {})
     assert "loot" in result
-    assert set(result["loot"]).issuperset({"gold", "card_choices", "relic_choices", "items"})
+    loot = result["loot"]
+    assert set(loot).issuperset({"gold", "card_choices", "relic_choices", "items"})
+    assert loot["gold"] > 0
+    upgrades = [i for i in loot["items"] if i["id"] != "ticket"]
+    assert upgrades
+    valid_ids = {e.lower() for e in ALL_DAMAGE_TYPES}
+    for item in upgrades:
+        assert item["id"] in valid_ids
+        assert 1 <= item["stars"] <= 4
+
+
+@pytest.mark.asyncio
+async def test_floor_boss_high_star_items(monkeypatch):
+    node = MapNode(room_id=1, room_type="battle-boss-floor", floor=1, index=1, loop=1, pressure=0)
+    room = rooms_module.BattleRoom(node)
+    member = Stats()
+    member.id = "p1"
+    party = Party(members=[member])
+    monkeypatch.setattr(rooms_module.random, "random", lambda: 0.5)
+    monkeypatch.setattr(rooms_module.random, "choice", lambda seq: seq[0])
+    monkeypatch.setattr(rooms_module, "card_choices", lambda *a, **k: [])
+    result = await room.resolve(party, {})
+    stars = [i["stars"] for i in result["loot"]["items"] if i["id"] != "ticket"]
+    assert stars and stars[0] >= 3

--- a/backend/tests/test_rdr.py
+++ b/backend/tests/test_rdr.py
@@ -1,0 +1,120 @@
+import pytest
+import autofighter.rooms as rooms_module
+from autofighter.mapgen import MapNode
+from autofighter.party import Party
+from autofighter.stats import Stats
+
+
+@pytest.mark.asyncio
+async def test_rdr_scales_relic_drop(monkeypatch):
+    node = MapNode(room_id=1, room_type="battle-normal", floor=1, index=1, loop=1, pressure=0)
+    room = rooms_module.BattleRoom(node)
+    member = Stats()
+    member.id = "p1"
+    low = Party(members=[member], rdr=1.0)
+    high = Party(members=[member], rdr=3.0)
+    monkeypatch.setattr(rooms_module, "card_choices", lambda *a, **k: [])
+    monkeypatch.setattr(
+        rooms_module,
+        "relic_choices",
+        lambda *a, **k: [type("R", (), {"id": "r", "name": "R", "stars": k.get("stars", 1)})() for _ in range(3)],
+    )
+    monkeypatch.setattr(rooms_module.random, "random", lambda: 0.2)
+    result_low = await room.resolve(low, {})
+    result_high = await room.resolve(high, {})
+    assert result_low["relic_choices"] == []
+    assert len(result_high["relic_choices"]) == 3
+
+
+@pytest.mark.asyncio
+async def test_rdr_scales_items_and_tickets(monkeypatch):
+    node = MapNode(room_id=1, room_type="battle-normal", floor=1, index=1, loop=1, pressure=0)
+    room = rooms_module.BattleRoom(node)
+    member = Stats()
+    member.id = "p1"
+    low = Party(members=[member], rdr=1.0)
+    high = Party(members=[member], rdr=2.0)
+    monkeypatch.setattr(rooms_module, "card_choices", lambda *a, **k: [])
+    monkeypatch.setattr(rooms_module, "relic_choices", lambda *a, **k: [])
+    monkeypatch.setattr(rooms_module.random, "choice", lambda seq: seq[0])
+    monkeypatch.setattr(rooms_module.random, "random", lambda: 0.15)
+    result_low = await room.resolve(low, {})
+    result_high = await room.resolve(high, {})
+    low_upgrades = [i for i in result_low["loot"]["items"] if i["id"] != "ticket"]
+    high_upgrades = [i for i in result_high["loot"]["items"] if i["id"] != "ticket"]
+    assert len(high_upgrades) > len(low_upgrades)
+    assert {i["stars"] for i in low_upgrades} == {i["stars"] for i in high_upgrades}
+    low_tickets = [i for i in result_low["loot"]["items"] if i["id"] == "ticket"]
+    high_tickets = [i for i in result_high["loot"]["items"] if i["id"] == "ticket"]
+    assert len(high_tickets) > len(low_tickets)
+
+
+@pytest.mark.asyncio
+async def test_rdr_buffs_relic_star_odds(monkeypatch):
+    node = MapNode(room_id=1, room_type="battle-normal", floor=1, index=1, loop=1, pressure=0)
+    room = rooms_module.BattleRoom(node)
+    member = Stats()
+    member.id = "p1"
+    low = Party(members=[member], rdr=1.0)
+    high = Party(members=[member], rdr=10.0)
+    monkeypatch.setattr(rooms_module, "card_choices", lambda *a, **k: [])
+    monkeypatch.setattr(rooms_module, "_pick_relic_stars", lambda room: 3)
+    monkeypatch.setattr(rooms_module, "_roll_relic_drop", lambda *a, **k: True)
+    monkeypatch.setattr(
+        rooms_module,
+        "relic_choices",
+        lambda *a, **k: [type("R", (), {"id": "r", "name": "R", "stars": k.get("stars", 1)})()],
+    )
+    monkeypatch.setattr(rooms_module.random, "random", lambda: 0.0)
+    result_low = await room.resolve(low, {})
+    result_high_lucky = await room.resolve(high, {})
+    monkeypatch.setattr(rooms_module.random, "random", lambda: 0.99)
+    result_high_unlucky = await room.resolve(high, {})
+    assert result_low["relic_choices"][0]["stars"] == 3
+    assert result_high_lucky["relic_choices"][0]["stars"] == 4
+    assert result_high_unlucky["relic_choices"][0]["stars"] == 3
+
+
+@pytest.mark.asyncio
+async def test_rdr_buffs_card_star_odds(monkeypatch):
+    node = MapNode(room_id=1, room_type="battle-boss-floor", floor=1, index=1, loop=1, pressure=0)
+    room = rooms_module.BossRoom(node)
+    member = Stats()
+    member.id = "p1"
+    low = Party(members=[member], rdr=1.0)
+    high = Party(members=[member], rdr=10.0)
+    monkeypatch.setattr(rooms_module, "_pick_card_stars", lambda room: 3)
+    monkeypatch.setattr(rooms_module, "_roll_relic_drop", lambda *a, **k: False)
+    monkeypatch.setattr(
+        rooms_module,
+        "card_choices",
+        lambda party, stars: [type("C", (), {"id": "c", "name": "C", "stars": stars})()],
+    )
+    monkeypatch.setattr(rooms_module.random, "random", lambda: 0.0)
+    result_low = await room.resolve(low, {})
+    result_high_lucky = await room.resolve(high, {})
+    monkeypatch.setattr(rooms_module.random, "random", lambda: 0.99)
+    result_high_unlucky = await room.resolve(high, {})
+    assert result_low["card_choices"][0]["stars"] == 3
+    assert result_high_lucky["card_choices"][0]["stars"] == 4
+    assert result_high_unlucky["card_choices"][0]["stars"] == 3
+
+
+@pytest.mark.asyncio
+async def test_rdr_scales_floor_boss_items_same_star(monkeypatch):
+    node = MapNode(room_id=1, room_type="battle-boss-floor", floor=1, index=1, loop=1, pressure=0)
+    room = rooms_module.BattleRoom(node)
+    member = Stats()
+    member.id = "p1"
+    low = Party(members=[member], rdr=1.0)
+    high = Party(members=[member], rdr=3.0)
+    monkeypatch.setattr(rooms_module, "card_choices", lambda *a, **k: [])
+    monkeypatch.setattr(rooms_module, "relic_choices", lambda *a, **k: [])
+    monkeypatch.setattr(rooms_module.random, "choice", lambda seq: seq[0])
+    monkeypatch.setattr(rooms_module.random, "random", lambda: 0.9)
+    result_low = await room.resolve(low, {})
+    result_high = await room.resolve(high, {})
+    low_upgrades = [i for i in result_low["loot"]["items"] if i["id"] != "ticket"]
+    high_upgrades = [i for i in result_high["loot"]["items"] if i["id"] != "ticket"]
+    assert len(high_upgrades) > len(low_upgrades)
+    assert {i["stars"] for i in low_upgrades} == {i["stars"] for i in high_upgrades} == {3}

--- a/feedback.md
+++ b/feedback.md
@@ -48,6 +48,11 @@ Details
 - Symptom: The top-left snapshot panel reads `Updating...` while the battle snapshot is being fetched/updated.
 - Impact: The wording is inconsistent with other UI uses of "sync" and can be confusing; "Syncing..." better indicates the round-trip network synchronization in combat.
 - Suggested follow-up (actionable):
-		- Frontend change: Update `frontend/src/lib/GameViewport.svelte` — change the `<span>Updating...</span>` (snapshot panel) to `<span>Syncing...</span>` so the label matches expected terminology for battle snapshot sync.
-		- Also audit any other occurrences of `Updating...` in the UI and change to `Syncing...` where it refers to network synchronization rather than content being edited.
+                - Frontend change: Update `frontend/src/lib/GameViewport.svelte` — change the `<span>Updating...</span>` (snapshot panel) to `<span>Syncing...</span>` so the label matches expected terminology for battle snapshot sync.
+                - Also audit any other occurrences of `Updating...` in the UI and change to `Syncing...` where it refers to network synchronization rather than content being edited.
+
+### 6) Loot system follow-up (New issue)
+- Symptom: Rare drop rate now multiplies gold rewards, relic odds, upgrade item counts, ticket chances, and—at extreme levels—can roll to raise relic and card star ranks. Future features may not reference it consistently.
+- Impact: New rooms or relics could ignore `rdr`, leading to inconsistent loot expectations.
+- Suggested follow-up: Document `rdr` usage in future design notes and ensure new content hooks into the existing `gold_earned` event and item-generation helpers.
 

--- a/myunderstanding.md
+++ b/myunderstanding.md
@@ -10,6 +10,8 @@ To get the game playable, the map now mimics Slay the Spire with the boss at the
 
 After each battle the backend may return card choices; the viewport now opens a reward overlay with art from `src/lib/assets` so I can pick one before moving on.
 
+Loot now follows room-type tables. Gold uses a base value multiplied by loop, a random range, and the party's rare drop rate (`rdr`). Relics roll `10% × rdr` in normal battles or `50% × rdr` in boss rooms, upgrade items cap at 4★ and scale their quantity with `rdr`, and every fight rolls a `10% × rdr` chance for a pull ticket. `rdr` affects quantities and odds and, at astronomical values, can bump relic and card star ranks with lucky rolls (3★→4★ at 1000% `rdr`, 4★→5★ at 1,000,000%).
+
 This is my current understanding of how the game behaves. I'll update it as new pieces fall into place.
 
 The frontend now ships 24×24 placeholder icons for items, relics, and cards, organized by damage type or star rank so art can drop in later.


### PR DESCRIPTION
## Summary
- allow rare drop rate to upgrade relic and card star ranks at extreme thresholds
- document star-rank boosts for `rdr` across loot tables, stats docs, and readmes
- test that high `rdr` bumps relic and card stars while leaving upgrade-item stars unchanged

## Testing
- `uv run pytest tests/test_loot_summary.py::test_battle_returns_loot_summary tests/test_loot_summary.py::test_floor_boss_high_star_items tests/test_rdr.py -q`
- `uv run pytest -q` *(KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_b_68a6a0381080832c9f3ec7de1b4d2096