### PR TITLE
Add global error handler with traceback

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import logging
+import traceback
 
 from pathlib import Path
 from logging.handlers import RotatingFileHandler
@@ -77,6 +78,18 @@ async def add_cors_headers(response):
 async def handle_cors_preflight():
     if request.method == "OPTIONS":
         return "", 204
+
+
+@app.errorhandler(Exception)
+async def handle_exception(e: Exception):
+    log.exception(e)
+    tb = traceback.format_exc()
+    response = jsonify({"error": str(e), "traceback": tb})
+    response.status_code = 500
+    response.headers["Access-Control-Allow-Origin"] = "*"
+    response.headers["Access-Control-Allow-Headers"] = "Content-Type"
+    response.headers["Access-Control-Allow-Methods"] = "GET, POST, PUT, DELETE, OPTIONS"
+    return response
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_error_handler.py
+++ b/backend/tests/test_error_handler.py
@@ -1,0 +1,39 @@
+import sys
+import importlib.util
+
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture()
+def app_client(tmp_path, monkeypatch):
+    db_path = tmp_path / "save.db"
+    monkeypatch.setenv("AF_DB_PATH", str(db_path))
+    monkeypatch.setenv("AF_DB_KEY", "testkey")
+    if "game" in sys.modules:
+        del sys.modules["game"]
+    monkeypatch.syspath_prepend(Path(__file__).resolve().parents[1])
+    spec = importlib.util.spec_from_file_location(
+        "app", Path(__file__).resolve().parents[1] / "app.py",
+    )
+    app_module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(app_module)
+    app_module.app.testing = True
+
+    @app_module.app.route("/explode")
+    async def explode() -> None:
+        raise RuntimeError("boom")
+
+    return app_module.app.test_client()
+
+
+@pytest.mark.asyncio
+async def test_error_handler_returns_traceback(app_client):
+    response = await app_client.get("/explode")
+    assert response.status_code == 500
+    data = await response.get_json()
+    assert "traceback" in data
+    assert "RuntimeError" in data["traceback"]
+    assert response.headers["Access-Control-Allow-Origin"] == "*"


### PR DESCRIPTION
## Summary
- add global Quart error handler returning JSON payload with stack trace and CORS headers
- test error handling to ensure traceback and CORS headers are included

## Testing
- `uv run ruff check backend/app.py backend/tests/test_error_handler.py`
- `./run-tests.sh` *(fails: backend tests/test_card_rewards.py, backend tests/test_enrage_stacking.py, backend tests/test_error_handler.py, backend tests/test_exp_leveling.py, backend tests/test_party_endpoint.py, backend tests/test_party_persistence.py, backend tests/test_player_editor.py, backend tests/test_random_player_foes.py, backend tests/test_save_management.py, backend tests/test_shadow_siphon.py; timed out: backend tests/test_app.py, backend tests/test_damage_type_on_action.py, backend tests/test_gacha.py, backend tests/test_rdr.py, backend tests/test_relic_rewards.py)*
- `uv run pytest tests/test_error_handler.py`


------
https://chatgpt.com/codex/tasks/task_b_68ab59f24958832cb5191f7dec7f7a50