### PR TITLE
[FEATURE] attach damage types to ongoing effects

### DIFF
--- a/backend/plugins/damage_types/dark.py
+++ b/backend/plugins/damage_types/dark.py
@@ -1,10 +1,13 @@
+from typing import TYPE_CHECKING
 from dataclasses import dataclass
 
 from autofighter.stats import BUS
 from autofighter.effects import DamageOverTime
-from plugins.dots.shadow_siphon import ShadowSiphon
-from plugins.dots.abyssal_corruption import AbyssalCorruption
 from plugins.damage_types._base import DamageTypeBase
+
+if TYPE_CHECKING:
+    from plugins.dots.shadow_siphon import ShadowSiphon
+    from plugins.dots.abyssal_corruption import AbyssalCorruption
 
 
 @dataclass
@@ -16,6 +19,8 @@ class Dark(DamageTypeBase):
     _cleanup_registered: bool = False
 
     async def on_action(self, actor, allies, enemies) -> bool:
+        from plugins.dots.shadow_siphon import ShadowSiphon
+
         for member in allies:
             mgr = getattr(member, "effect_manager", None)
             if mgr is not None:
@@ -24,6 +29,8 @@ class Dark(DamageTypeBase):
 
         if not self._cleanup_registered:
             def _clear(_):
+                from plugins.dots.shadow_siphon import ShadowSiphon
+
                 for member in allies:
                     member.dots = [d for d in member.dots if d != ShadowSiphon.id]
                     mgr = getattr(member, "effect_manager", None)
@@ -52,6 +59,8 @@ class Dark(DamageTypeBase):
             # Preconditions: source must be Dark and the target must have Shadow Siphon.
             if getattr(attacker, "damage_type", None) is not self:
                 return damage
+            from plugins.dots.shadow_siphon import ShadowSiphon
+
             if ShadowSiphon.id not in getattr(target, "dots", []):
                 return damage
 
@@ -73,6 +82,8 @@ class Dark(DamageTypeBase):
         return damage
 
     def create_dot(self, damage: float, source) -> DamageOverTime | None:
+        from plugins.dots.abyssal_corruption import AbyssalCorruption
+
         dot = AbyssalCorruption(int(damage * 0.4), 3)
         dot.source = source
         return dot

--- a/backend/plugins/damage_types/fire.py
+++ b/backend/plugins/damage_types/fire.py
@@ -1,9 +1,12 @@
+from typing import TYPE_CHECKING
 from dataclasses import dataclass
 
 from autofighter.stats import Stats
 from autofighter.effects import DamageOverTime
-from plugins.dots.blazing_torment import BlazingTorment
 from plugins.damage_types._base import DamageTypeBase
+
+if TYPE_CHECKING:
+    from plugins.dots.blazing_torment import BlazingTorment
 
 
 @dataclass
@@ -13,6 +16,8 @@ class Fire(DamageTypeBase):
     color: tuple[int, int, int] = (255, 0, 0)
 
     def create_dot(self, damage: float, source) -> DamageOverTime | None:
+        from plugins.dots.blazing_torment import BlazingTorment
+
         dot = BlazingTorment(int(damage * 0.5), 3)
         dot.source = source
         return dot

--- a/backend/plugins/damage_types/ice.py
+++ b/backend/plugins/damage_types/ice.py
@@ -1,8 +1,11 @@
+from typing import TYPE_CHECKING
 from dataclasses import dataclass
 
 from autofighter.effects import DamageOverTime
-from plugins.dots.frozen_wound import FrozenWound
 from plugins.damage_types._base import DamageTypeBase
+
+if TYPE_CHECKING:
+    from plugins.dots.frozen_wound import FrozenWound
 
 
 @dataclass
@@ -12,6 +15,8 @@ class Ice(DamageTypeBase):
     color: tuple[int, int, int] = (0, 255, 255)
 
     def create_dot(self, damage: float, source) -> DamageOverTime | None:
+        from plugins.dots.frozen_wound import FrozenWound
+
         dot = FrozenWound(int(damage * 0.25), 3)
         dot.source = source
         return dot

--- a/backend/plugins/damage_types/light.py
+++ b/backend/plugins/damage_types/light.py
@@ -1,9 +1,12 @@
+from typing import TYPE_CHECKING
 from dataclasses import dataclass
 
 from autofighter.effects import DamageOverTime
-from plugins.dots.celestial_atrophy import CelestialAtrophy
 from plugins.damage_types._base import DamageTypeBase
-from plugins.hots.radiant_regeneration import RadiantRegeneration
+
+if TYPE_CHECKING:
+    from plugins.dots.celestial_atrophy import CelestialAtrophy
+    from plugins.hots.radiant_regeneration import RadiantRegeneration
 
 
 @dataclass
@@ -13,11 +16,15 @@ class Light(DamageTypeBase):
     color: tuple[int, int, int] = (255, 255, 255)
 
     def create_dot(self, damage: float, source) -> DamageOverTime | None:
+        from plugins.dots.celestial_atrophy import CelestialAtrophy
+
         dot = CelestialAtrophy(int(damage * 0.3), 3)
         dot.source = source
         return dot
 
     async def on_action(self, actor, allies, enemies):
+        from plugins.hots.radiant_regeneration import RadiantRegeneration
+
         for ally in allies:
             ally.effect_manager.add_hot(RadiantRegeneration())
         for ally in allies:

--- a/backend/plugins/damage_types/lightning.py
+++ b/backend/plugins/damage_types/lightning.py
@@ -1,9 +1,12 @@
 import asyncio
+from typing import TYPE_CHECKING
 from dataclasses import dataclass
 
 from autofighter.effects import DamageOverTime
-from plugins.dots.charged_decay import ChargedDecay
 from plugins.damage_types._base import DamageTypeBase
+
+if TYPE_CHECKING:
+    from plugins.dots.charged_decay import ChargedDecay
 
 
 @dataclass
@@ -13,6 +16,8 @@ class Lightning(DamageTypeBase):
     color: tuple[int, int, int] = (255, 255, 0)
 
     def create_dot(self, damage: float, source) -> DamageOverTime | None:
+        from plugins.dots.charged_decay import ChargedDecay
+
         dot = ChargedDecay(int(damage * 0.25), 3)
         dot.source = source
         return dot

--- a/backend/plugins/damage_types/wind.py
+++ b/backend/plugins/damage_types/wind.py
@@ -1,8 +1,11 @@
+from typing import TYPE_CHECKING
 from dataclasses import dataclass
 
 from autofighter.effects import DamageOverTime
-from plugins.dots.gale_erosion import GaleErosion
 from plugins.damage_types._base import DamageTypeBase
+
+if TYPE_CHECKING:
+    from plugins.dots.gale_erosion import GaleErosion
 
 
 @dataclass
@@ -12,6 +15,8 @@ class Wind(DamageTypeBase):
     color: tuple[int, int, int] = (0, 255, 0)
 
     def create_dot(self, damage: float, source) -> DamageOverTime | None:
+        from plugins.dots.gale_erosion import GaleErosion
+
         dot = GaleErosion(int(damage * 0.25), 3)
         dot.source = source
         return dot

--- a/backend/plugins/dots/abyssal_corruption.py
+++ b/backend/plugins/dots/abyssal_corruption.py
@@ -1,9 +1,12 @@
 from autofighter.effects import DamageOverTime
+from plugins.damage_types.dark import Dark
+from plugins.damage_types._base import DamageTypeBase
 
 
 class AbyssalCorruption(DamageOverTime):
     plugin_type = "dot"
     id = "abyssal_corruption"
+    damage_type: DamageTypeBase = Dark()
 
     def __init__(self, damage: int, turns: int) -> None:
         super().__init__("Abyssal Corruption", damage, turns, self.id)

--- a/backend/plugins/dots/abyssal_weakness.py
+++ b/backend/plugins/dots/abyssal_weakness.py
@@ -1,9 +1,12 @@
 from autofighter.effects import DamageOverTime
+from plugins.damage_types.dark import Dark
+from plugins.damage_types._base import DamageTypeBase
 
 
 class AbyssalWeakness(DamageOverTime):
     plugin_type = "dot"
     id = "abyssal_weakness"
+    damage_type: DamageTypeBase = Dark()
 
     def __init__(self, damage: int, turns: int) -> None:
         super().__init__("Abyssal Weakness", damage, turns, self.id)

--- a/backend/plugins/dots/blazing_torment.py
+++ b/backend/plugins/dots/blazing_torment.py
@@ -1,9 +1,12 @@
 from autofighter.effects import DamageOverTime
+from plugins.damage_types.fire import Fire
+from plugins.damage_types._base import DamageTypeBase
 
 
 class BlazingTorment(DamageOverTime):
     plugin_type = "dot"
     id = "blazing_torment"
+    damage_type: DamageTypeBase = Fire()
 
     def __init__(self, damage: int, turns: int) -> None:
         super().__init__("Blazing Torment", damage, turns, self.id)

--- a/backend/plugins/dots/bleed.py
+++ b/backend/plugins/dots/bleed.py
@@ -1,9 +1,12 @@
 from autofighter.effects import DamageOverTime
+from plugins.damage_types.generic import Generic
+from plugins.damage_types._base import DamageTypeBase
 
 
 class Bleed(DamageOverTime):
     plugin_type = "dot"
     id = "bleed"
+    damage_type: DamageTypeBase = Generic()
 
     def __init__(self, damage: int, turns: int) -> None:
         super().__init__("Bleed", damage, turns, self.id)

--- a/backend/plugins/dots/celestial_atrophy.py
+++ b/backend/plugins/dots/celestial_atrophy.py
@@ -1,9 +1,12 @@
 from autofighter.effects import DamageOverTime
+from plugins.damage_types.light import Light
+from plugins.damage_types._base import DamageTypeBase
 
 
 class CelestialAtrophy(DamageOverTime):
     plugin_type = "dot"
     id = "celestial_atrophy"
+    damage_type: DamageTypeBase = Light()
 
     def __init__(self, damage: int, turns: int) -> None:
         super().__init__("Celestial Atrophy", damage, turns, self.id)

--- a/backend/plugins/dots/charged_decay.py
+++ b/backend/plugins/dots/charged_decay.py
@@ -1,9 +1,12 @@
 from autofighter.effects import DamageOverTime
+from plugins.damage_types.lightning import Lightning
+from plugins.damage_types._base import DamageTypeBase
 
 
 class ChargedDecay(DamageOverTime):
     plugin_type = "dot"
     id = "charged_decay"
+    damage_type: DamageTypeBase = Lightning()
 
     def __init__(self, damage: int, turns: int) -> None:
         super().__init__("Charged Decay", damage, turns, self.id)

--- a/backend/plugins/dots/cold_wound.py
+++ b/backend/plugins/dots/cold_wound.py
@@ -1,9 +1,12 @@
 from autofighter.effects import DamageOverTime
+from plugins.damage_types.ice import Ice
+from plugins.damage_types._base import DamageTypeBase
 
 
 class ColdWound(DamageOverTime):
     plugin_type = "dot"
     id = "cold_wound"
+    damage_type: DamageTypeBase = Ice()
     max_stacks = 5
 
     def __init__(self, damage: int, turns: int) -> None:

--- a/backend/plugins/dots/frozen_wound.py
+++ b/backend/plugins/dots/frozen_wound.py
@@ -1,11 +1,14 @@
 import random
 
 from autofighter.effects import DamageOverTime
+from plugins.damage_types.ice import Ice
+from plugins.damage_types._base import DamageTypeBase
 
 
 class FrozenWound(DamageOverTime):
     plugin_type = "dot"
     id = "frozen_wound"
+    damage_type: DamageTypeBase = Ice()
 
     def __init__(self, damage: int, turns: int) -> None:
         super().__init__("Frozen Wound", damage, turns, self.id)

--- a/backend/plugins/dots/gale_erosion.py
+++ b/backend/plugins/dots/gale_erosion.py
@@ -1,9 +1,12 @@
 from autofighter.effects import DamageOverTime
+from plugins.damage_types.wind import Wind
+from plugins.damage_types._base import DamageTypeBase
 
 
 class GaleErosion(DamageOverTime):
     plugin_type = "dot"
     id = "gale_erosion"
+    damage_type: DamageTypeBase = Wind()
 
     def __init__(self, damage: int, turns: int) -> None:
         super().__init__("Gale Erosion", damage, turns, self.id)

--- a/backend/plugins/dots/impact_echo.py
+++ b/backend/plugins/dots/impact_echo.py
@@ -1,9 +1,12 @@
 from autofighter.effects import DamageOverTime
+from plugins.damage_types.generic import Generic
+from plugins.damage_types._base import DamageTypeBase
 
 
 class ImpactEcho(DamageOverTime):
     plugin_type = "dot"
     id = "impact_echo"
+    damage_type: DamageTypeBase = Generic()
 
     def __init__(self, turns: int = 3) -> None:
         super().__init__("Impact Echo", 0, turns, self.id)

--- a/backend/plugins/dots/poison.py
+++ b/backend/plugins/dots/poison.py
@@ -1,9 +1,12 @@
 from autofighter.effects import DamageOverTime
+from plugins.damage_types.generic import Generic
+from plugins.damage_types._base import DamageTypeBase
 
 
 class Poison(DamageOverTime):
     plugin_type = "dot"
     id = "poison"
+    damage_type: DamageTypeBase = Generic()
 
     def __init__(self, damage: int, turns: int) -> None:
         super().__init__("Poison", damage, turns, self.id)

--- a/backend/plugins/dots/shadow_siphon.py
+++ b/backend/plugins/dots/shadow_siphon.py
@@ -1,9 +1,12 @@
 from autofighter.effects import DamageOverTime
+from plugins.damage_types.dark import Dark
+from plugins.damage_types._base import DamageTypeBase
 
 
 class ShadowSiphon(DamageOverTime):
     plugin_type = "dot"
     id = "shadow_siphon"
+    damage_type: DamageTypeBase = Dark()
 
     def __init__(self, damage: int) -> None:
         super().__init__("Shadow Siphon", damage, 1, self.id)

--- a/backend/plugins/dots/twilight_decay.py
+++ b/backend/plugins/dots/twilight_decay.py
@@ -1,9 +1,12 @@
 from autofighter.effects import DamageOverTime
+from plugins.damage_types.generic import Generic
+from plugins.damage_types._base import DamageTypeBase
 
 
 class TwilightDecay(DamageOverTime):
     plugin_type = "dot"
     id = "twilight_decay"
+    damage_type: DamageTypeBase = Generic()
 
     def __init__(self, damage: int, turns: int) -> None:
         super().__init__("Twilight Decay", damage, turns, self.id)

--- a/backend/plugins/hots/player_echo.py
+++ b/backend/plugins/hots/player_echo.py
@@ -1,9 +1,12 @@
 from autofighter.effects import HealingOverTime
+from plugins.damage_types.generic import Generic
+from plugins.damage_types._base import DamageTypeBase
 
 
 class PlayerEcho(HealingOverTime):
     plugin_type = "hot"
     id = "player_echo"
+    damage_type: DamageTypeBase = Generic()
 
     def __init__(self, player_name: str, healing: int, turns: int) -> None:
         super().__init__(f"{player_name}'s Echo", healing, turns, self.id)

--- a/backend/plugins/hots/player_heal.py
+++ b/backend/plugins/hots/player_heal.py
@@ -1,9 +1,12 @@
 from autofighter.effects import HealingOverTime
+from plugins.damage_types.generic import Generic
+from plugins.damage_types._base import DamageTypeBase
 
 
 class PlayerHeal(HealingOverTime):
     plugin_type = "hot"
     id = "player_heal"
+    damage_type: DamageTypeBase = Generic()
 
     def __init__(self, player_name: str, healing: int, turns: int) -> None:
         super().__init__(f"{player_name}'s Heal", healing, turns, self.id)

--- a/backend/plugins/hots/radiant_regeneration.py
+++ b/backend/plugins/hots/radiant_regeneration.py
@@ -1,10 +1,13 @@
 from autofighter.effects import HealingOverTime
+from plugins.damage_types.light import Light
+from plugins.damage_types._base import DamageTypeBase
 
 
 class RadiantRegeneration(HealingOverTime):
     plugin_type = "hot"
     # Include element in the id so frontends can infer visuals without extra metadata
     id = "light_radiant_regeneration"
+    damage_type: DamageTypeBase = Light()
 
     def __init__(self, healing: int = 5, turns: int = 2) -> None:
         super().__init__("Radiant Regeneration", healing, turns, self.id)

--- a/backend/plugins/hots/regeneration.py
+++ b/backend/plugins/hots/regeneration.py
@@ -1,9 +1,12 @@
 from autofighter.effects import HealingOverTime
+from plugins.damage_types.generic import Generic
+from plugins.damage_types._base import DamageTypeBase
 
 
 class Regeneration(HealingOverTime):
     plugin_type = "hot"
     id = "regeneration"
+    damage_type: DamageTypeBase = Generic()
 
     def __init__(self, healing: int, turns: int) -> None:
         super().__init__("Regeneration", healing, turns, self.id)


### PR DESCRIPTION
## Summary
- ensure DamageOverTime and HealingOverTime ticks use an effect's own element
- assign explicit damage types to all DoT and HoT plugins
- lazy-load damage type hooks to avoid circular imports

## Testing
- [ ] Backend tests
- [ ] Frontend tests
- [ ] Linting
- [ ] Doc sync updates (README and `.codex/implementation` docs; link tasks below)


------
https://chatgpt.com/codex/tasks/task_b_68ab5b7962e8832ca6d3360468f8fbc1