### PR TITLE
feat: freeze battle view and reward popup

### DIFF
--- a/.codex/implementation/reward-overlay.md
+++ b/.codex/implementation/reward-overlay.md
@@ -1,8 +1,8 @@
 # Reward Overlay
 
-After a battle resolves, the backend returns a `loot` object summarizing gold and any reward options. `GameViewport.svelte` now always shows `RewardOverlay.svelte` after battles, passing along `card_choices`, `relic_choices`, and the gold gain. The overlay wraps its options in `MenuPanel` for consistent theming and loads art from `src/lib/assets` rather than the `.codex` downloads. Card rewards display a random gray background tinted to the card's star rank with the name overlaid at the top. Clicking a choice opens a status panel below with the card's description and a confirm button so players can verify their selection. Relic and item rewards reuse the same component and asset pipeline.
+After a battle resolves, the backend returns a `loot` object summarizing gold and any reward options. `GameViewport.svelte` keeps `BattleView` mounted and stops its polling loop so the last snapshot remains visible. A `PopupWindow` inside `OverlaySurface` then presents `RewardOverlay.svelte`, which receives the battle's `card_choices`, `relic_choices`, and gold gain. The reward popup loads art from `src/lib/assets` and displays card options with a gray background tinted to the card's star rank and the name overlaid at the top. Clicking a choice opens a status panel below with the card's description and a confirm button so players can verify their selection. Relic and item rewards reuse the same component and asset pipeline.
 
-Selecting a card posts to `/cards/<run_id>` via the `chooseCard` API helper once the player confirms, clearing `card_choices`. A disabled "Next Room" button is shown at the bottom of the overlay until all selections are resolved. When the player clicks it, the frontend calls `/run/<id>/next` to advance the map.
+Selecting a card posts to `/cards/<run_id>` via the `chooseCard` API helper once the player confirms, clearing `card_choices`. The "Next Room" button remains disabled until all selections are resolved. Clicking it dismisses the popup, unmounts `BattleView`, and calls `/run/<id>/next` to advance the map.
 
 ## Testing
 - `bun test frontend/tests/rewardoverlay.test.js`

--- a/frontend/src/lib/BattleView.svelte
+++ b/frontend/src/lib/BattleView.svelte
@@ -7,6 +7,7 @@
   export let party = [];
   export let enrage = { active: false, stacks: 0 };
   export let reducedMotion = false;
+  export let active = true;
   let foes = [];
   let timer;
   let initialLogged = false;
@@ -15,6 +16,7 @@
   $: pollDelay = 1000 / framerate;
   let bg = getRandomBackground();
   $: flashDuration = reducedMotion ? 20 : 10;
+  $: if (!active) clearTimeout(timer);
 
   // Dynamic sizing per side based on fighter counts
   $: partyCount = Array.isArray(party) ? party.length : 0;
@@ -183,6 +185,7 @@
   }
 
   async function fetchSnapshot() {
+    if (!active) return;
     const start = performance.now();
     dispatch('snapshot-start');
     try {
@@ -228,13 +231,15 @@
     } finally {
       const duration = performance.now() - start;
       dispatch('snapshot-end', { duration });
-      timer = setTimeout(fetchSnapshot, Math.max(0, pollDelay - duration));
+      if (active) {
+        timer = setTimeout(fetchSnapshot, Math.max(0, pollDelay - duration));
+      }
     }
   }
 
   onMount(() => {
     window.addEventListener('keydown', onKeydown);
-    fetchSnapshot();
+    if (active) fetchSnapshot();
   });
 
   onDestroy(() => {

--- a/frontend/src/lib/RewardOverlay.svelte
+++ b/frontend/src/lib/RewardOverlay.svelte
@@ -1,7 +1,6 @@
 <script>
   import { createEventDispatcher } from 'svelte';
   import { cardArt, getRewardArt, randomCardArt } from './rewardLoader.js';
-  import MenuPanel from './MenuPanel.svelte';
 
   const starColors = {
     1: '#808080',
@@ -63,11 +62,6 @@
     height: fit-content;
   }
 
-  .reward :global(.panel) {
-    width: fit-content;
-    height: fit-content;
-  }
-
   .choices {
     display: grid;
     grid-template-columns: repeat(3, 72px);
@@ -118,7 +112,6 @@
 </style>
 
 <div class="reward">
-<MenuPanel>
   {#if cards.length}
     <h3>Choose a Card</h3>
     <div class="choices">
@@ -179,5 +172,4 @@
   <div class="status">
     <button on:click={() => dispatch('next')} disabled={remaining > 0}>Next Room</button>
   </div>
-</MenuPanel>
 </div>

--- a/frontend/tests/battleview.test.js
+++ b/frontend/tests/battleview.test.js
@@ -62,8 +62,8 @@ describe('BattleView layout and polling', () => {
 
   test('uses backend element for foe portrait', () => {
     const content = readFileSync(join(import.meta.dir, '../src/lib/BattleView.svelte'), 'utf8');
-    expect(content).toContain('getElementIcon(foe.element)');
-    expect(content).toContain('getElementColor(foe.element)');
+    expect(content).toContain('getElementIcon(elementOf(foe))');
+    expect(content).toContain('getElementColor(elementOf(foe))');
   });
 
   test('polling respects framerate settings', async () => {


### PR DESCRIPTION
## Summary
- keep BattleView mounted and pause polling when combat ends
- show RewardOverlay as a PopupWindow over the frozen battle
- document reward popup flow and battle freeze behavior

## Testing
- [ ] Backend tests (failed: KeyboardInterrupt after partial run)
- [x] Frontend tests `bun test`


------
https://chatgpt.com/codex/tasks/task_b_68a868159438832ca156fbeb446bdee8