### PR TITLE
Handle battle error snapshots and polling stop

### DIFF
--- a/backend/.codex/implementation/battle-snapshots.md
+++ b/backend/.codex/implementation/battle-snapshots.md
@@ -8,6 +8,9 @@ poll for results:
 - Reward processing is wrapped in a `try/except`. If an exception occurs, the
   snapshot is populated with any available loot, an `error` message, and
   `awaiting_next` set to `false` so clients are not blocked waiting for results.
+- Any exception now yields a snapshot with `result: "error"`, `ended: true`,
+  and empty `party` and `foes` arrays so the frontend can detect that combat
+  finished even when failures occur.
 - The call to `room.resolve` is wrapped in a `try/except` to guard against
   crashes. On failure the battle flag is cleared, map and party data are saved,
   and the snapshot records the `error` with `awaiting_next` set to `false` so

--- a/backend/game.py
+++ b/backend/game.py
@@ -232,7 +232,14 @@ async def _run_battle(
         except Exception as exc:
             state["battle"] = False
             log.exception("Battle resolution failed for %s", run_id)
-            battle_snapshots[run_id] = {"error": str(exc), "awaiting_next": False}
+            battle_snapshots[run_id] = {
+                "result": "error",
+                "error": str(exc),
+                "ended": True,
+                "party": [],
+                "foes": [],
+                "awaiting_next": False,
+            }
             try:
                 await asyncio.to_thread(save_map, run_id, state)
                 await asyncio.to_thread(save_party, run_id, party)
@@ -313,9 +320,12 @@ async def _run_battle(
         except Exception as exc:
             log.exception("Battle processing failed for %s", run_id)
             battle_snapshots[run_id] = {
-                "result": result.get("result"),
+                "result": "error",
                 "loot": result.get("loot"),
                 "error": str(exc),
+                "ended": True,
+                "party": [],
+                "foes": [],
                 "awaiting_next": False,
             }
     finally:

--- a/backend/tests/test_battle_error_snapshot.py
+++ b/backend/tests/test_battle_error_snapshot.py
@@ -1,0 +1,47 @@
+from pathlib import Path
+import importlib.util
+
+import pytest
+
+from autofighter.rooms import BattleRoom
+
+
+@pytest.fixture()
+def app_with_db(tmp_path, monkeypatch):
+    db_path = tmp_path / "save.db"
+    monkeypatch.setenv("AF_DB_PATH", str(db_path))
+    monkeypatch.setenv("AF_DB_KEY", "testkey")
+    monkeypatch.syspath_prepend(Path(__file__).resolve().parents[1])
+    spec = importlib.util.spec_from_file_location(
+        "app", Path(__file__).resolve().parents[1] / "app.py",
+    )
+    app_module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(app_module)
+    app_module.app.testing = True
+    return app_module, db_path
+
+
+@pytest.mark.asyncio
+async def test_run_battle_exception_snapshot_fields(app_with_db, monkeypatch):
+    app_module, _ = app_with_db
+    app = app_module.app
+    client = app.test_client()
+
+    async def boom(self, party, data, progress, foe=None):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(BattleRoom, "resolve", boom)
+
+    start_resp = await client.post("/run/start", json={"party": ["player"]})
+    run_id = (await start_resp.get_json())["run_id"]
+
+    await client.post(f"/rooms/{run_id}/battle")
+    task = app_module.battle_tasks[run_id]
+    await task
+
+    snap = app_module.battle_snapshots[run_id]
+    assert snap["result"] == "error"
+    assert snap["ended"] is True
+    assert snap["party"] == []
+    assert snap["foes"] == []

--- a/frontend/.codex/implementation/battle-polling.md
+++ b/frontend/.codex/implementation/battle-polling.md
@@ -6,3 +6,6 @@ no rewards or completion flags have arrived. After roughly three seconds of
 such stalled polling, the function stops the battle, records an error on the
 snapshot, and logs a warning so the reward overlay or reset flow can proceed.
 
+If a snapshot includes an `error` field, polling halts immediately and the
+error state is surfaced without waiting for combat-over indicators.
+

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -178,6 +178,12 @@
     if (!battleActive) return;
     try {
       const snap = mapStatuses(await roomAction(runId, 'battle', 'snapshot'));
+      if (snap?.error) {
+        roomData = snap;
+        battleActive = false;
+        stalledTicks = 0;
+        return;
+      }
       const snapHasRewards = Boolean(snap?.loot) || (snap?.card_choices?.length > 0) || (snap?.relic_choices?.length > 0);
       const snapCompleted = Boolean(snap?.awaiting_next) || Boolean(snap?.next_room) || (snap?.ended && snap?.result === 'defeat');
       const partyDead = Array.isArray(snap?.party) && snap.party.length > 0 && snap.party.every(m => (m?.hp ?? 1) <= 0);

--- a/frontend/tests/battlepolling.test.js
+++ b/frontend/tests/battlepolling.test.js
@@ -1,0 +1,14 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { describe, test, expect } from 'bun:test';
+
+describe('battle polling', () => {
+  test('stops on error snapshots', () => {
+    const content = readFileSync(
+      join(import.meta.dir, '../src/routes/+page.svelte'),
+      'utf8'
+    );
+    expect(content).toContain('if (snap?.error)');
+    expect(content).toContain('battleActive = false');
+  });
+});


### PR DESCRIPTION
## Summary
- ensure battle error snapshots mark combat ended with empty party/foes
- stop frontend polling immediately on error snapshots
- document new error handling and add regression tests

## Testing
- `uv run ruff backend/tests/test_battle_error_snapshot.py`
- `uv run pytest` *(fails: tests/test_app.py::test_run_flow - TypeError: 'NoneType' object is not subscriptable)*
- `bun test`


------
https://chatgpt.com/codex/tasks/task_b_68ab4b7ac110832c9eb4b2c87064a4fb