### PR TITLE
[REFACTOR] use CriticalBoost for Lucky Button

### DIFF
--- a/backend/plugins/relics/lucky_button.py
+++ b/backend/plugins/relics/lucky_button.py
@@ -4,46 +4,54 @@ from dataclasses import field
 from plugins.relics._base import RelicBase
 from autofighter.stats import BUS
 from plugins.players._base import PlayerBase
+from plugins.effects.critical_boost import CriticalBoost
 
 
 @dataclass
 class LuckyButton(RelicBase):
-    """+3% Crit Rate; missed crits add +3% Crit Rate next turn."""
+    """+3% Crit Rate; missed crits grant Critical Boost next turn."""
 
     id: str = "lucky_button"
     name: str = "Lucky Button"
     stars: int = 1
     effects: dict[str, float] = field(default_factory=lambda: {"crit_rate": 0.03})
-    about: str = "+3% Crit Rate; missed crits add +3% Crit Rate next turn."
+    about: str = "+3% Crit Rate; missed crits grant Critical Boost next turn."
 
     def apply(self, party) -> None:
         super().apply(party)
 
-        pending: dict[int, float] = {}
-        active: dict[int, tuple[PlayerBase, float]] = {}
+        pending: dict[int, int] = {}
+        active: dict[int, tuple[PlayerBase, CriticalBoost]] = {}
 
         def _crit_missed(attacker, target) -> None:
             pid = id(attacker)
-            pending[pid] = pending.get(pid, 0) + 0.03
+            pending[pid] = pending.get(pid, 0) + 1
 
         def _turn_start() -> None:
-            for pid, bonus in list(pending.items()):
+            for pid, stacks in list(pending.items()):
                 member = next((m for m in party.members if id(m) == pid), None)
                 if member is None:
                     continue
-                member.crit_rate += bonus
-                active[pid] = (member, bonus)
+                effect = active.get(pid)
+                if effect is None:
+                    effect = CriticalBoost()
+                    active[pid] = (member, effect)
+                for _ in range(stacks):
+                    effect.apply(member)
             pending.clear()
 
         def _turn_end() -> None:
-            for pid, (member, bonus) in list(active.items()):
-                member.crit_rate -= bonus
-            active.clear()
+            for pid, (member, effect) in list(active.items()):
+                effect._on_damage_taken(member)
+                del active[pid]
 
         BUS.subscribe("crit_missed", _crit_missed)
-        BUS.subscribe("turn_start", lambda: _turn_start())
-        BUS.subscribe("turn_end", lambda: _turn_end())
+        BUS.subscribe("turn_start", _turn_start)
+        BUS.subscribe("turn_end", _turn_end)
 
     def describe(self, stacks: int) -> str:
         rate = 3 * stacks
-        return f"+{rate}% Crit Rate; missed crits add +{rate}% Crit Rate next turn."
+        return (
+            f"+{rate}% Crit Rate; missed crits grant {stacks} "
+            f"Critical Boost stack{'s' if stacks != 1 else ''} next turn."
+        )

--- a/backend/tests/test_relics.py
+++ b/backend/tests/test_relics.py
@@ -210,14 +210,17 @@ def test_lucky_button_missed_crit():
     party = Party()
     a = PlayerBase()
     a.crit_rate = 0.1
+    a.crit_damage = 2.0
     party.members.append(a)
     award_relic(party, "lucky_button")
     apply_relics(party)
     BUS.emit("crit_missed", a, None)
     BUS.emit("turn_start")
-    assert isclose(a.crit_rate, 0.1 * 1.03 + 0.03, rel_tol=1e-4)
+    assert isclose(a.crit_rate, 0.1 * 1.03 + 0.005, rel_tol=1e-4)
+    assert isclose(a.crit_damage, 2.0 + 0.05, rel_tol=1e-4)
     BUS.emit("turn_end")
     assert isclose(a.crit_rate, 0.1 * 1.03, rel_tol=1e-4)
+    assert isclose(a.crit_damage, 2.0, rel_tol=1e-4)
 
 
 def test_old_coin_gold_and_discount():


### PR DESCRIPTION
## Summary
- apply CriticalBoost effect when Lucky Button users miss critical hits
- reset CriticalBoost stacks at turn end and improve relic description
- test Lucky Button to verify crit rate and damage bonuses

## Testing
- `uv run pytest tests/test_relics.py::test_lucky_button_missed_crit -q`
- `uvx ruff check .`
- `./run-tests.sh` *(failed: test_card_rewards.py::test_battle_offers_choices_and_applies_effect, test_enrage_stacking.py::test_enrage_stacks, test_loot_summary.py, test_party_persistence.py, test_player_editor.py::test_player_editor_snapshot_during_run, test_pressure_scaling.py::test_build_foes_pressure[50-10], test_random_player_foes.py::test_random_player_foes, test_rdr.py [incomplete])*

------
https://chatgpt.com/codex/tasks/task_b_68a8a32785a4832ca481a5aab4ccf055