### PR TITLE
Adjust foe mitigation and vitality scaling

### DIFF
--- a/.codex/implementation/player-foe-reference.md
+++ b/.codex/implementation/player-foe-reference.md
@@ -34,8 +34,10 @@ Characters marked as "random" roll one of the six elements when first loaded
 and reuse that element in future sessions.
 
 ## Foe Generation
-Foe plugins inherit from `FoeBase`, which mirrors `PlayerBase` stats. To keep
-encounters from stalling, foes regain health at one hundredth the player rate.
+Foe plugins inherit from `FoeBase`, which mirrors `PlayerBase` stats but begins
+with minimal mitigation and vitality (0.001 each) that grow by 0.0001 on
+level-up. To keep encounters from stalling, foes regain health at one hundredth
+the player rate.
 They are procedurally named by prefixing a randomly selected adjective plugin
 from `plugins/themedadj` to a player name. Adjective plugins are
 auto-discovered based on files in that directory, so adding a new adjective

--- a/README.md
+++ b/README.md
@@ -177,7 +177,8 @@ non-party player character scaled by floor, room, Pressure level, and loop
 count. Foes are procedurally named by prefixing a themed adjective plugin to a
 player name. Adjective plugins are auto-discovered from files in
 `plugins/themedadj`, allowing new adjectives to be added without modifying
-package code. Foes inherit from a dedicated `FoeBase` that mirrors player stats;
+package code. Foes inherit from a dedicated `FoeBase` that mirrors player stats
+but starts with negligible mitigation and vitality;
 the default `Slime` reduces them by 90% on spawn, while player-derived foes gain
 `FoeBase` behaviors like turn-based regeneration. The scene shows floating
 damage numbers and status icons and flashes

--- a/backend/plugins/foes/_base.py
+++ b/backend/plugins/foes/_base.py
@@ -32,12 +32,12 @@ class FoeBase(Stats):
     effect_hit_rate: float = 0.01
     base_damage_type: DamageTypeBase = field(default_factory=Generic)
 
-    mitigation: int = 100
+    mitigation: float = 0.001
     regain: int = 1
     dodge_odds: float = 0
     effect_resistance: float = 1.0
 
-    vitality: float = 1.0
+    vitality: float = 0.001
     action_points: int = 1
     damage_taken: int = 1
     damage_dealt: int = 1
@@ -61,3 +61,9 @@ class FoeBase(Stats):
         percent = (0.01 + bonus) / 100
         heal = int(self.max_hp * percent)
         await self.apply_healing(heal)
+
+    def _on_level_up(self) -> None:  # noqa: D401
+        """Apply base bonuses then boost mitigation and vitality."""
+        super()._on_level_up()
+        self.mitigation += 0.0001
+        self.vitality += 0.0001

--- a/backend/tests/test_foe_scaling.py
+++ b/backend/tests/test_foe_scaling.py
@@ -1,0 +1,22 @@
+import pytest
+
+from autofighter.stats import Stats
+from plugins.foes._base import FoeBase
+
+
+def test_level_up_increases_mitigation_and_vitality(monkeypatch):
+    foe = FoeBase()
+    base_mitigation = foe.mitigation
+    base_vitality = foe.vitality
+    called = False
+
+    def stub(self):
+        nonlocal called
+        called = True
+
+    monkeypatch.setattr(Stats, "_on_level_up", stub)
+    foe._on_level_up()
+    assert called
+    assert foe.mitigation == pytest.approx(base_mitigation + 0.0001)
+    assert foe.vitality == pytest.approx(base_vitality + 0.0001)
+


### PR DESCRIPTION
## Summary
- lower foe base mitigation and vitality and grant small increases on level-up
- document foe stat growth and add test to verify scaling

## Testing
- `uvx ruff check backend/plugins/foes/_base.py backend/tests/test_foe_scaling.py --exclude README.md --exclude .codex/implementation/player-foe-reference.md`
- `uv run pytest` *(fails: KeyboardInterrupt)*
- `uv run pytest tests/test_foe_scaling.py`


------
https://chatgpt.com/codex/tasks/task_b_68a7743ebf3c832caa9b20a368a29fab