### PR TITLE
[FEAT] add error overlay

### DIFF
--- a/frontend/.codex/implementation/error-overlay.md
+++ b/frontend/.codex/implementation/error-overlay.md
@@ -1,0 +1,6 @@
+# Error Overlay
+
+`src/lib/ErrorOverlay.svelte` wraps `PopupWindow.svelte` to present API or runtime errors.
+The overlay shows the error message and server traceback in a `pre` block and includes a
+"Report Issue" button that opens a new GitHub issue using the `FEEDBACK_URL` constant.
+It is opened via `openOverlay('error', { message, traceback })`.

--- a/frontend/src/lib/ErrorOverlay.svelte
+++ b/frontend/src/lib/ErrorOverlay.svelte
@@ -1,0 +1,63 @@
+<script>
+  import { createEventDispatcher } from 'svelte';
+  import PopupWindow from './PopupWindow.svelte';
+  import { FEEDBACK_URL } from './constants.js';
+
+  export let message = '';
+  export let traceback = '';
+
+  const dispatch = createEventDispatcher();
+  let reportUrl = '';
+
+  $: reportUrl = `${FEEDBACK_URL}?title=${encodeURIComponent(message)}&body=${encodeURIComponent('```\n' + traceback + '\n```')}`;
+
+  function report() {
+    window.open(reportUrl, '_blank', 'noopener');
+  }
+
+  function close() {
+    dispatch('close');
+  }
+</script>
+
+<PopupWindow title="Error" on:close={close}>
+  <div style="padding: 0.5rem 0.25rem; line-height: 1.4;">
+    <pre>{message}\n{traceback}</pre>
+    <div class="stained-glass-row" style="justify-content: flex-end; margin-top: 0.75rem;">
+      <button class="icon-btn" on:click={report}>Report Issue</button>
+      <button class="icon-btn" on:click={close}>Close</button>
+    </div>
+  </div>
+</PopupWindow>
+
+<style>
+  .stained-glass-row {
+    display: flex;
+    gap: 0.5rem;
+    justify-content: flex-end;
+    margin-top: 0.5rem;
+    padding: 0.5rem 0.7rem;
+    background: var(--glass-bg);
+    box-shadow: var(--glass-shadow);
+    border: var(--glass-border);
+    backdrop-filter: var(--glass-filter);
+  }
+
+  .icon-btn {
+    background: rgba(255,255,255,0.10);
+    border: none;
+    border-radius: 0;
+    color: #fff;
+    padding: 0.35rem 0.6rem;
+    cursor: pointer;
+  }
+
+  pre {
+    white-space: pre-wrap;
+    max-height: 60vh;
+    overflow: auto;
+    background: rgba(0,0,0,0.5);
+    padding: 0.5rem;
+    margin: 0;
+  }
+</style>

--- a/frontend/src/lib/OverlayController.js
+++ b/frontend/src/lib/OverlayController.js
@@ -4,18 +4,23 @@
 import { writable, get } from 'svelte/store';
 
 export const overlayView = writable('main');
+export const overlayData = writable({});
 const stack = [];
 
-export function openOverlay(view) {
-  stack.push(get(overlayView));
+export function openOverlay(view, data = {}) {
+  stack.push({ view: get(overlayView), data: get(overlayData) });
   overlayView.set(view);
+  overlayData.set(data);
 }
 
 export function backOverlay() {
-  overlayView.set(stack.pop() || 'main');
+  const prev = stack.pop() || { view: 'main', data: {} };
+  overlayView.set(prev.view);
+  overlayData.set(prev.data);
 }
 
 export function homeOverlay() {
   stack.length = 0;
   overlayView.set('main');
+  overlayData.set({});
 }

--- a/frontend/src/lib/OverlayHost.svelte
+++ b/frontend/src/lib/OverlayHost.svelte
@@ -4,7 +4,7 @@
   and forwards user actions to the parent GameViewport.
 -->
 <script>
-  import { overlayView } from './OverlayController.js';
+  import { overlayView, overlayData } from './OverlayController.js';
   import { createEventDispatcher } from 'svelte';
   import OverlaySurface from './OverlaySurface.svelte';
   import PopupWindow from './PopupWindow.svelte';
@@ -18,6 +18,7 @@
   import ShopMenu from './ShopMenu.svelte';
   import RestRoom from './RestRoom.svelte';
   import BattleView from './BattleView.svelte';
+  import ErrorOverlay from './ErrorOverlay.svelte';
   import { rewardOpen as computeRewardOpen } from './viewportState.js';
 
   export let selected = [];
@@ -57,6 +58,14 @@
       </div>
     </div>
   </PopupWindow>
+{/if}
+
+{#if $overlayView === 'error'}
+  <ErrorOverlay
+    message={$overlayData.message || 'An unexpected error occurred.'}
+    traceback={$overlayData.traceback || ''}
+    on:close={() => dispatch('back')}
+  />
 {/if}
 
 {#if $overlayView === 'party-start'}

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -1,82 +1,103 @@
+import { openOverlay } from './OverlayController.js';
+
 const API_BASE = import.meta.env.VITE_API_BASE || 'http://localhost:59002';
 
+async function handleFetch(url, options = {}, parser = (r) => r.json()) {
+  try {
+    const res = await fetch(url, options);
+    if (!res.ok) {
+      let data;
+      try { data = await res.json(); } catch {}
+      const message = data?.message || `HTTP error ${res.status}`;
+      const traceback = data?.traceback || '';
+      openOverlay('error', { message, traceback });
+      const err = new Error(message);
+      err.overlayShown = true;
+      throw err;
+    }
+    return await parser(res);
+  } catch (e) {
+    if (!e.overlayShown) {
+      openOverlay('error', { message: e.message, traceback: e.stack || '' });
+    }
+    throw e;
+  }
+}
+
 export async function getBackendFlavor() {
-  const res = await fetch(`${API_BASE}/`, { cache: 'no-store' });
-  const data = await res.json();
+  const data = await handleFetch(`${API_BASE}/`, { cache: 'no-store' });
   return data.flavor;
 }
 
 export async function getPlayers() {
-  const res = await fetch(`${API_BASE}/players`, { cache: 'no-store' });
-  return res.json();
+  return handleFetch(`${API_BASE}/players`, { cache: 'no-store' });
 }
 
 export async function getGacha() {
-  const res = await fetch(`${API_BASE}/gacha`, { cache: 'no-store' });
-  return res.json();
+  return handleFetch(`${API_BASE}/gacha`, { cache: 'no-store' });
 }
 
 export async function pullGacha(count = 1) {
-  const res = await fetch(`${API_BASE}/gacha/pull`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ count })
-  });
-  if (!res.ok) throw new Error(`HTTP error ${res.status}`);
-  return res.json();
+  return handleFetch(
+    `${API_BASE}/gacha/pull`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ count })
+    }
+  );
 }
 
 export async function setAutoCraft(enabled) {
-  const res = await fetch(`${API_BASE}/gacha/auto-craft`, {
+  return handleFetch(`${API_BASE}/gacha/auto-craft`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ enabled })
   });
-  return res.json();
 }
 
 export async function craftItems() {
-  const res = await fetch(`${API_BASE}/gacha/craft`, {
+  return handleFetch(`${API_BASE}/gacha/craft`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' }
   });
-  return res.json();
 }
 
 export async function getPlayerConfig() {
-  const res = await fetch(`${API_BASE}/player/editor`, { cache: 'no-store' });
-  return res.json();
+  return handleFetch(`${API_BASE}/player/editor`, { cache: 'no-store' });
 }
 
 export async function savePlayerConfig(config) {
-  const res = await fetch(`${API_BASE}/player/editor`, {
+  return handleFetch(`${API_BASE}/player/editor`, {
     method: 'PUT',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(config)
   });
-  return res.json();
 }
 
 export async function endRun(runId) {
-  const res = await fetch(`${API_BASE}/run/${runId}`, { method: 'DELETE' });
-  return res.ok;
+  return handleFetch(
+    `${API_BASE}/run/${runId}`,
+    { method: 'DELETE' },
+    (r) => r.ok
+  );
 }
 
 export async function wipeData() {
-  const res = await fetch(`${API_BASE}/save/wipe`, { method: 'POST' });
-  if (!res.ok) throw new Error(`HTTP error ${res.status}`);
-  return res.json();
+  return handleFetch(`${API_BASE}/save/wipe`, { method: 'POST' });
 }
 
 export async function exportSave() {
-  const res = await fetch(`${API_BASE}/save/backup`, { cache: 'no-store' });
-  return res.blob();
+  return handleFetch(
+    `${API_BASE}/save/backup`,
+    { cache: 'no-store' },
+    (r) => r.blob()
+  );
 }
 
 export async function importSave(file) {
-  const res = await fetch(`${API_BASE}/save/restore`, {
+  return handleFetch(`${API_BASE}/save/restore`, {
     method: 'POST',
     body: await file.arrayBuffer()
   });
-  return res.json();
 }

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -513,5 +513,6 @@
     on:nextRoom={handleNextRoom}
     on:endRun={handleRunEnd}
     on:saveParty={handlePartySave}
+    on:error={(e) => openOverlay('error', e.detail)}
   />
 </div>

--- a/frontend/tests/erroroverlay.test.js
+++ b/frontend/tests/erroroverlay.test.js
@@ -1,0 +1,25 @@
+import { describe, expect, test, mock } from 'bun:test';
+import { getPlayers } from '../src/lib/api.js';
+import { overlayView, overlayData, homeOverlay } from '../src/lib/OverlayController.js';
+import { get } from 'svelte/store';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { FEEDBACK_URL } from '../src/lib/constants.js';
+
+describe('Error overlay', () => {
+  test('opens when fetch fails', async () => {
+    homeOverlay();
+    const payload = { message: 'Boom', traceback: 'stack trace' };
+    global.fetch = mock(async () => ({ ok: false, status: 500, json: async () => payload }));
+    await expect(getPlayers()).rejects.toThrow('Boom');
+    expect(get(overlayView)).toBe('error');
+    expect(get(overlayData)).toEqual(payload);
+  });
+
+  test('report button uses feedback url', () => {
+    const content = readFileSync(join(import.meta.dir, '../src/lib/ErrorOverlay.svelte'), 'utf8');
+    expect(content).toContain('Report Issue');
+    expect(content).toContain('FEEDBACK_URL');
+    expect(FEEDBACK_URL).toBe('https://github.com/Midori-AI-OSS/Midori-AI-AutoFighter/issues/new');
+  });
+});


### PR DESCRIPTION
## Summary
- add reusable error overlay with GitHub report link
- open overlay on API failure and wire through controller and host
- cover error overlay via regression test

## Testing
- [ ] Backend tests
- [x] Frontend tests
- [ ] Linting
- [x] Doc sync updates (README and `.codex/implementation` docs; link tasks below)

## Checklist
- [ ] Linked or updated relevant `.codex/tasks` entries
- [ ] Updated player roster and foe docs if adding or modifying fighters or enemies

------
https://chatgpt.com/codex/tasks/task_b_68ab5bba84c0832c8accb245b1e7b88e