### PR TITLE
[FEAT] Add server-side logger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ settings.json
 
 # Node lock files
 package-lock.json
+
+# Frontend logs
+frontend/logs/

--- a/frontend/.codex/implementation/logger.md
+++ b/frontend/.codex/implementation/logger.md
@@ -1,0 +1,5 @@
+# Logger
+
+`src/lib/logger.js` ensures a `logs` directory exists and appends timestamped
+messages to `logs/webui.log`. It exports `info`, `warn`, and `error` helpers
+for server-side or development logging from Svelte components and scripts.

--- a/frontend/docker-entrypoint.sh
+++ b/frontend/docker-entrypoint.sh
@@ -8,5 +8,7 @@ if [[ ! -d node_modules || -z "$(ls -A node_modules 2>/dev/null || true)" ]]; th
   bun install
 fi
 
-exec bun run dev --host 0.0.0.0 --port 59001
+mkdir -p logs
+
+exec bun run dev --host 0.0.0.0 --port 59001 2>&1 | tee -a logs/webui.log
 

--- a/frontend/src/lib/PartyPicker.svelte
+++ b/frontend/src/lib/PartyPicker.svelte
@@ -6,6 +6,7 @@
   import PartyRoster from './PartyRoster.svelte';
   import PlayerPreview from './PlayerPreview.svelte';
   import StatTabs from './StatTabs.svelte';
+  import { browser, dev } from '$app/environment';
 
   let background = '';
   let roster = [];
@@ -44,7 +45,10 @@
         previewId = selected[0] ?? player.id;
       }
     } catch (e) {
-      console.error('Unable to load roster. Is the backend running on 59002?');
+      if (dev || !browser) {
+        const { error } = await import('$lib/logger.js');
+        error('Unable to load roster. Is the backend running on 59002?');
+      }
     }
   });
 

--- a/frontend/src/lib/PullsMenu.svelte
+++ b/frontend/src/lib/PullsMenu.svelte
@@ -3,6 +3,7 @@
   import { createEventDispatcher } from 'svelte';
   import MenuPanel from './MenuPanel.svelte';
   import { getGacha, pullGacha } from './api.js';
+  import { browser, dev } from '$app/environment';
   const dispatch = createEventDispatcher();
   let pity = 0;
   let items = {};
@@ -21,7 +22,10 @@
       items = data.items;
       results = data.results || [];
     } catch (err) {
-      console.error('pull failed', err);
+      if (dev || !browser) {
+        const { error } = await import('$lib/logger.js');
+        error('pull failed', err);
+      }
       alert('Not enough tickets');
     }
     loading = false;

--- a/frontend/src/lib/logger.js
+++ b/frontend/src/lib/logger.js
@@ -1,0 +1,33 @@
+import fs from 'fs';
+import path from 'path';
+
+const logDir = path.resolve('logs');
+if (!fs.existsSync(logDir)) {
+  fs.mkdirSync(logDir, { recursive: true });
+}
+
+const logFile = path.join(logDir, 'webui.log');
+
+function write(level, ...args) {
+  const message = args
+    .map((arg) => {
+      if (arg instanceof Error) return arg.stack || arg.message;
+      if (typeof arg === 'object') return JSON.stringify(arg);
+      return String(arg);
+    })
+    .join(' ');
+  const line = `[${new Date().toISOString()}] [${level.toUpperCase()}] ${message}\n`;
+  fs.appendFileSync(logFile, line);
+}
+
+export function info(...args) {
+  write('info', ...args);
+}
+
+export function warn(...args) {
+  write('warn', ...args);
+}
+
+export function error(...args) {
+  write('error', ...args);
+}

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -15,6 +15,7 @@
   import { buildRunMenu } from '$lib/RunButtons.svelte';
   import { FEEDBACK_URL } from '$lib/constants.js';
   import { openOverlay, backOverlay, homeOverlay } from '$lib/OverlayController.js';
+  import { browser, dev } from '$app/environment';
 
   let runId = '';
   let backendFlavor = '';
@@ -202,7 +203,10 @@
         if (stalledTicks > STALL_TICKS) {
           battleActive = false;
           roomData = { ...snap, error: 'Battle results could not be fetched.' };
-          console.warn('Battle results could not be fetched.');
+          if (dev || !browser) {
+            const { warn } = await import('$lib/logger.js');
+            warn('Battle results could not be fetched.');
+          }
           return;
         }
       } else {


### PR DESCRIPTION
## Summary
- add logger module for web UI that writes to `logs/webui.log`
- replace remaining console statements with conditional server-side logger usage
- capture dev server output in `docker-entrypoint.sh`

## Testing
- `uvx ruff check backend` *(fails: unused imports and unused variables)*
- `ESLINT_USE_FLAT_CONFIG=false bunx eslint .`
- `./run-tests.sh` *(fails: backend tests failing and timeouts)*

------
https://chatgpt.com/codex/tasks/task_b_68aaf7c49c18832cba93adeec829fc0b