### PR TITLE
[PATCH] Use Aftertaste effect in Pocket Manual

### DIFF
--- a/backend/plugins/relics/pocket_manual.py
+++ b/backend/plugins/relics/pocket_manual.py
@@ -1,8 +1,11 @@
+import asyncio
+
 from dataclasses import dataclass
 from dataclasses import field
 
-from plugins.relics._base import RelicBase
 from autofighter.stats import BUS
+from plugins.relics._base import RelicBase
+from plugins.effects.aftertaste import Aftertaste
 
 
 @dataclass
@@ -24,7 +27,12 @@ class PocketManual(RelicBase):
             pid = id(attacker)
             counts[pid] = counts.get(pid, 0) + 1
             if counts[pid] % 10 == 0:
-                target.hp -= int(amount * 0.03)
+                base = int(amount * 0.03)
+                if base > 0:
+                    effect = Aftertaste(base_pot=base)
+                    asyncio.get_event_loop().create_task(
+                        effect.apply(attacker, target)
+                    )
 
         BUS.subscribe("hit_landed", _hit)
 

--- a/backend/tests/test_relics.py
+++ b/backend/tests/test_relics.py
@@ -1,11 +1,14 @@
+import asyncio
+
 from math import isclose
 
+import plugins.event_bus as event_bus_module
+
 from autofighter.party import Party
+from autofighter.stats import BUS
 from autofighter.relics import apply_relics
 from autofighter.relics import award_relic
-from autofighter.stats import BUS
 from plugins.players._base import PlayerBase
-import plugins.event_bus as event_bus_module
 
 
 def test_award_relics_stack():
@@ -257,11 +260,15 @@ def test_pocket_manual_tenth_hit():
     party.members.append(a)
     award_relic(party, "pocket_manual")
     apply_relics(party)
-    for i in range(9):
-        BUS.emit("hit_landed", a, b, 10)
-    assert b.hp == 100 - 0
-    BUS.emit("hit_landed", a, b, 10)
-    assert b.hp == 100 - int(10 * 0.03)
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    for _ in range(9):
+        BUS.emit("hit_landed", a, b, 100)
+        loop.run_until_complete(asyncio.sleep(0))
+    assert b.hp == 100
+    BUS.emit("hit_landed", a, b, 100)
+    loop.run_until_complete(asyncio.sleep(0))
+    assert b.hp == 99
 
 
 def test_arcane_flask_shields():


### PR DESCRIPTION
## Summary
- trigger Aftertaste effect on every tenth hit for the Pocket Manual relic
- cover Pocket Manual's effect through async test

## Testing
- `./run-tests.sh` *(fails: backend tests/test_card_rewards.py, backend tests/test_enrage_stacking.py, backend tests/test_loot_summary.py, backend tests/test_party_persistence.py, backend tests/test_player_editor.py, backend tests/test_pressure_scaling.py, backend tests/test_random_player_foes.py, backend tests/test_relics.py, backend tests/test_shadow_siphon.py, frontend tests/assets.test.js; timed out: backend tests/test_app.py, backend tests/test_damage_type_on_action.py, backend tests/test_gacha.py, backend tests/test_rdr.py, backend tests/test_relic_rewards.py)*


------
https://chatgpt.com/codex/tasks/task_b_68a8a3101bbc832ca1230d6a62514de5