### PR TITLE
Use Aftertaste in Frost Sigil relic

### DIFF
--- a/backend/plugins/relics/frost_sigil.py
+++ b/backend/plugins/relics/frost_sigil.py
@@ -1,28 +1,39 @@
+import asyncio
+
 from dataclasses import dataclass
 from dataclasses import field
 
-from plugins.relics._base import RelicBase
 from autofighter.stats import BUS
+from plugins.effects.aftertaste import Aftertaste
+from plugins.relics._base import RelicBase
 
 
 @dataclass
 class FrostSigil(RelicBase):
-    """Hits apply chill dealing 5% ATK as Aftertaste per stack."""
+    """Hits apply chill dealing 5% ATK as Aftertaste; each stack adds a hit."""
 
     id: str = "frost_sigil"
     name: str = "Frost Sigil"
     stars: int = 2
     effects: dict[str, float] = field(default_factory=dict)
-    about: str = "Hits apply chill dealing 5% ATK as Aftertaste per stack."
+    about: str = "Hits apply chill dealing 5% ATK as Aftertaste; each stack adds a hit."
 
     def apply(self, party) -> None:
         super().apply(party)
 
-        def _hit(attacker, target, amount) -> None:
-            target.hp -= int(attacker.atk * 0.05)
+        state = getattr(party, "_frost_sigil_state", None)
+        if state is None:
+            party._frost_sigil_state = True
 
-        BUS.subscribe("hit_landed", _hit)
+            def _hit(attacker, target, amount) -> None:
+                stacks = party.relics.count(self.id)
+                dmg = int(attacker.atk * 0.05)
+                asyncio.create_task(
+                    Aftertaste(base_pot=dmg, hits=stacks).apply(attacker, target)
+                )
+
+            BUS.subscribe("hit_landed", _hit)
 
     def describe(self, stacks: int) -> str:
-        pct = 5 * stacks
-        return f"Hits apply chill dealing {pct}% ATK as Aftertaste."
+        hit_word = "hit" if stacks == 1 else "hits"
+        return f"Hits apply chill dealing 5% ATK as Aftertaste {stacks} {hit_word}."

--- a/backend/tests/test_relics.py
+++ b/backend/tests/test_relics.py
@@ -1,11 +1,17 @@
-from math import isclose
+import asyncio
 
-from autofighter.party import Party
-from autofighter.relics import apply_relics
-from autofighter.relics import award_relic
-from autofighter.stats import BUS
-from plugins.players._base import PlayerBase
+import pytest
+
 import plugins.event_bus as event_bus_module
+
+from math import isclose
+from autofighter.party import Party
+from autofighter.stats import BUS
+from autofighter.stats import Stats
+from autofighter.relics import award_relic
+from autofighter.relics import apply_relics
+from plugins.players._base import PlayerBase
+from plugins.effects.aftertaste import Aftertaste
 
 
 def test_award_relics_stack():
@@ -295,18 +301,57 @@ def test_echo_bell_repeats_first_action():
     assert b.hp == 100 - 20 - int(20 * 0.15) - 20
 
 
-def test_frost_sigil_applies_chill():
+@pytest.mark.asyncio
+async def test_frost_sigil_applies_chill(monkeypatch):
     event_bus_module.bus._subs.clear()
     party = Party()
     a = PlayerBase()
     b = PlayerBase()
-    b.hp = 100
+    b.hp = b.max_hp = 100
     a.atk = 100
     party.members.append(a)
     award_relic(party, "frost_sigil")
     apply_relics(party)
+
+    monkeypatch.setattr(Aftertaste, "rolls", lambda self: [self.base_pot] * self.hits)
+
+    async def fake_apply_damage(self, amount, attacker=None):
+        self.hp -= amount
+        return amount
+
+    monkeypatch.setattr(Stats, "apply_damage", fake_apply_damage, raising=False)
+
     BUS.emit("hit_landed", a, b, 10)
+    await asyncio.sleep(0)
+
     assert b.hp == 100 - int(100 * 0.05)
+
+
+@pytest.mark.asyncio
+async def test_frost_sigil_stacks(monkeypatch):
+    event_bus_module.bus._subs.clear()
+    party = Party()
+    a = PlayerBase()
+    b = PlayerBase()
+    b.hp = b.max_hp = 100
+    a.atk = 100
+    party.members.append(a)
+    award_relic(party, "frost_sigil")
+    award_relic(party, "frost_sigil")
+    apply_relics(party)
+
+    monkeypatch.setattr(Aftertaste, "rolls", lambda self: [self.base_pot] * self.hits)
+
+    async def fake_apply_damage(self, amount, attacker=None):
+        self.hp -= amount
+        return amount
+
+    monkeypatch.setattr(Stats, "apply_damage", fake_apply_damage, raising=False)
+
+    BUS.emit("hit_landed", a, b, 10)
+    await asyncio.sleep(0)
+
+    assert b.hp == 100 - int(100 * 0.05) * 2
 
 
 def test_killer_instinct_grants_extra_turn():


### PR DESCRIPTION
## Summary
- replace Frost Sigil’s damage with Aftertaste hits that scale with stack count
- cover Frost Sigil stacking with an async test

## Testing
- [x] Backend tests (`uv run pytest tests/test_relics.py::test_frost_sigil_applies_chill tests/test_relics.py::test_frost_sigil_stacks -vv`)
- [ ] Frontend tests
- [x] Linting (`uv run ruff check plugins/relics/frost_sigil.py ../backend/tests/test_relics.py`)
- [ ] Doc sync updates (README and `.codex/implementation` docs; link tasks below)


------
https://chatgpt.com/codex/tasks/task_b_68a8a3037dec832c96cedc97fd3a032d