### PR TITLE
Fix inconsistent foe elements in battle snapshots

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -35,6 +35,7 @@ from autofighter.rooms import ShopRoom
 from autofighter.rooms import _choose_foe
 from autofighter.rooms import _scale_stats
 from autofighter.rooms import _serialize
+from autofighter.stats import Stats
 from autofighter.stats import apply_status_hooks
 from autofighter.gacha import GachaManager
 from autofighter.mapgen import MapGenerator
@@ -722,6 +723,7 @@ def save_party(run_id: str, party: Party) -> None:
 async def _run_battle(
     run_id: str,
     room: BattleRoom,
+    foe: Stats,
     party: Party,
     data: dict[str, Any],
     state: dict[str, Any],
@@ -729,7 +731,7 @@ async def _run_battle(
     progress: Callable[[dict[str, Any]], Awaitable[None]],
 ) -> None:
     try:
-        result = await room.resolve(party, data, progress)
+        result = await room.resolve(party, data, progress, foe)
         state["battle"] = False
         has_card_choices = bool(result.get("card_choices"))
         has_relic_choices = bool(result.get("relic_choices"))
@@ -856,7 +858,7 @@ async def battle_room(run_id: str) -> tuple[str, int, dict[str, str]]:
         battle_snapshots[run_id] = snapshot
 
     task = asyncio.create_task(
-        _run_battle(run_id, room, party, data, state, rooms, progress)
+        _run_battle(run_id, room, foe, party, data, state, rooms, progress)
     )
     battle_tasks[run_id] = task
     app.logger.info(

--- a/backend/autofighter/rooms.py
+++ b/backend/autofighter/rooms.py
@@ -275,12 +275,14 @@ class BattleRoom(Room):
         party: Party,
         data: dict[str, Any],
         progress: Callable[[dict[str, Any]], Awaitable[None]] | None = None,
+        foe: Stats | None = None,
     ) -> dict[str, Any]:
         registry = PassiveRegistry()
         start_gold = party.gold
-        foe = _choose_foe(party)
-        # TODO: Extend to support battles with multiple foes and target selection.
-        _scale_stats(foe, self.node, self.strength)
+        if foe is None:
+            foe = _choose_foe(party)
+            # TODO: Extend to support battles with multiple foes and target selection.
+            _scale_stats(foe, self.node, self.strength)
         combat_party = Party(
             members=[copy.deepcopy(m) for m in party.members],
             gold=party.gold,

--- a/backend/tests/test_battle_snapshot_consistency.py
+++ b/backend/tests/test_battle_snapshot_consistency.py
@@ -1,0 +1,76 @@
+import asyncio
+import importlib.util
+
+from pathlib import Path
+
+import pytest
+
+from plugins.foes._base import FoeBase
+from plugins.damage_types.ice import Ice
+from plugins.damage_types.fire import Fire
+
+
+@pytest.fixture()
+def app_with_db(tmp_path, monkeypatch):
+    db_path = tmp_path / "save.db"
+    monkeypatch.setenv("AF_DB_PATH", str(db_path))
+    monkeypatch.setenv("AF_DB_KEY", "testkey")
+    monkeypatch.syspath_prepend(Path(__file__).resolve().parents[1])
+    spec = importlib.util.spec_from_file_location(
+        "app", Path(__file__).resolve().parents[1] / "app.py",
+    )
+    app_module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(app_module)
+    app_module.app.testing = True
+    return app_module, db_path
+
+
+@pytest.mark.asyncio
+async def test_foe_element_stable_across_snapshots(app_with_db, monkeypatch):
+    app_module, _ = app_with_db
+    app = app_module.app
+    client = app.test_client()
+
+    elements = [Fire(), Ice()]
+
+    class DummyFoe(FoeBase):
+        id = "dummy"
+        name = "Dummy"
+
+    def choose_foe(_party):
+        foe = DummyFoe()
+        foe.base_damage_type = elements.pop(0)
+        foe.hp = foe.max_hp = 1
+        return foe
+
+    import autofighter.rooms as rooms_module
+
+    monkeypatch.setattr(app_module, "_choose_foe", choose_foe)
+    monkeypatch.setattr(rooms_module, "_choose_foe", choose_foe)
+    monkeypatch.setattr(app_module, "_scale_stats", lambda *args, **kwargs: None)
+    monkeypatch.setattr(rooms_module, "_scale_stats", lambda *args, **kwargs: None)
+
+    original_run_battle = app_module._run_battle
+
+    async def delayed_run_battle(run_id, room, foe, party, data, state, rooms, progress):
+        await asyncio.sleep(0)
+        return await original_run_battle(run_id, room, foe, party, data, state, rooms, progress)
+
+    monkeypatch.setattr(app_module, "_run_battle", delayed_run_battle)
+
+    start_resp = await client.post("/run/start", json={"party": ["player"]})
+    run_id = (await start_resp.get_json())["run_id"]
+    await client.put(f"/party/{run_id}", json={"party": ["player"]})
+
+    battle_resp = await client.post(f"/rooms/{run_id}/battle")
+    first = await battle_resp.get_json()
+    initial = first["foes"][0]["element"]
+
+    await asyncio.sleep(0)
+    snap_resp = await client.post(
+        f"/rooms/{run_id}/battle", json={"action": "snapshot"}
+    )
+    second = await snap_resp.get_json()
+
+    assert second["foes"][0]["element"] == initial


### PR DESCRIPTION
## Summary
- reuse foe chosen at battle start when resolving battles
- allow BattleRoom.resolve to accept an injected foe
- add regression test to ensure battle snapshots retain the same foe element

## Testing
- `uv run ruff check app.py autofighter/rooms.py tests/test_battle_snapshot_consistency.py`
- `uv run pytest tests/test_battle_snapshot_consistency.py`
- `uv run pytest` *(fails: KeyboardInterrupt after ~35s)*

------
https://chatgpt.com/codex/tasks/task_b_68a71f1721bc832c9dfcee86169cbf6a