### PR TITLE
Update feedback URL for Midori-AI-OSS repository

### DIFF
--- a/frontend/src/lib/constants.js
+++ b/frontend/src/lib/constants.js
@@ -1,1 +1,1 @@
-export const FEEDBACK_URL = 'https://github.com/Midori-AI/Midori-AI-AutoFighter/issues/new?title=Feedback&body=...';
+export const FEEDBACK_URL = 'https://github.com/Midori-AI-OSS/Midori-AI-AutoFighter/issues/new';

--- a/frontend/tests/feedback.test.js
+++ b/frontend/tests/feedback.test.js
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'bun:test';
 import { readFileSync } from 'fs';
 import { join } from 'path';
+import { FEEDBACK_URL } from '../src/lib/constants.js';
 
 describe('Feedback button', () => {
   test('page provides a feedback link', () => {
@@ -10,5 +11,8 @@ describe('Feedback button', () => {
     expect(page).toContain('openFeedback');
     expect(page).toContain('FEEDBACK_URL');
     expect(page).toContain("window.open(FEEDBACK_URL, '_blank', 'noopener')");
+    expect(FEEDBACK_URL).toBe(
+      'https://github.com/Midori-AI-OSS/Midori-AI-AutoFighter/issues/new'
+    );
   });
 });

--- a/frontend/tests/layout.test.js
+++ b/frontend/tests/layout.test.js
@@ -17,7 +17,7 @@ describe('layoutForWidth', () => {
 
   test('feedback URL points to repository issues', () => {
     expect(FEEDBACK_URL).toBe(
-      'https://github.com/Midori-AI/Midori-AI-AutoFighter/issues/new?title=Feedback&body=...'
+      'https://github.com/Midori-AI-OSS/Midori-AI-AutoFighter/issues/new'
     );
   });
 });


### PR DESCRIPTION
## Summary
- point feedback URL to `https://github.com/Midori-AI-OSS/Midori-AI-AutoFighter/issues/new`
- adjust layout test for new feedback link
- ensure feedback test verifies new Midori-AI-OSS path

## Testing
- `./run-tests.sh` *(fails: tests/test_card_rewards.py, tests/test_enrage_stacking.py, tests/test_exp_leveling.py, tests/test_party_endpoint.py, tests/test_party_persistence.py, tests/test_player_editor.py, tests/test_random_player_foes.py, tests/test_save_management.py, tests/test_shadow_siphon.py; timed out: tests/test_app.py, tests/test_damage_type_on_action.py, tests/test_gacha.py, tests/test_rdr.py, tests/test_relic_rewards.py)*

------
https://chatgpt.com/codex/tasks/task_b_68ab57babed8832ca05b1c30f2296c1a