### PR TITLE
[FIX] guard battle resolution errors

### DIFF
--- a/backend/.codex/implementation/battle-snapshots.md
+++ b/backend/.codex/implementation/battle-snapshots.md
@@ -8,6 +8,10 @@ poll for results:
 - Reward processing is wrapped in a `try/except`. If an exception occurs, the
   snapshot is populated with any available loot, an `error` message, and
   `awaiting_next` set to `false` so clients are not blocked waiting for results.
+- The call to `room.resolve` is wrapped in a `try/except` to guard against
+  crashes. On failure the battle flag is cleared, map and party data are saved,
+  and the snapshot records the `error` with `awaiting_next` set to `false` so
+  runs do not hang.
 
 These snapshots are stored in `game.battle_snapshots` and polled by the
 frontend during combat.


### PR DESCRIPTION
## Summary
- wrap room.resolve in _run_battle with try/except to record error snapshots and clear battle state
- document battle snapshot error handling for resolve failures

## Testing
- `uvx ruff check backend/game.py`
- `ESLINT_USE_FLAT_CONFIG=false bunx eslint .` (frontend)
- `./run-tests.sh` *(fails: tests/test_card_rewards.py, tests/test_enrage_stacking.py, tests/test_exp_leveling.py, tests/test_party_endpoint.py, tests/test_party_persistence.py, tests/test_player_editor.py, tests/test_random_player_foes.py, tests/test_save_management.py, tests/test_shadow_siphon.py; timed out: tests/test_app.py, tests/test_damage_type_on_action.py, tests/test_gacha.py, tests/test_rdr.py, tests/test_relic_rewards.py)*

------
https://chatgpt.com/codex/tasks/task_b_68ab175eab34832ca21865bc47a4ce81