### PR TITLE
Enhance battle snapshots with effect details

### DIFF
--- a/.codex/implementation/stats-and-effects.md
+++ b/.codex/implementation/stats-and-effects.md
@@ -47,7 +47,7 @@ adding the effect. The difference is clamped to zero and jittered by ±10%, and 
 - `tick(others=None)` – advances all effects, applying damage or healing and removing expired ones. DoT names are removed from `stats.dots` when finished. If `others` is provided, effects with `on_death` hooks may spread on target death.
 - `on_action()` – triggers `on_action` hooks for effects that react when the target performs an action.
 
-Active effect names are mirrored in the `Stats` lists (`dots`, `hots`) for UI display. Plugins can extend base `DamageOverTime` and `HealingOverTime` classes to implement custom behavior or additional stat modifications.
+Active effect names are mirrored in the `Stats` lists (`dots`, `hots`) for UI display. Battle snapshots aggregate effect details from each fighter's `effect_manager`, grouping DoTs and HoTs by ID with entries exposing `id`, `name`, `damage` or `healing`, remaining `turns`, the source's ID, and stack counts. Passive IDs are similarly collapsed into `{id, stacks}` objects in the serialized snapshot.
 
 ## Lightning Pop
 Lightning attacks trigger an extra pass over the target's active DoTs. Each effect deals 25% of its damage immediately while leaving remaining turns and stack counts untouched.

--- a/backend/tests/test_effect_serialization.py
+++ b/backend/tests/test_effect_serialization.py
@@ -1,0 +1,43 @@
+from autofighter.effects import DamageOverTime, EffectManager, HealingOverTime
+from autofighter.rooms.utils import _serialize
+from autofighter.stats import Stats
+
+
+def test_serialize_effect_details():
+    target = Stats()
+    target.id = "t"
+    mgr = EffectManager(target)
+    target.effect_manager = mgr
+
+    source = Stats()
+    source.id = "s"
+    mgr.add_dot(DamageOverTime("burn", 5, 2, "burn", source))
+    mgr.add_dot(DamageOverTime("burn", 5, 1, "burn", source))
+    mgr.add_hot(HealingOverTime("regen", 3, 1, "regen", source))
+
+    target.passives = ["p1", "p1", "p2"]
+
+    data = _serialize(target)
+
+    assert data["dots"] == [
+        {
+            "id": "burn",
+            "name": "burn",
+            "damage": 5,
+            "turns": 2,
+            "source": "s",
+            "stacks": 2,
+        }
+    ]
+    assert data["hots"] == [
+        {
+            "id": "regen",
+            "name": "regen",
+            "healing": 3,
+            "turns": 1,
+            "source": "s",
+            "stacks": 1,
+        }
+    ]
+    assert any(p["id"] == "p1" and p["stacks"] == 2 for p in data["passives"])
+    assert any(p["id"] == "p2" and p["stacks"] == 1 for p in data["passives"])

--- a/backend/tests/test_enrage_stacking.py
+++ b/backend/tests/test_enrage_stacking.py
@@ -36,4 +36,4 @@ async def test_enrage_stacks(monkeypatch):
     assert result["enrage"]["stacks"] == 3
     foe = result["foes"][0]
     assert foe["atk"] == 11
-    assert "Enraged" in foe["passives"]
+    assert any(p["id"] == "Enraged" for p in foe["passives"])


### PR DESCRIPTION
## Summary
- include detailed DoT, HoT, and passive data in serialized fighter snapshots
- document effect serialization and add tests for new structure

## Testing
- `uvx ruff check backend/autofighter/rooms/utils.py backend/tests/test_enrage_stacking.py backend/tests/test_effect_serialization.py`
- `./run-tests.sh` *(fails: AttributeError: 'EffectManager' object has no attribute 'cleanup')*


------
https://chatgpt.com/codex/tasks/task_b_68a8ea70e744832c813d62a86b78c485