### PR TITLE
Add unified test runner script for backend and frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,12 +96,16 @@ required.
 
 ## Testing
 
-Run the test suite before submitting changes:
+Run the test suites before submitting changes with the helper script:
 
 ```bash
-cd backend
-uv run pytest
+./run-tests.sh
 ```
+
+The script runs each backend `pytest` module via `uv` and then executes the
+frontend `bun test` files. Each test is given a 15-second timeout, and all tests
+are run regardless of failures. The script prints a summary of any failing or
+timed-out tests and exits with the first non-zero status code encountered.
 
 ## Loot and Rare Drop Rate
 

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+status=0
+failed_tests=()
+timeout_tests=()
+ROOT_DIR=$(pwd)
+
+run_test() {
+  local cmd="$1"
+  local name="$2"
+
+  timeout 15 bash -c "$cmd"
+  local result=$?
+
+  if [ $result -eq 124 ]; then
+    timeout_tests+=("$name")
+    if [ $status -eq 0 ]; then
+      status=124
+    fi
+  elif [ $result -ne 0 ]; then
+    failed_tests+=("$name")
+    if [ $status -eq 0 ]; then
+      status=$result
+    fi
+  fi
+}
+
+# Backend tests
+cd backend
+for file in $(find tests -maxdepth 1 -name "test_*.py" -type f -printf "%f\n" | sort); do
+  echo "Running backend test: $file"
+  run_test "uv run pytest tests/$file" "backend tests/$file"
+done
+cd "$ROOT_DIR"
+
+# Frontend tests
+cd frontend
+for file in $(find tests -maxdepth 1 -name "*.test.js" -type f -printf "%f\n" | sort); do
+  echo "Running frontend test: $file"
+  run_test "bun test tests/$file" "frontend tests/$file"
+done
+cd "$ROOT_DIR"
+
+# Summary
+if [ ${#failed_tests[@]} -eq 0 ] && [ ${#timeout_tests[@]} -eq 0 ]; then
+  echo "All tests passed."
+else
+  if [ ${#failed_tests[@]} -ne 0 ]; then
+    echo "Failed tests:"
+    for t in "${failed_tests[@]}"; do
+      echo "  $t"
+    done
+  fi
+  if [ ${#timeout_tests[@]} -ne 0 ]; then
+    echo "Timed out (>15s) tests:"
+    for t in "${timeout_tests[@]}"; do
+      echo "  $t"
+    done
+  fi
+fi
+
+exit $status
+


### PR DESCRIPTION
## Summary
- add `run-tests.sh` to run backend and frontend tests sequentially with 15s timeouts
- document test script usage in `README.md`

## Testing
- `uv sync`
- `bun install`
- `./run-tests.sh` *(fails: backend tests/test_card_rewards.py, tests/test_player_editor.py, tests/test_shadow_siphon.py; frontend tests/battleview.test.js; timed out: backend tests/test_app.py, tests/test_damage_type_on_action.py, tests/test_enrage_stacking.py, tests/test_gacha.py, tests/test_rdr.py, tests/test_relic_rewards.py)*

------
https://chatgpt.com/codex/tasks/task_b_68a866efd9b4832caf58dbbd6f667c87