### PR TITLE
[REFACTOR] split party picker into subcomponents

### DIFF
--- a/.codex/implementation/party-picker.md
+++ b/.codex/implementation/party-picker.md
@@ -2,24 +2,19 @@
 
 The Svelte `PartyPicker` component lets players choose up to four allies before a run. The shared `assetLoader` picks a random background from `frontend/src/lib/assets/backgrounds`, provides portraits from `assets/characters` with fallbacks, and supplies damage type icons and colors via `getElementIcon` and `getElementColor`.
 
-The roster only shows owned characters plus the player's avatar, which is pinned to the top and preselected. Any characters removed by a data wipe are filtered from both the roster and the current selection. Entries render one per row with a small portrait, name, and element icon. Each row's outline and icon are tinted with `getElementColor` so damage types are visible at a glance. Clicking a row previews the character without toggling party membership. The stats panel provides an **Add to party** / **Remove from party** control.
+`PartyPicker` now composes three focused child components:
 
-The layout uses percentage-based columns so the roster, preview, and stats
-panels all shrink with the viewport. Content is wrapped in `MenuPanel`,
-which sizes itself just under the overlay surface to avoid a surrounding
-scrollbar. Preview portraits scale without a minimum size so they remain
-visible on small screens.
+- **`PartyRoster`** – lists owned characters and handles selection. Rows tint the outline and element icon with `getElementColor` for quick damage-type recognition. Selection uses two-way binding on `previewId` so the parent can preview or modify the party.
+- **`PlayerPreview`** – shows a large portrait of the currently selected character or a placeholder message when none is chosen.
+- **`StatTabs`** – renders a tabbed stats panel with Core, Offense, and Defense groups and exposes a **Add to party** / **Remove from party** toggle via a `toggle` event.
 
-Player stats are grouped into Core, Offense, and Defense tabs. The Core tab
-lists HP, EXP, Vitality, and Regain. The Defense tab begins with DEF
-followed by Mitigation, Dodge Odds, and Effect Resist.
+The layout uses percentage-based columns so the roster, preview, and stats panels all shrink with the viewport. Content is wrapped in `MenuPanel`, which sizes itself just under the overlay surface to avoid a surrounding scrollbar. Preview portraits scale without a minimum size so they remain visible on small screens.
 
 `PartyPicker` exposes the `selected` array as a bound prop so parents can reactively read the lineup. When launched from the Run button it opens as a modal that requires an explicit **Start Run** confirmation before proceeding.
 
 `startRun` in `frontend/src/lib/api.js` posts the chosen party and optional player damage type to the Quart backend's `/run/start` endpoint, which validates ownership and returns run data with passive names.
 
-Upon success, the parent page stores the `run_id` and initial map and immediately
-switches to the map view so the run can begin.
+Upon success, the parent page stores the `run_id` and initial map and immediately switches to the map view so the run can begin.
 
 The confirmation footer wraps **Start Run** and **Cancel** in a stained-glass row so these buttons match the rest of the interface.
 

--- a/frontend/src/lib/PartyPicker.svelte
+++ b/frontend/src/lib/PartyPicker.svelte
@@ -1,20 +1,18 @@
 <script>
   import { onMount } from 'svelte';
   import { getPlayers } from './api.js';
-  import { getCharacterImage, getHourlyBackground, getRandomFallback, getElementIcon, getElementColor } from './assetLoader.js';
+  import { getCharacterImage, getHourlyBackground, getRandomFallback } from './assetLoader.js';
   import MenuPanel from './MenuPanel.svelte';
+  import PartyRoster from './PartyRoster.svelte';
+  import PlayerPreview from './PlayerPreview.svelte';
+  import StatTabs from './StatTabs.svelte';
 
   let background = '';
-
   let roster = [];
-  let error = '';
 
   export let selected = [];
   export let compact = false;
   let previewId;
-
-  let activeTab = 'Core';
-  const statTabs = ['Core', 'Offense', 'Defense'];
 
   onMount(async () => {
     background = getHourlyBackground();
@@ -46,407 +44,40 @@
         previewId = selected[0] ?? player.id;
       }
     } catch (e) {
-      error = 'Unable to load roster. Is the backend running on 59002?';
+      console.error('Unable to load roster. Is the backend running on 59002?');
     }
   });
 
-  function select(id) {
-    const char = roster.find(c => c.id === id);
-    if (char) {
-      previewId = id;
-    }
-  }
-
-  function toggleMember() {
-    if (!previewId) return;
-    if (selected.includes(previewId)) {
-      selected = selected.filter(c => c !== previewId);
+  function toggleMember(id) {
+    if (!id) return;
+    if (selected.includes(id)) {
+      selected = selected.filter((c) => c !== id);
     } else if (selected.length < 4) {
-      selected = [...selected, previewId];
+      selected = [...selected, id];
     }
   }
-
 </script>
 
-<style>
-  .panel {
-    border: 2px solid #fff;
-    padding: 1rem;
-    background: #000;
-    background-size: cover;
-    display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
-    width: min(90vw, 480px);
-    max-height: 80vh;
-  }
-  .full {
-  display: grid;
-  grid-template-columns: minmax(8rem, 22%) 1fr minmax(12rem, 26%);
-  width: 100%;
-  height: 96%;
-  max-width: 100%;
-  max-height: 98%;
-  /* allow internal scrolling instead of clipping when content grows */
-  
-  }
-  .panel.compact {
-    width: 100%;
-    max-width: none;
-    background: #0a0a0a;
-    background-image: none !important;
-    border-color: #555;
-    padding: 0.5rem;
-    max-height: 200px;
-  }
-  .roster {
-    overflow-y: auto;
-    mask-image: linear-gradient(to bottom, transparent, black 5%, black 95%, transparent);
-    -webkit-mask-image: linear-gradient(to bottom, transparent, black 5%, black 95%, transparent);
-    display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
-    padding: 0.5rem 0;
-    height: 98%;
-    gap: 0.75rem;
-    background: rgba(0,0,0,0.7);
-    color: #fff;
-    padding: 0.5rem 0.75rem;
-    width: 100%;
-    justify-content: flex-start;
-    transition: all 0.2s ease;
-    backdrop-filter: blur(2px);
-  }
-  .char-btn:hover {
-    border-color: #888;
-    background: rgba(20,20,20,0.8);
-    transform: translateY(-1px);
-    box-shadow: 0 4px 12px rgba(0,0,0,0.3);
-  }
-  .panel.compact .char-btn {
-    background: transparent;
-    border: none;
-    padding: 0;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-  }
-  .char-btn img {
-    width: 40px;
-    height: 40px;
-    border-radius: 6px;
-    border: 2px solid #333;
-    object-fit: cover;
-    box-shadow: 0 2px 8px rgba(0,0,0,0.4);
-  }
-  .char-btn.selected img {
-    border-color: #000;
-    box-shadow: 0 2px 12px rgba(0,0,0,0.6);
-  }
-  .panel.compact .char-btn img { 
-    width: 24px; 
-    height: 24px;
-    border-radius: 4px;
-    border-width: 1px;
-  }
-  :global(.elem) { width: 18px; height: 18px; opacity: 0.85; }
-  .preview {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 1rem;
-    width: 100%;
-    height: 100%;
-    box-sizing: border-box;
-    min-width: 0;
-    min-height: 0;
-  }
-  .preview img {
-    width: auto;
-    height: auto;
-    max-width: 100%;
-    max-height: 100%;
-    object-fit: contain;
-    border: 3px solid #555;
-    background: #222;
-    border-radius: 12px;
-    box-shadow: 0 8px 24px rgba(0,0,0,0.5);
-    display: block;
-    margin: 0 auto;
-  }
-  /* New stats panel styling */
-  .stats-panel {
-    flex: 1;
-    width: 350px;
-    background: rgba(0,0,0,0.25);
-    border-left: 2px solid #444;
-    padding: 1rem;
-    display: flex;
-    flex-direction: column;
-    gap: 1rem;
-    box-sizing: border-box;
-    border-radius: 8px;
-  }
-  .stats-header {
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
-    border-bottom: 1px solid rgba(255,255,255,0.2);
-    padding-bottom: 0.5rem;
-  }
-  .char-name {
-    font-size: 1.2rem;
-    color: #fff;
-    flex: 1;
-  }
-  .char-level {
-    font-size: 1rem;
-    color: #ccc;
-  }
-  .type-icon {
-    width: 24px;
-    height: 24px;
-  }
-  .stats-list {
-    display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
-  }
-  .stats-list div {
-    display: flex;
-    justify-content: space-between;
-    color: #ddd;
-  }
-  .stats-placeholder {
-    flex: 1;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    color: #888;
-    font-style: italic;
-  }
-  .stats-confirm {
-  display: flex;
-  justify-content: flex-end;
-  align-items: center;
-  min-height: 32px;
-  padding: 0.15rem 0;
-  margin-top: 0.25rem;
-  }
-  button.confirm {
-  border: 1.5px solid #fff;
-  background: transparent;
-  color: #fff;
-  padding: 0.12rem 0.4rem;
-  align-self: flex-end;
-  font-size: 0.95rem;
-  min-height: 28px;
-  border-radius: 6px;
-  }
-  .roster-list {
-    display: flex;
-    flex-direction: column;
-    gap: 0.4rem;
-    padding: 0.4rem;
-    height: 100%;
-    overflow-y: auto;
-    border-right: 2px solid #444;
-    border-left: 2px solid #444;
-    min-width: 0;
-  }
-  .char-row {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    padding: 0.25rem 0.4rem;
-    background: rgba(0,0,0,0.6);
-    border: 2px solid transparent;
-    border-radius: 6px;
-    cursor: pointer;
-    transition: background 0.2s, box-shadow 0.2s;
-  }
-  .char-row:hover {
-    background: rgba(20,20,20,0.8);
-  }
-  .char-row.selected {
-    border-color: #ffd700;
-    box-shadow: 0 0 8px rgba(255,215,0,0.5);
-  }
-  .row-img {
-    width: 40px;
-    height: 40px;
-    object-fit: cover;
-    border-radius: 4px;
-    border: 1px solid #222;
-    flex-shrink: 0;
-  }
-  .row-name {
-    flex: 1;
-    text-align: left;
-    color: #fff;
-    font-size: 0.9rem;
-  }
-  .row-type {
-    width: 20px;
-    height: 20px;
-    flex-shrink: 0;
-  }
-  .stats-tabs {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.5rem;
-    margin-bottom: 1rem;
-  }
-  .tab-btn {
-    background: rgba(255,255,255,0.1);
-    color: #ddd;
-    padding: 0.5rem 1rem;
-    border: none;
-    border-radius: 4px;
-    cursor: pointer;
-    transition: background 0.2s;
-  }
-  .tab-btn.active {
-    background: rgba(255,255,255,0.3);
-    color: #fff;
-  }
-  /* Party compact icons */
-  .party-icon {
-    width: 36px;
-    height: 36px;
-    border-radius: 50%;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    background: #000;
-    border: 2px solid currentColor; 
-    color: currentColor; 
-  }
-  /* Compact mode: small photo thumbnails in side panel */
-  .roster.list.compact {
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-    gap: 0.25rem;
-    padding: 0.25rem;
-    background: transparent;
-    border: none;
-    min-height: 32px;
-    height: auto;
-  }
-  .roster.list.compact .char-btn {
-    border: none;
-    background: transparent;
-    padding: 0;
-    flex-shrink: 0;
-  }
-  .roster.list.compact .char-btn img {
-    width: 28px;
-    height: 28px;
-    border-radius: 4px;
-    object-fit: cover;
-    border: 1px solid #fff;
-  }
-</style>
-
-  {#if compact}
-  <!-- compact mode: small portrait thumbnails for party side menu -->
-  <div class="roster list compact" data-testid="roster">
-    {#each roster.filter(c => selected.includes(c.id)) as char}
-      <button
-        data-testid={`choice-${char.id}`}
-        class="char-btn"
-        on:click={() => select(char.id)}>
-        <img src={char.img} alt={char.name} class="compact-img" />
-      </button>
-    {/each}
-  </div>
+{#if compact}
+  <PartyRoster {roster} {selected} bind:previewId {compact} />
 {:else}
-  <MenuPanel>
-  <div class="full" data-testid="party-picker">
-    <!-- Left: Roster list -->
-    <div class="roster-list">
-      {#each roster as char}
-        <button
-          type="button"
-          data-testid={`choice-${char.id}`}
-          class="char-row"
-          class:selected={selected.includes(char.id)}
-          on:click={() => select(char.id)}
-          style={`border-color: ${getElementColor(char.element)}`}>
-          <img src={char.img} alt={char.name} class="row-img" />
-          <span class="row-name">{char.name}</span>
-          <svelte:component
-            this={getElementIcon(char.element)}
-            class="row-type"
-            style={`color: ${getElementColor(char.element)}`}
-            aria-hidden="true" />
-        </button>
-      {/each}
+  <MenuPanel style={`background-image: url(${background}); background-size: cover;`}>
+    <div class="full" data-testid="party-picker">
+      <PartyRoster {roster} {selected} bind:previewId />
+      <PlayerPreview {roster} {previewId} />
+      <StatTabs {roster} {previewId} {selected} on:toggle={(e) => toggleMember(e.detail)} />
     </div>
-
-    <!-- Center: Portrait preview of selected -->
-    <div class="preview">
-      {#if previewId}
-        {#each roster.filter(r => r.id === previewId) as sel}
-          <img src={sel.img} alt={sel.name} />
-        {/each}
-      {:else}
-        <div class="placeholder">Select up to 4 allies</div>
-      {/if}
-    </div>
-
-    <!-- Right: Character Stats -->
-    <div class="stats-panel" data-testid="stats-panel">
-      <!-- Tab buttons for stats categories -->
-      <div class="stats-tabs">
-        {#each statTabs as tab}
-          <button class="tab-btn" class:active={activeTab === tab} on:click={() => activeTab = tab}>
-            {tab}
-          </button>
-        {/each}
-      </div>
-      {#if previewId}
-        {#each roster.filter(r => r.id === previewId) as sel}
-          <div class="stats-header">
-            <span class="char-name">{sel.name}</span>
-            <span class="char-level">Lv {sel.stats.level}</span>
-            <svelte:component
-              this={getElementIcon(sel.element)}
-              class="type-icon"
-              style={`color: ${getElementColor(sel.element)}`}
-              aria-hidden="true" />
-          </div>
-          <div class="stats-list">
-            {#if activeTab === 'Core'}
-              <div><span>HP</span><span>{sel.stats.hp ?? '-'}</span></div>
-              <div><span>EXP</span><span>{sel.stats.exp ?? sel.stats.xp ?? '-'}</span></div>
-              <div><span>Vitality</span><span>{sel.stats.vitality ?? sel.stats.vita ?? '-'}</span></div>
-              <div><span>Regain</span><span>{sel.stats.regain ?? sel.stats.regain_rate ?? '-'}</span></div>
-            {:else if activeTab === 'Offense'}
-              <div><span>ATK</span><span>{sel.stats.atk ?? '-'}</span></div>
-              <div><span>CRIT Rate</span><span>{(sel.stats.critRate ?? sel.stats.crit_rate ?? 0) + '%'}</span></div>
-              <div><span>CRIT DMG</span><span>{(sel.stats.critDamage ?? sel.stats.crit_dmg ?? 0) + '%'}</span></div>
-              <div><span>Effect Hit Rate</span><span>{(sel.stats.effectHit ?? sel.stats.effect_hit ?? 0) + '%'}</span></div>
-            {:else if activeTab === 'Defense'}
-              <div><span>DEF</span><span>{sel.stats.defense ?? '-'}</span></div>
-              <div><span>Mitigation</span><span>{sel.stats.mitigation ?? '-'}</span></div>
-              <div><span>Dodge Odds</span><span>{sel.stats.dodge ?? sel.stats.dodgeOdds ?? '-'}</span></div>
-              <div><span>Effect Resist</span><span>{sel.stats.effectResist ?? sel.stats.effect_res ?? '-'}</span></div>
-            {/if}
-          </div>
-        {/each}
-      {:else}
-        <div class="stats-placeholder">Select a character to view stats</div>
-      {/if}
-      {#if previewId}
-        <div class="stats-confirm">
-          <button class="confirm" on:click={toggleMember}>
-            {selected.includes(previewId) ? 'Remove from party' : 'Add to party'}
-          </button>
-        </div>
-      {/if}
-    </div>
-  </div>
   </MenuPanel>
 {/if}
+
+<style>
+  .full {
+    display: grid;
+    grid-template-columns: minmax(8rem, 22%) 1fr minmax(12rem, 26%);
+    width: 100%;
+    height: 96%;
+    max-width: 100%;
+    max-height: 98%;
+    /* allow internal scrolling instead of clipping when content grows */
+  }
+</style>

--- a/frontend/src/lib/PartyRoster.svelte
+++ b/frontend/src/lib/PartyRoster.svelte
@@ -1,7 +1,4 @@
-// Bun Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`PartyPicker component roster layout snapshot 1`] = `
-"<script>
+<script>
   import { getElementIcon, getElementColor } from './assetLoader.js';
 
   /**
@@ -27,7 +24,7 @@ exports[`PartyPicker component roster layout snapshot 1`] = `
 <div class="roster list compact" data-testid="roster">
   {#each roster.filter(c => selected.includes(c.id)) as char}
     <button
-      data-testid={\`choice-\${char.id}\`}
+      data-testid={`choice-${char.id}`}
       class="char-btn"
       on:click={() => select(char.id)}>
       <img src={char.img} alt={char.name} class="compact-img" />
@@ -39,17 +36,17 @@ exports[`PartyPicker component roster layout snapshot 1`] = `
   {#each roster as char}
     <button
       type="button"
-      data-testid={\`choice-\${char.id}\`}
+      data-testid={`choice-${char.id}`}
       class="char-row"
       class:selected={selected.includes(char.id)}
       on:click={() => select(char.id)}
-      style={\`border-color: \${getElementColor(char.element)}\`}> 
+      style={`border-color: ${getElementColor(char.element)}`}> 
       <img src={char.img} alt={char.name} class="row-img" />
       <span class="row-name">{char.name}</span>
       <svelte:component
         this={getElementIcon(char.element)}
         class="row-type"
-        style={\`color: \${getElementColor(char.element)}\`}
+        style={`color: ${getElementColor(char.element)}`}
         aria-hidden="true" />
     </button>
   {/each}
@@ -127,5 +124,3 @@ exports[`PartyPicker component roster layout snapshot 1`] = `
   border: 1px solid #fff;
 }
 </style>
-"
-`;

--- a/frontend/src/lib/PlayerPreview.svelte
+++ b/frontend/src/lib/PlayerPreview.svelte
@@ -1,0 +1,52 @@
+<script>
+  /**
+   * Shows a portrait preview for the currently selected character.
+   *
+   * Props:
+   * - roster: array of character objects
+   * - previewId: ID of character to display
+   */
+  export let roster = [];
+  export let previewId;
+</script>
+
+<div class="preview">
+  {#if previewId}
+    {#each roster.filter(r => r.id === previewId) as sel}
+      <img src={sel.img} alt={sel.name} />
+    {/each}
+  {:else}
+    <div class="placeholder">Select up to 4 allies</div>
+  {/if}
+</div>
+
+<style>
+.preview {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  width: 100%;
+  height: 100%;
+  box-sizing: border-box;
+  min-width: 0;
+  min-height: 0;
+}
+.preview img {
+  width: auto;
+  height: auto;
+  max-width: 100%;
+  max-height: 100%;
+  object-fit: contain;
+  border: 3px solid #555;
+  background: #222;
+  border-radius: 12px;
+  box-shadow: 0 8px 24px rgba(0,0,0,0.5);
+  display: block;
+  margin: 0 auto;
+}
+.placeholder {
+  color: #888;
+  font-style: italic;
+}
+</style>

--- a/frontend/src/lib/StatTabs.svelte
+++ b/frontend/src/lib/StatTabs.svelte
@@ -1,0 +1,151 @@
+<script>
+  import { getElementIcon, getElementColor } from './assetLoader.js';
+  import { createEventDispatcher } from 'svelte';
+
+  /**
+   * Renders the stats panel with category tabs and a toggle control.
+   *
+   * Props:
+   * - roster: array of character objects
+   * - previewId: ID of character to show stats for
+   * - selected: array of selected character IDs
+   *
+   * Events:
+   * - toggle: dispatched with the previewId when Add/Remove is clicked
+   */
+  export let roster = [];
+  export let previewId;
+  export let selected = [];
+
+  const statTabs = ['Core', 'Offense', 'Defense'];
+  let activeTab = 'Core';
+  const dispatch = createEventDispatcher();
+
+  function toggleMember() {
+    if (!previewId) return;
+    dispatch('toggle', previewId);
+  }
+</script>
+
+<div class="stats-panel" data-testid="stats-panel">
+  <div class="stats-tabs">
+    {#each statTabs as tab}
+      <button class="tab-btn" class:active={activeTab === tab} on:click={() => activeTab = tab}>
+        {tab}
+      </button>
+    {/each}
+  </div>
+  {#if previewId}
+    {#each roster.filter(r => r.id === previewId) as sel}
+      <div class="stats-header">
+        <span class="char-name">{sel.name}</span>
+        <span class="char-level">Lv {sel.stats.level}</span>
+        <svelte:component
+          this={getElementIcon(sel.element)}
+          class="type-icon"
+          style={`color: ${getElementColor(sel.element)}`}
+          aria-hidden="true" />
+      </div>
+      <div class="stats-list">
+        {#if activeTab === 'Core'}
+          <div><span>HP</span><span>{sel.stats.hp ?? '-'}</span></div>
+          <div><span>EXP</span><span>{sel.stats.exp ?? sel.stats.xp ?? '-'}</span></div>
+          <div><span>Vitality</span><span>{sel.stats.vitality ?? sel.stats.vita ?? '-'}</span></div>
+          <div><span>Regain</span><span>{sel.stats.regain ?? sel.stats.regain_rate ?? '-'}</span></div>
+        {:else if activeTab === 'Offense'}
+          <div><span>ATK</span><span>{sel.stats.atk ?? '-'}</span></div>
+          <div><span>CRIT Rate</span><span>{(sel.stats.critRate ?? sel.stats.crit_rate ?? 0) + '%'}</span></div>
+          <div><span>CRIT DMG</span><span>{(sel.stats.critDamage ?? sel.stats.crit_dmg ?? 0) + '%'}</span></div>
+          <div><span>Effect Hit Rate</span><span>{(sel.stats.effectHit ?? sel.stats.effect_hit ?? 0) + '%'}</span></div>
+        {:else if activeTab === 'Defense'}
+          <div><span>DEF</span><span>{sel.stats.defense ?? '-'}</span></div>
+          <div><span>Mitigation</span><span>{sel.stats.mitigation ?? '-'}</span></div>
+          <div><span>Dodge Odds</span><span>{sel.stats.dodge ?? sel.stats.dodgeOdds ?? '-'}</span></div>
+          <div><span>Effect Resist</span><span>{sel.stats.effectResist ?? sel.stats.effect_res ?? '-'}</span></div>
+        {/if}
+      </div>
+    {/each}
+  {:else}
+    <div class="stats-placeholder">Select a character to view stats</div>
+  {/if}
+  {#if previewId}
+    <div class="stats-confirm">
+      <button class="confirm" on:click={toggleMember}>
+        {selected.includes(previewId) ? 'Remove from party' : 'Add to party'}
+      </button>
+    </div>
+  {/if}
+</div>
+
+<style>
+.stats-panel {
+  flex: 1;
+  width: 350px;
+  background: rgba(0,0,0,0.25);
+  border-left: 2px solid #444;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  box-sizing: border-box;
+  border-radius: 8px;
+}
+.stats-header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  border-bottom: 1px solid rgba(255,255,255,0.2);
+  padding-bottom: 0.5rem;
+}
+.char-name { font-size: 1.2rem; color: #fff; flex: 1; }
+.char-level { font-size: 1rem; color: #ccc; }
+.type-icon { width: 24px; height: 24px; }
+.stats-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+.stats-list div { display: flex; justify-content: space-between; color: #ddd; }
+.stats-placeholder {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #888;
+  font-style: italic;
+}
+.stats-confirm {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  min-height: 32px;
+  padding: 0.15rem 0;
+  margin-top: 0.25rem;
+}
+button.confirm {
+  border: 1.5px solid #fff;
+  background: transparent;
+  color: #fff;
+  padding: 0.12rem 0.4rem;
+  align-self: flex-end;
+  font-size: 0.95rem;
+  min-height: 28px;
+  border-radius: 6px;
+}
+.stats-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+.tab-btn {
+  background: rgba(255,255,255,0.1);
+  color: #ddd;
+  padding: 0.5rem 1rem;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+.tab-btn.active { background: rgba(255,255,255,0.3); color: #fff; }
+</style>

--- a/frontend/tests/partypicker.test.js
+++ b/frontend/tests/partypicker.test.js
@@ -9,7 +9,7 @@ describe('PartyPicker component', () => {
   });
 
   test('includes add/remove control', () => {
-    const content = readFileSync(join(import.meta.dir, '../src/lib/PartyPicker.svelte'), 'utf8');
+    const content = readFileSync(join(import.meta.dir, '../src/lib/StatTabs.svelte'), 'utf8');
     expect(content).toContain('Add to party');
   });
 
@@ -21,7 +21,7 @@ describe('PartyPicker component', () => {
   });
 
   test('orders stats correctly', () => {
-    const content = readFileSync(join(import.meta.dir, '../src/lib/PartyPicker.svelte'), 'utf8');
+    const content = readFileSync(join(import.meta.dir, '../src/lib/StatTabs.svelte'), 'utf8');
     const coreStart = content.indexOf("{#if activeTab === 'Core'}");
     const coreEnd = content.indexOf("{:else if activeTab === 'Offense'}");
     const coreSection = content.slice(coreStart, coreEnd);
@@ -34,15 +34,14 @@ describe('PartyPicker component', () => {
   });
 
   test('uses element colors for icon and outline', () => {
-    const content = readFileSync(join(import.meta.dir, '../src/lib/PartyPicker.svelte'), 'utf8');
-    expect(content).toContain('style={`border-color: ${getElementColor(char.element)}`}');
-    expect(content).toContain('style={`color: ${getElementColor(char.element)}`}');
+    const rosterContent = readFileSync(join(import.meta.dir, '../src/lib/PartyRoster.svelte'), 'utf8');
+    expect(rosterContent).toContain('style={`border-color: ${getElementColor(char.element)}`}');
+    expect(rosterContent).toContain('style={`color: ${getElementColor(char.element)}`}');
   });
 
   test('roster layout snapshot', () => {
-    const content = readFileSync(join(import.meta.dir, '../src/lib/PartyPicker.svelte'), 'utf8');
-    const snippet = content.split('<!-- Left: Roster list -->')[1].split('<!-- Center: Portrait preview of selected -->')[0];
-    expect(snippet.trim()).toMatchSnapshot();
+    const content = readFileSync(join(import.meta.dir, '../src/lib/PartyRoster.svelte'), 'utf8');
+    expect(content).toMatchSnapshot();
   });
 });
 


### PR DESCRIPTION
## Summary
- factor party roster display into `PartyRoster` with selection handling
- move portrait and stats panels into `PlayerPreview` and `StatTabs`
- document new subcomponents in party picker implementation notes

## Testing
- `bun test --update-snapshots tests/partypicker.test.js`
- `./run-tests.sh` *(failed: backend tests/test_card_rewards.py, tests/test_enrage_stacking.py, tests/test_party_persistence.py, tests/test_player_editor.py, tests/test_random_player_foes.py, tests/test_relics.py, tests/test_shadow_siphon.py, tests/test_wind_multi_target.py; frontend tests/assets.test.js; timed out: backend tests/test_app.py, tests/test_damage_type_on_action.py, tests/test_gacha.py, tests/test_rdr.py, tests/test_relic_rewards.py)*

------
https://chatgpt.com/codex/tasks/task_b_68a8b8e9e4dc832c93fe2e8d2e505485