### PR TITLE
[FIX] Instantiate damage types before effect ticking

### DIFF
--- a/backend/tests/test_choose_foe_damage_type.py
+++ b/backend/tests/test_choose_foe_damage_type.py
@@ -1,0 +1,17 @@
+import sys
+import random
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from autofighter.party import Party
+from plugins.players import Player
+from autofighter.rooms import _choose_foe
+from plugins.damage_types._base import DamageTypeBase
+
+
+def test_choose_foe_instantiates_damage_type() -> None:
+    random.seed(0)
+    party = Party(members=[Player()])
+    foe = _choose_foe(party)
+    assert isinstance(foe.damage_type, DamageTypeBase)


### PR DESCRIPTION
## Summary
- ensure foe damage types are converted to plugin instances when chosen
- instantiate player and foe damage types before effect ticking
- add test covering foe damage type instantiation

## Testing
- `uv run ruff check backend`
- `./run-tests.sh` *(fails: backend tests/test_card_rewards.py, backend tests/test_loot_summary.py, backend tests/test_party_persistence.py, backend tests/test_player_editor.py, backend tests/test_pressure_scaling.py, backend tests/test_random_player_foes.py, backend tests/test_relics.py, backend tests/test_shadow_siphon.py, frontend tests/assets.test.js; timed out: backend tests/test_app.py, backend tests/test_damage_type_on_action.py, backend tests/test_enrage_stacking.py, backend tests/test_gacha.py, backend tests/test_rdr.py, backend tests/test_relic_rewards.py)*
- `uv run pytest backend/tests/test_choose_foe_damage_type.py`


------
https://chatgpt.com/codex/tasks/task_b_68a8a4584990832cb2f765328e73851d