### PR TITLE
[FIX] ensure battle polling waits for rewards

### DIFF
--- a/backend/.codex/implementation/battle-defeat.md
+++ b/backend/.codex/implementation/battle-defeat.md
@@ -1,0 +1,3 @@
+# Battle defeat handling
+
+`BattleRoom.resolve` reports a `"defeat"` result when all party members have zero or less HP. `_run_battle` checks for this outcome, clears pending state flags, saves the final snapshot with `ended: true`, and removes the run from storage.

--- a/backend/app.py
+++ b/backend/app.py
@@ -21,6 +21,7 @@ from game import _assign_damage_type  # noqa: F401
 from game import _load_player_customization  # noqa: F401
 from game import _passive_names  # noqa: F401
 from game import _run_battle  # noqa: F401
+from game import _scale_stats  # noqa: F401
 from game import battle_snapshots  # noqa: F401
 from game import battle_tasks  # noqa: F401
 from game import load_map  # noqa: F401

--- a/backend/autofighter/rooms/battle.py
+++ b/backend/autofighter/rooms/battle.py
@@ -373,6 +373,28 @@ class BattleRoom(Room):
         party.cards = combat_party.cards
         party_data = [_serialize(p) for p in party.members]
         foes_data = [_serialize(f) for f in foes]
+        if all(m.hp <= 0 for m in combat_party.members):
+            loot = {
+                "gold": 0,
+                "card_choices": [],
+                "relic_choices": [],
+                "items": [],
+            }
+            return {
+                "result": "defeat",
+                "party": party_data,
+                "gold": party.gold,
+                "relics": party.relics,
+                "cards": party.cards,
+                "card_choices": [],
+                "relic_choices": [],
+                "loot": loot,
+                "foes": foes_data,
+                "room_number": self.node.index,
+                "exp_reward": exp_reward,
+                "enrage": {"active": enrage_active, "stacks": enrage_stacks},
+                "rdr": party.rdr,
+            }
         card_opts = [
             c
             for c in card_choices(

--- a/backend/game.py
+++ b/backend/game.py
@@ -240,6 +240,9 @@ async def _run_battle(
         result["items"] = items
         state["battle"] = False
         if result.get("result") == "defeat":
+            state["awaiting_card"] = False
+            state["awaiting_relic"] = False
+            state["awaiting_next"] = False
             try:
                 await asyncio.to_thread(save_map, run_id, state)
                 await asyncio.to_thread(save_party, run_id, party)

--- a/backend/tests/test_battle_defeat.py
+++ b/backend/tests/test_battle_defeat.py
@@ -1,0 +1,63 @@
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+from autofighter.mapgen import MapNode
+from autofighter.party import Party
+from autofighter.rooms import BattleRoom
+from autofighter.stats import Stats
+from plugins.players.player import Player
+
+
+@pytest.mark.asyncio
+async def test_battle_resolve_reports_defeat():
+    player = Player()
+    player.hp = 0
+    party = Party(members=[player])
+    node = MapNode(0, "battle-normal", 1, 0, 1, 0)
+    room = BattleRoom(node=node)
+    foe = Stats()
+    foe.id = "dummy"
+    result = await room.resolve(party, {}, foe=foe)
+    assert result["result"] == "defeat"
+
+
+@pytest.fixture()
+def app_with_db(tmp_path, monkeypatch):
+    db_path = tmp_path / "save.db"
+    monkeypatch.setenv("AF_DB_PATH", str(db_path))
+    monkeypatch.setenv("AF_DB_KEY", "testkey")
+    monkeypatch.syspath_prepend(Path(__file__).resolve().parents[1])
+    spec = importlib.util.spec_from_file_location(
+        "app", Path(__file__).resolve().parents[1] / "app.py",
+    )
+    app_module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(app_module)
+    app_module.app.testing = True
+    return app_module, db_path
+
+
+@pytest.mark.asyncio
+async def test_run_battle_handles_defeat_cleanup(app_with_db, monkeypatch):
+    app_module, _ = app_with_db
+    app = app_module.app
+    client = app.test_client()
+
+    async def fake_resolve(self, party, data, progress, foe=None):
+        return {"result": "defeat"}
+
+    monkeypatch.setattr(BattleRoom, "resolve", fake_resolve)
+
+    start_resp = await client.post("/run/start", json={"party": ["player"]})
+    run_id = (await start_resp.get_json())["run_id"]
+
+    await client.post(f"/rooms/{run_id}/battle")
+    task = app_module.battle_tasks[run_id]
+    await task
+
+    with app_module.SAVE_MANAGER.connection() as conn:
+        row = conn.execute("SELECT id FROM runs WHERE id = ?", (run_id,)).fetchone()
+    assert row is None
+    assert app_module.battle_snapshots[run_id]["ended"] is True

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -180,13 +180,21 @@
       const partyDead = Array.isArray(snap?.party) && snap.party.length > 0 && snap.party.every(m => (m?.hp ?? 1) <= 0);
       const foesDead = Array.isArray(snap?.foes) && snap.foes.length > 0 && snap.foes.every(f => (f?.hp ?? 1) <= 0);
       const combatOver = partyDead || foesDead;
-      if (snapHasRewards || snapCompleted || combatOver) {
+      if (snapHasRewards || snapCompleted) {
+        // Stop only when rewards or completion flags arrive
         roomData = snap;
-        battleActive = false;
-        nextRoom = snap.next_room || nextRoom;
-        if (typeof snap.current_index === 'number') currentIndex = snap.current_index;
-        if (snap.current_room) currentRoomType = snap.current_room;
-        return;
+        const rewardsReady = Boolean(roomData?.loot) || (roomData?.card_choices?.length > 0) || (roomData?.relic_choices?.length > 0);
+        if (rewardsReady || snapCompleted) {
+          battleActive = false;
+          nextRoom = snap.next_room || nextRoom;
+          if (typeof snap.current_index === 'number') currentIndex = snap.current_index;
+          if (snap.current_room) currentRoomType = snap.current_room;
+          return;
+        }
+      }
+      if (combatOver) {
+        // Update snapshot but keep polling until rewards are available
+        roomData = snap;
       }
     } catch {
       /* ignore */


### PR DESCRIPTION
## Summary
- keep battle polling active until rewards or completion flags arrive
- avoid stopping early when combat over but rewards missing
- report defeat when party wiped and clean up run state

## Testing
- `uv sync`
- `bun install`
- `./run-tests.sh` *(fails: backend tests/test_app.py, tests/test_battle_snapshot_consistency.py, tests/test_battle_timing.py, tests/test_card_rewards.py, tests/test_enrage_stacking.py, tests/test_exp_leveling.py, tests/test_gacha.py, tests/test_party_endpoint.py, tests/test_party_persistence.py, tests/test_player_editor.py, tests/test_random_player_foes.py, tests/test_save_management.py, tests/test_shadow_siphon.py; timed out: tests/test_app.py, tests/test_damage_type_on_action.py, tests/test_rdr.py, tests/test_relic_rewards.py)*
- `ESLINT_USE_FLAT_CONFIG=false bunx eslint .`


------
https://chatgpt.com/codex/tasks/task_b_68aae355a468832c818a4ecbc59b7bce