### PR TITLE
feat: expose backend flavor

### DIFF
--- a/backend/.codex/implementation/status-endpoint.md
+++ b/backend/.codex/implementation/status-endpoint.md
@@ -1,0 +1,4 @@
+# Status Endpoint
+
+- `GET /` responds with `{ "status": "ok", "flavor": "default" }`.
+- The `flavor` field reflects the `UV_EXTRA` environment variable, defaulting to `"default"`.

--- a/backend/README.md
+++ b/backend/README.md
@@ -13,7 +13,7 @@ uv sync
 uv run app.py
 ```
 
-The root endpoint returns a simple status payload. Additional routes support
+The root endpoint returns a simple status payload including the configured flavor. Set `UV_EXTRA` (default `"default"`) to label this instance. Additional routes support
 starting runs with a seeded 45-room map, updating the party, retrieving floor
 maps, listing available player characters, returning room background images,
 editing player pronouns and starting stats, and posting actions to battle, shop,

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import os
+
 from quart import Quart
 from quart import jsonify
 from quart import request
@@ -34,10 +36,12 @@ app.register_blueprint(runs_bp)
 app.register_blueprint(rooms_bp)
 app.register_blueprint(rewards_bp)
 
+BACKEND_FLAVOR = os.getenv("UV_EXTRA", "default")
+
 
 @app.get("/")
 async def status() -> tuple[str, int, dict[str, str]]:
-    return jsonify({"status": "ok"})
+    return jsonify({"status": "ok", "flavor": BACKEND_FLAVOR})
 
 
 @app.after_request

--- a/backend/tests/test_app.py
+++ b/backend/tests/test_app.py
@@ -1,5 +1,6 @@
 import json
 import importlib.util
+import sys
 
 from pathlib import Path
 
@@ -12,6 +13,9 @@ def app_with_db(tmp_path, monkeypatch):
     db_path = tmp_path / "save.db"
     monkeypatch.setenv("AF_DB_PATH", str(db_path))
     monkeypatch.setenv("AF_DB_KEY", "testkey")
+    monkeypatch.setenv("UV_EXTRA", "test")
+    if "game" in sys.modules:
+        del sys.modules["game"]
     monkeypatch.syspath_prepend(Path(__file__).resolve().parents[1])
     spec = importlib.util.spec_from_file_location(
         "app", Path(__file__).resolve().parents[1] / "app.py",
@@ -30,7 +34,7 @@ async def test_status_endpoint(app_with_db):
     response = await client.get("/")
     assert response.status_code == 200
     data = await response.get_json()
-    assert data == {"status": "ok"}
+    assert data == {"status": "ok", "flavor": "test"}
 
 
 @pytest.mark.asyncio

--- a/frontend/.codex/implementation/run-helpers.md
+++ b/frontend/.codex/implementation/run-helpers.md
@@ -4,4 +4,5 @@
 - `src/lib/runApi.js`: thin wrappers around backend endpoints used during a run (start, room actions, rewards).
 - `src/lib/MainMenu.svelte`: renders the stained glass side menu from a list of items.
 - `src/lib/RunButtons.svelte`: module script exporting `buildRunMenu` for constructing the menu item list.
-- `src/routes/+page.svelte` now coordinates these helpers and avoids direct `localStorage` or fetch logic.
+- `src/lib/api.js`: `getBackendFlavor()` reports which backend flavor is active.
+- `src/routes/+page.svelte` now coordinates these helpers and avoids direct `localStorage` or fetch logic, also checking the backend flavor on mount.

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -1,5 +1,11 @@
 const API_BASE = import.meta.env.VITE_API_BASE || 'http://localhost:59002';
 
+export async function getBackendFlavor() {
+  const res = await fetch(`${API_BASE}/`, { cache: 'no-store' });
+  const data = await res.json();
+  return data.flavor;
+}
+
 export async function getPlayers() {
   const res = await fetch(`${API_BASE}/players`, { cache: 'no-store' });
   return res.json();

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -1,7 +1,7 @@
 <script>
   import GameViewport from '$lib/GameViewport.svelte';
   import { onMount } from 'svelte';
-  import { getPlayerConfig, savePlayerConfig } from '$lib/api.js';
+  import { getPlayerConfig, savePlayerConfig, getBackendFlavor } from '$lib/api.js';
   import {
     startRun,
     roomAction,
@@ -17,6 +17,7 @@
   import { openOverlay, backOverlay, homeOverlay } from '$lib/OverlayController.js';
 
   let runId = '';
+  let backendFlavor = '';
   let selectedParty = ['sample_player'];
   let roomData = null;
   // Track map state to render room/floor context in battle header
@@ -30,6 +31,8 @@
   let battleActive = false;
 
   onMount(async () => {
+    backendFlavor = await getBackendFlavor();
+    window.backendFlavor = backendFlavor;
     const saved = loadRunState();
     if (saved) {
       try {


### PR DESCRIPTION
## Summary
- expose `UV_EXTRA` via root status endpoint for flavor identification
- document flavor handling in backend docs and tests

## Testing
- `uv run pytest tests/test_app.py::test_run_flow -q`
- `uv run pytest tests/test_app.py::test_status_endpoint -q`
- `ESLINT_USE_FLAT_CONFIG=false bunx eslint .`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_b_68a8e4789c98832caed884a641e24680