### PR TITLE
Add Shadow Siphon dark damage party drain

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,12 +142,15 @@ types.
 
 DoT and HoT plugins manage ongoing damage or recovery. Supported DoTs include
 Bleed, Celestial Atrophy, Abyssal Corruption (spreads on death), Blazing
-Torment (extra tick on action), Cold Wound (five-stack cap), and Impact Echo
-(half of the last hit each turn). HoTs cover Regeneration, Player Echo, and
-Player Heal. Light characters additionally apply a weak Radiant Regeneration
-HoT to all allies each action, and if an ally falls below a quarter of their
-health they prioritize a direct heal over attacking. Foes regenerate at one
-hundredth the player rate to prevent drawn-out encounters.
+Torment (extra tick on action), Cold Wound (five-stack cap), Impact Echo
+(half of the last hit each turn), and Shadow Siphon. Shadow Siphon is applied by
+Dark characters to every party member on each action; stacks never expire and
+drain 5% of max HP per tick while granting the caster matching attack and
+defense for the HP lost. HoTs cover Regeneration, Player Echo, and Player Heal.
+Light characters additionally apply a weak Radiant Regeneration HoT to all
+allies each action, and if an ally falls below a quarter of their health they
+prioritize a direct heal over attacking. Foes regenerate at one hundredth the
+player rate to prevent drawn-out encounters.
 
 ## Battle Room
 

--- a/backend/.codex/implementation/vitality-effects.md
+++ b/backend/.codex/implementation/vitality-effects.md
@@ -5,3 +5,7 @@
 - Light damage type users grant all allies a stack of Radiant Regeneration
   (5 HP over 2 turns) on each action and will directly heal allies under 25%
   HP instead of attacking.
+- Dark damage type users apply a stack of Shadow Siphon to every party member
+  each action. The DoT has no turn limit and drains 5% of max HP per stack each
+  tick. For every 1% of max HP drained, the Dark user gains matching attack and
+  defense. All Shadow Siphon stacks are cleared when the battle ends.

--- a/backend/autofighter/effects.py
+++ b/backend/autofighter/effects.py
@@ -23,8 +23,19 @@ class DamageOverTime:
 
     async def tick(self, target: Stats, *_: object) -> bool:
         attacker = self.source or target
-        dmg = target.base_damage_type.on_dot_damage_taken(self.damage, attacker, target)
-        dmg = target.base_damage_type.on_party_dot_damage_taken(dmg, attacker, target)
+        dmg = target.base_damage_type.on_dot_damage_taken(
+            self.damage,
+            attacker,
+            target,
+        )
+        dmg = target.base_damage_type.on_party_dot_damage_taken(
+            dmg,
+            attacker,
+            target,
+        )
+        source_type = getattr(attacker, "base_damage_type", None)
+        if source_type is not target.base_damage_type:
+            dmg = source_type.on_party_dot_damage_taken(dmg, attacker, target)
         await target.apply_damage(int(dmg), attacker=attacker)
         self.turns -= 1
         return self.turns > 0

--- a/backend/autofighter/rooms.py
+++ b/backend/autofighter/rooms.py
@@ -324,9 +324,11 @@ class BattleRoom(Room):
             member.effect_manager = mgr
             party_effects.append(mgr)
 
+        BUS.emit("battle_start", foe)
         registry.trigger("battle_start", foe)
         console.log(f"Battle start: {foe.id} vs {[m.id for m in combat_party.members]}")
         for member_effect, member in zip(party_effects, combat_party.members):
+            BUS.emit("battle_start", member)
             registry.trigger("battle_start", member)
 
         base_foe_atk = foe.atk
@@ -531,9 +533,11 @@ class BattleRoom(Room):
                 continue
             break
 
+        BUS.emit("battle_end", foe)
         registry.trigger("battle_end", foe)
         console.log("Battle end")
         for member in combat_party.members:
+            BUS.emit("battle_end", member)
             registry.trigger("battle_end", member)
         for member, orig in zip(combat_party.members, party.members):
             orig.gain_exp(exp_reward)

--- a/backend/plugins/damage_types/dark.py
+++ b/backend/plugins/damage_types/dark.py
@@ -1,6 +1,8 @@
 from dataclasses import dataclass
 
 from autofighter.effects import DamageOverTime
+from autofighter.stats import BUS
+from plugins.dots.shadow_siphon import ShadowSiphon
 from plugins.damage_types._base import DamageTypeBase
 
 
@@ -10,5 +12,41 @@ class Dark(DamageTypeBase):
     weakness = "Light"
     color = (145, 0, 145)
 
+    _cleanup_registered: bool = False
+
+    async def on_action(self, actor, allies, enemies) -> bool:
+        for member in allies:
+            mgr = getattr(member, "effect_manager", None)
+            if mgr is not None:
+                dmg = int(member.max_hp * 0.05)
+                mgr.add_dot(ShadowSiphon(dmg))
+
+        if not self._cleanup_registered:
+            def _clear(_):
+                for member in allies:
+                    member.dots = [d for d in member.dots if d != ShadowSiphon.id]
+                    mgr = getattr(member, "effect_manager", None)
+                    if mgr is not None:
+                        mgr.dots = [d for d in mgr.dots if getattr(d, "id", "") != ShadowSiphon.id]
+                self._cleanup_registered = False
+
+            BUS.subscribe("battle_end", _clear)
+            self._cleanup_registered = True
+
+        return True
+
+    def on_party_dot_damage_taken(self, damage, attacker, target) -> float:
+        if getattr(attacker, "base_damage_type", None) is self and ShadowSiphon.id in target.dots:
+            percent = damage / target.max_hp
+            attacker.atk *= 1 + percent
+            attacker.defense *= 1 + percent
+        return damage
+
     def create_dot(self, damage: float, source) -> DamageOverTime | None:
-        return DamageOverTime("Abyssal Corruption", int(damage * 0.4), 3, "dark_dot", source)
+        return DamageOverTime(
+            "Abyssal Corruption",
+            int(damage * 0.4),
+            3,
+            "dark_dot",
+            source,
+        )

--- a/backend/plugins/dots/shadow_siphon.py
+++ b/backend/plugins/dots/shadow_siphon.py
@@ -1,0 +1,14 @@
+from autofighter.effects import DamageOverTime
+
+
+class ShadowSiphon(DamageOverTime):
+    plugin_type = "dot"
+    id = "shadow_siphon"
+
+    def __init__(self, damage: int) -> None:
+        super().__init__("Shadow Siphon", damage, 1, self.id)
+
+    async def tick(self, target, *_):
+        await super().tick(target)
+        self.turns += 1
+        return True

--- a/backend/tests/test_shadow_siphon.py
+++ b/backend/tests/test_shadow_siphon.py
@@ -1,0 +1,53 @@
+from autofighter.effects import EffectManager
+from autofighter.stats import BUS
+from autofighter.stats import Stats
+from plugins.damage_types.dark import Dark
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_shadow_siphon_persistence_and_stat_gain():
+    dark = Dark()
+    actor = Stats(atk=100, defense=100, base_damage_type=dark)
+    ally = Stats()
+    actor.id = "actor"
+    ally.id = "ally"
+    actor.effect_manager = EffectManager(actor)
+    ally.effect_manager = EffectManager(ally)
+    allies = [actor, ally]
+
+    await dark.on_action(actor, allies, [])
+
+    for member in allies:
+        await member.effect_manager.tick()
+
+    assert actor.atk > 100
+    assert actor.defense > 100
+    first = actor.atk
+
+    for member in allies:
+        await member.effect_manager.tick()
+
+    for member in allies:
+        assert any(d.id == "shadow_siphon" for d in member.effect_manager.dots)
+
+    assert actor.atk > first
+
+
+@pytest.mark.asyncio
+async def test_shadow_siphon_clears_on_battle_end():
+    dark = Dark()
+    actor = Stats(base_damage_type=dark)
+    ally = Stats()
+    actor.id = "actor"
+    ally.id = "ally"
+    actor.effect_manager = EffectManager(actor)
+    ally.effect_manager = EffectManager(ally)
+    allies = [actor, ally]
+
+    await dark.on_action(actor, allies, [])
+    BUS.emit("battle_end", actor)
+
+    for member in allies:
+        assert "shadow_siphon" not in member.dots
+        assert all(d.id != "shadow_siphon" for d in member.effect_manager.dots)


### PR DESCRIPTION
## Summary
- add persistent Shadow Siphon DoT plugin
- Dark damage type applies Shadow Siphon to party and gains stats from drained HP
- emit battle start/end events and document new dark siphon mechanics

## Testing
- `uv run --active pytest tests/test_shadow_siphon.py`

------
https://chatgpt.com/codex/tasks/task_b_68a74512260c832cbb80bcc8354b94d6