### PR TITLE
[FEATURE] support multiple foes by pressure

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -32,7 +32,7 @@ from autofighter.rooms import BossRoom
 from autofighter.rooms import ChatRoom
 from autofighter.rooms import RestRoom
 from autofighter.rooms import ShopRoom
-from autofighter.rooms import _choose_foe
+from autofighter.rooms import _build_foes
 from autofighter.rooms import _scale_stats
 from autofighter.rooms import _serialize
 from autofighter.stats import Stats
@@ -764,7 +764,7 @@ def save_party(run_id: str, party: Party) -> None:
 async def _run_battle(
     run_id: str,
     room: BattleRoom,
-    foe: Stats,
+    foes: Stats | list[Stats],
     party: Party,
     data: dict[str, Any],
     state: dict[str, Any],
@@ -772,7 +772,7 @@ async def _run_battle(
     progress: Callable[[dict[str, Any]], Awaitable[None]],
 ) -> None:
     try:
-        result = await room.resolve(party, data, progress, foe)
+        result = await room.resolve(party, data, progress, foes)
         state["battle"] = False
         # If the party was defeated, immediately end the run and publish the final snapshot
         if result.get("result") == "defeat":
@@ -909,8 +909,9 @@ async def battle_room(run_id: str) -> tuple[str, int, dict[str, str]]:
     state["battle"] = True
     await asyncio.to_thread(save_map, run_id, state)
     room = BattleRoom(node)
-    foe = _choose_foe(party)
-    _scale_stats(foe, node, room.strength)
+    foes = _build_foes(node, party)
+    for f in foes:
+        _scale_stats(f, node, room.strength)
     combat_party = Party(
         members=[copy.deepcopy(m) for m in party.members],
         gold=party.gold,
@@ -921,7 +922,7 @@ async def battle_room(run_id: str) -> tuple[str, int, dict[str, str]]:
     battle_snapshots[run_id] = {
         "result": "battle",
         "party": [_serialize(m) for m in combat_party.members],
-        "foes": [_serialize(foe)],
+        "foes": [_serialize(f) for f in foes],
         "gold": party.gold,
         "relics": party.relics,
         "cards": party.cards,
@@ -937,7 +938,7 @@ async def battle_room(run_id: str) -> tuple[str, int, dict[str, str]]:
         battle_snapshots[run_id] = snapshot
 
     task = asyncio.create_task(
-        _run_battle(run_id, room, foe, party, data, state, rooms, progress)
+        _run_battle(run_id, room, foes, party, data, state, rooms, progress)
     )
     battle_tasks[run_id] = task
     app.logger.info(

--- a/backend/tests/test_battle_snapshot_consistency.py
+++ b/backend/tests/test_battle_snapshot_consistency.py
@@ -46,16 +46,15 @@ async def test_foe_element_stable_across_snapshots(app_with_db, monkeypatch):
 
     import autofighter.rooms as rooms_module
 
-    monkeypatch.setattr(app_module, "_choose_foe", choose_foe)
     monkeypatch.setattr(rooms_module, "_choose_foe", choose_foe)
     monkeypatch.setattr(app_module, "_scale_stats", lambda *args, **kwargs: None)
     monkeypatch.setattr(rooms_module, "_scale_stats", lambda *args, **kwargs: None)
 
     original_run_battle = app_module._run_battle
 
-    async def delayed_run_battle(run_id, room, foe, party, data, state, rooms, progress):
+    async def delayed_run_battle(run_id, room, foes, party, data, state, rooms, progress):
         await asyncio.sleep(0)
-        return await original_run_battle(run_id, room, foe, party, data, state, rooms, progress)
+        return await original_run_battle(run_id, room, foes, party, data, state, rooms, progress)
 
     monkeypatch.setattr(app_module, "_run_battle", delayed_run_battle)
 

--- a/backend/tests/test_pressure_scaling.py
+++ b/backend/tests/test_pressure_scaling.py
@@ -1,0 +1,55 @@
+import pytest
+
+from autofighter.mapgen import MapNode
+from autofighter.party import Party
+from autofighter.rooms import BattleRoom
+from autofighter.rooms import _build_foes
+from autofighter.stats import Stats
+
+
+@pytest.mark.parametrize(
+    "pressure,expected",
+    [(0, 1), (5, 2), (25, 6), (50, 10)],
+)
+def test_build_foes_pressure(pressure, expected) -> None:
+    node = MapNode(
+        room_id=0,
+        room_type="battle-normal",
+        floor=1,
+        index=1,
+        loop=1,
+        pressure=pressure,
+    )
+    player = Stats(hp=10, max_hp=10, atk=1, defense=1)
+    player.id = "p1"
+    party = Party(members=[player])
+    foes = _build_foes(node, party)
+    assert len(foes) == expected
+
+
+@pytest.mark.asyncio
+async def test_multi_foe_battle(monkeypatch) -> None:
+    node = MapNode(
+        room_id=0,
+        room_type="battle-normal",
+        floor=1,
+        index=1,
+        loop=1,
+        pressure=10,
+    )
+    room = BattleRoom(node)
+    player = Stats(hp=100, max_hp=100, atk=50, defense=1, mitigation=1.0)
+    player.id = "p1"
+    party = Party(members=[player])
+
+    def build(node, party):
+        foes = []
+        for i in range(3):
+            f = Stats(hp=10, max_hp=10, atk=1, defense=0)
+            f.id = f"f{i}"
+            foes.append(f)
+        return foes
+
+    monkeypatch.setattr("autofighter.rooms._build_foes", build)
+    result = await room.resolve(party, {})
+    assert len(result["foes"]) == 3


### PR DESCRIPTION
## Summary
- spawn multiple foes based on map pressure
- update battle logic for enemy selection and enrage across groups
- add tests for pressure-driven foe counts and multi-foe combat

## Testing
- `pytest backend/tests/test_pressure_scaling.py backend/tests/test_battle_snapshot_consistency.py`
- `pytest backend/tests` *(fails: KeyboardInterrupt while running full suite)*

------
https://chatgpt.com/codex/tasks/task_b_68a75b89cc74832c8105184473a1b6d1