### PR TITLE
[FIX] add roomAction error recovery

### DIFF
--- a/frontend/.codex/implementation/run-helpers.md
+++ b/frontend/.codex/implementation/run-helpers.md
@@ -6,3 +6,4 @@
 - `src/lib/RunButtons.svelte`: module script exporting `buildRunMenu` for constructing the menu item list.
 - `src/lib/api.js`: `getBackendFlavor()` reports which backend flavor is active.
 - `src/routes/+page.svelte` now coordinates these helpers and avoids direct `localStorage` or fetch logic, also checking the backend flavor on mount.
+- `enterRoom` wraps `roomAction` calls with error handling. If the request fails, it attempts to load the latest battle snapshot and alerts the user when recovery is not possible.


### PR DESCRIPTION
## Summary
- handle roomAction failures in enterRoom by restoring the last battle snapshot or alerting the user
- document new error-recovery flow for run helpers

## Testing
- `uv run pytest` (fails: TypeError: 'NoneType' object is not subscriptable)
- `uvx ruff check backend` (fails: F401 unused imports)
- `bun test`
- `ESLINT_USE_FLAT_CONFIG=false bunx eslint .`


------
https://chatgpt.com/codex/tasks/task_b_68ab1716ec5c832cbfc217a342851a39