### PR TITLE
Add battle reward stats table

### DIFF
--- a/.codex/implementation/reward-overlay.md
+++ b/.codex/implementation/reward-overlay.md
@@ -2,6 +2,8 @@
 
 After a battle resolves, the backend returns a `loot` object summarizing gold and any reward options. `GameViewport.svelte` keeps `BattleView` mounted and stops its polling loop so the last snapshot remains visible. A `PopupWindow` inside `OverlaySurface` then presents `RewardOverlay.svelte`, which receives the battle's `card_choices`, `relic_choices`, and gold gain. The reward popup loads art from `src/lib/assets` and displays card options with a gray background tinted to the card's star rank and the name overlaid at the top. Clicking a choice opens a status panel below with the card's description and a confirm button so players can verify their selection. Relic and item rewards reuse the same component and asset pipeline.
 
+`RewardOverlay` also accepts a `partyStats` array derived from `_serialize`, rendering a right-hand table listing each party member and their `damage_dealt`. Placeholder columns reserve space for future metrics like damage taken or healing.
+
 Selecting a card posts to `/cards/<run_id>` via the `chooseCard` API helper once the player confirms, clearing `card_choices`. The "Next Room" button remains disabled until all selections are resolved. Clicking it dismisses the popup, unmounts `BattleView`, and calls `/run/<id>/next` to advance the map.
 
 ## Testing

--- a/.codex/instructions/battle-room.md
+++ b/.codex/instructions/battle-room.md
@@ -9,6 +9,7 @@ Describes the backend battle endpoint.
 - Exiting returns control to the previous room.
 - The top navigation bar remains visible during battles, with the home button replaced by a non-interactive battle icon.
 - The reward overlay centers on the battle viewport and sizes to a 1×3 card grid, expanding to 2×3 when six cards are offered.
+- After a battle, the overlay now includes a right-side stats column that lists each party member and their damage dealt.
 - Combat UI places the party in a resizable left column with stats beside each portrait and HoT/DoT markers below; foes mirror the layout on the right. Stats include HP, Attack, Defense, Mitigation, and Crit rate, and shared fallback art is used when portraits are missing. Duplicate HoT/DoT effects collapse into single icons that display stack counts in the bottom-right.
 - The frontend polls `roomAction(runId, 'battle', 'snapshot')` once per frame-rate tick to fetch full party and foe snapshots without overloading the CPU and only updates arrays when data differs to reduce re-renders.
 - Backend storage helpers like `load_party`, `load_map`, `save_party`, and `save_map` run via `asyncio.to_thread` so battle polling stays responsive and the event loop remains unblocked.

--- a/frontend/src/lib/GameViewport.svelte
+++ b/frontend/src/lib/GameViewport.svelte
@@ -412,6 +412,7 @@
                 cards={roomData.card_choices || []}
                 relics={roomData.relic_choices || []}
                 items={roomData.loot?.items || []}
+                partyStats={roomData.party || []}
                 on:select={(e) => dispatch('rewardSelect', e.detail)}
                 on:next={() => { roomData = null; dispatch('nextRoom'); }}
               />

--- a/frontend/src/lib/RewardOverlay.svelte
+++ b/frontend/src/lib/RewardOverlay.svelte
@@ -15,6 +15,7 @@
   export let relics = [];
   export let items = [];
   export let gold = 0;
+  export let partyStats = [];
 
   const dispatch = createEventDispatcher();
   const artMap = new Map();
@@ -56,8 +57,14 @@
 </script>
 
 <style>
+  .layout {
+    display: grid;
+    grid-template-columns: 1fr minmax(180px, 220px);
+    gap: 1rem;
+    align-items: flex-start;
+  }
+
   .reward {
-    margin: auto;
     width: fit-content;
     height: fit-content;
   }
@@ -109,67 +116,120 @@
     margin-top: 0.5rem;
     text-align: center;
   }
+
+  .stats {
+    background: var(--glass-bg);
+    box-shadow: var(--glass-shadow);
+    border: var(--glass-border);
+    backdrop-filter: var(--glass-filter);
+    padding: 0.5rem;
+    color: #fff;
+    font-size: 0.85rem;
+  }
+
+  .stats table {
+    width: 100%;
+    border-collapse: collapse;
+  }
+
+  .stats th,
+  .stats td {
+    padding: 0.25rem 0.5rem;
+    text-align: left;
+  }
+
+  .stats th {
+    border-bottom: 1px solid rgba(255,255,255,0.2);
+  }
+
+  .stats td {
+    border-bottom: 1px solid rgba(255,255,255,0.1);
+  }
 </style>
 
-<div class="reward">
-  {#if cards.length}
-    <h3>Choose a Card</h3>
-    <div class="choices">
-      {#each cards as card}
-        <button
-          class="choice"
-          on:click={() => show('card', card)}
-        >
-          <div
-            class="art"
-            style={`--star-color: ${starColors[card.stars] || starColors.fallback}`}
+<div class="layout">
+  <div class="reward">
+    {#if cards.length}
+      <h3>Choose a Card</h3>
+      <div class="choices">
+        {#each cards as card}
+          <button
+            class="choice"
+            on:click={() => show('card', card)}
           >
-            <img src={artFor(card)} alt={card.name} />
-            <div class="label">{card.name}</div>
-          </div>
-        </button>
-      {/each}
-    </div>
-  {/if}
-  {#if relics.length}
-    <h3>Choose a Relic</h3>
-    <div class="choices">
-      {#each relics as relic}
-        <button class="choice" on:click={() => show('relic', relic)}>
-          <div
-            class="art"
-            style={`--star-color: ${starColors[relic.stars] || starColors.fallback}`}
-          >
-            <img src={getRewardArt('relic', relic.id)} alt={relic.name} />
-            <div class="label">{relic.name}</div>
-          </div>
-        </button>
-      {/each}
-    </div>
-  {/if}
-  {#if items.length}
-    <h3>Drops</h3>
-    <div class="status">
-      <ul>
-        {#each items as item}
-          <li>{titleForItem(item)}</li>
+            <div
+              class="art"
+              style={`--star-color: ${starColors[card.stars] || starColors.fallback}`}
+            >
+              <img src={artFor(card)} alt={card.name} />
+              <div class="label">{card.name}</div>
+            </div>
+          </button>
         {/each}
-      </ul>
-    </div>
-  {/if}
-  {#if selected}
+      </div>
+    {/if}
+    {#if relics.length}
+      <h3>Choose a Relic</h3>
+      <div class="choices">
+        {#each relics as relic}
+          <button class="choice" on:click={() => show('relic', relic)}>
+            <div
+              class="art"
+              style={`--star-color: ${starColors[relic.stars] || starColors.fallback}`}
+            >
+              <img src={getRewardArt('relic', relic.id)} alt={relic.name} />
+              <div class="label">{relic.name}</div>
+            </div>
+          </button>
+        {/each}
+      </div>
+    {/if}
+    {#if items.length}
+      <h3>Drops</h3>
+      <div class="status">
+        <ul>
+          {#each items as item}
+            <li>{titleForItem(item)}</li>
+          {/each}
+        </ul>
+      </div>
+    {/if}
+    {#if selected}
+      <div class="status">
+        <strong>{selected.data.name}</strong>
+        {#if selected.type === 'card'}
+          <p>{selected.data.about}</p>
+        {/if}
+        <button on:click={confirm}>Confirm</button>
+      </div>
+    {/if}
+    {#if gold}
+      <div class="status">Gold +{gold}</div>
+    {/if}
     <div class="status">
-      <strong>{selected.data.name}</strong>
-      {#if selected.type === 'card'}
-        <p>{selected.data.about}</p>
-      {/if}
-      <button on:click={confirm}>Confirm</button>
+      <button on:click={() => dispatch('next')} disabled={remaining > 0}>Next Room</button>
     </div>
-  {/if}
-  {#if gold}
-    <div class="status">Gold +{gold}</div>
-  {/if}
-  <div class="status">
-    <button on:click={() => dispatch('next')} disabled={remaining > 0}>Next Room</button>
+  </div>
+  <div class="stats">
+    <table>
+      <thead>
+        <tr>
+          <th>Member</th>
+          <th>Dmg Dealt</th>
+          <th>Dmg Taken</th>
+          <th>Healing</th>
+        </tr>
+      </thead>
+      <tbody>
+        {#each partyStats as member}
+          <tr>
+            <td>{member.name}</td>
+            <td>{member.damage_dealt ?? 0}</td>
+            <td>-</td>
+            <td>-</td>
+          </tr>
+        {/each}
+      </tbody>
+    </table>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- pass serialized party data to RewardOverlay via new `partyStats` prop
- display two-column reward overlay with right-hand party damage stats
- document battle reward stats table in battle room and overlay docs

## Testing
- `./run-tests.sh` *(fails: tests/test_card_rewards.py, tests/test_player_editor.py, tests/test_relic_rewards.py, tests/test_shadow_siphon.py, frontend/tests/battleview.test.js; timed out: tests/test_app.py, tests/test_damage_type_on_action.py, tests/test_enrage_stacking.py, tests/test_gacha.py, tests/test_rdr.py)*

------
https://chatgpt.com/codex/tasks/task_b_68a86c8ef63c832cb7211b83c169a92a