### PR TITLE
Allow stat redirection for level-ups and effects

### DIFF
--- a/.codex/implementation/player-foe-reference.md
+++ b/.codex/implementation/player-foe-reference.md
@@ -19,7 +19,7 @@ to support future character-specific prompts.
 - **Ally** (B, random) – applies `ally_passive` on load to grant ally-specific bonuses.
 - **Becca** (B, random) – builds high attack but takes more damage from lower defense.
 - **Bubbles** (A, random) – starts with a default item and applies `bubbles_passive`.
-- **Carly** (B, Light) – applies `carly_passive`.
+- **Carly** (B, Light) – applies `carly_passive` and converts attack gains into defense.
 - **Chibi** (A, random) – gains four times the normal benefit from Vitality.
 - **Graygray** (B, random) – applies `graygray_passive`.
 - **Hilander** (A, random) – builds increased crit rate and crit damage.

--- a/.codex/implementation/stats-and-effects.md
+++ b/.codex/implementation/stats-and-effects.md
@@ -23,6 +23,12 @@ Experience feeds into `exp` and triggers a level-up when it meets or exceeds
 normal rate to accelerate early progression. Level-ups increase core stats but
 no longer restore HP, preserving damage taken.
 
+Direct stat adjustments route through `adjust_stat_on_gain` and
+`adjust_stat_on_loss`. These helpers make it possible for subclasses to
+redirect bonuses or penalties to different attributes. `_on_level_up` iterates
+through a `level_up_gains` map so plugins can remap growth by overriding the
+dictionary or the adjust methods themselves.
+
 `apply_damage()` and `apply_healing()` update `hp`, fire damage and healing hooks on the attacker and target damage types, and emit
 global `damage_taken`, `damage_dealt`, `heal_received`, and `heal` events on the repository-wide event bus. Fire's `on_damage` hook multiplies outgoing damage by `1 + (1 - hp/max_hp)`, doubling attacks at zero HP.
 

--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ Pygame version:
 - Ally (B, random damage type)
 - Becca (B, random damage type)
 - Bubbles (A, random damage type)
-- Carly (B, Light)
+- Carly (B, Light) – converts attack growth into defense
 - Chibi (A, Lightning)
 - Graygray (B, random damage type)
 - Hilander (A, random damage type)

--- a/backend/autofighter/stats.py
+++ b/backend/autofighter/stats.py
@@ -46,6 +46,18 @@ class Stats:
     dots: list[str] = field(default_factory=list)
     hots: list[str] = field(default_factory=list)
 
+    level_up_gains: dict[str, int] = field(
+        default_factory=lambda: {"max_hp": 10, "atk": 5, "defense": 3}
+    )
+
+    def adjust_stat_on_gain(self, stat_name: str, amount: int) -> None:
+        current = getattr(self, stat_name, 0)
+        setattr(self, stat_name, current + amount)
+
+    def adjust_stat_on_loss(self, stat_name: str, amount: int) -> None:
+        current = getattr(self, stat_name, 0)
+        setattr(self, stat_name, current - amount)
+
     @property
     def element_id(self) -> str:
         dt = getattr(self, "damage_type", Generic())
@@ -74,10 +86,9 @@ class Stats:
             if isinstance(value, (int, float)):
                 new_val = value * (1 + inc)
                 setattr(self, f.name, type(value)(new_val))
-        self.max_hp += 10 * self.level
+        for stat, base in self.level_up_gains.items():
+            self.adjust_stat_on_gain(stat, base * self.level)
         self.hp = self.max_hp
-        self.atk += 5 * self.level
-        self.defense += 3 * self.level
 
     def gain_exp(self, amount: int) -> None:
         if self.level < 1000:

--- a/backend/plugins/dots/abyssal_weakness.py
+++ b/backend/plugins/dots/abyssal_weakness.py
@@ -11,9 +11,10 @@ class AbyssalWeakness(DamageOverTime):
 
     def tick(self, target, *_):
         if not self._applied:
-            target.defense = max(target.defense - 1, 0)
+            target.adjust_stat_on_loss("defense", 1)
+            target.defense = max(target.defense, 0)
             self._applied = True
         alive = super().tick(target)
         if not alive:
-            target.defense += 1
+            target.adjust_stat_on_gain("defense", 1)
         return alive

--- a/backend/plugins/foes/_base.py
+++ b/backend/plugins/foes/_base.py
@@ -49,6 +49,17 @@ class FoeBase(Stats):
     dots: list[str] = field(default_factory=list)
     hots: list[str] = field(default_factory=list)
 
+    stat_gain_map: dict[str, str] = field(default_factory=dict)
+    stat_loss_map: dict[str, str] = field(default_factory=dict)
+
+    def adjust_stat_on_gain(self, stat_name: str, amount: int) -> None:
+        target = self.stat_gain_map.get(stat_name, stat_name)
+        super().adjust_stat_on_gain(target, amount)
+
+    def adjust_stat_on_loss(self, stat_name: str, amount: int) -> None:
+        target = self.stat_loss_map.get(stat_name, stat_name)
+        super().adjust_stat_on_loss(target, amount)
+
     async def maybe_regain(self, turn: int) -> None:  # noqa: D401
         """Regain a fraction of HP every other turn."""
         if turn % 2 != 0:
@@ -61,5 +72,5 @@ class FoeBase(Stats):
     def _on_level_up(self) -> None:  # noqa: D401
         """Apply base bonuses then boost mitigation and vitality."""
         super()._on_level_up()
-        self.mitigation += 0.0001
-        self.vitality += 0.0001
+        self.adjust_stat_on_gain("mitigation", 0.0001)
+        self.adjust_stat_on_gain("vitality", 0.0001)

--- a/backend/plugins/passives/attack_up.py
+++ b/backend/plugins/passives/attack_up.py
@@ -10,4 +10,4 @@ class AttackUp:
     amount = 5
 
     def apply(self, target) -> None:
-        target.atk += self.amount
+        target.adjust_stat_on_gain("atk", self.amount)

--- a/backend/plugins/players/_base.py
+++ b/backend/plugins/players/_base.py
@@ -47,3 +47,14 @@ class PlayerBase(Stats):
     dots: list[str] = field(default_factory=list)
     hots: list[str] = field(default_factory=list)
 
+    stat_gain_map: dict[str, str] = field(default_factory=dict)
+    stat_loss_map: dict[str, str] = field(default_factory=dict)
+
+    def adjust_stat_on_gain(self, stat_name: str, amount: int) -> None:
+        target = self.stat_gain_map.get(stat_name, stat_name)
+        super().adjust_stat_on_gain(target, amount)
+
+    def adjust_stat_on_loss(self, stat_name: str, amount: int) -> None:
+        target = self.stat_loss_map.get(stat_name, stat_name)
+        super().adjust_stat_on_loss(target, amount)
+

--- a/backend/plugins/players/carly.py
+++ b/backend/plugins/players/carly.py
@@ -13,4 +13,7 @@ class Carly(PlayerBase):
     char_type = CharacterType.B
     gacha_rarity = 5
     damage_type: DamageTypeBase = field(default_factory=Light)
+    stat_gain_map: dict[str, str] = field(
+        default_factory=lambda: {"atk": "defense"}
+    )
 

--- a/backend/plugins/relics/killer_instinct.py
+++ b/backend/plugins/relics/killer_instinct.py
@@ -23,7 +23,7 @@ class KillerInstinct(RelicBase):
 
         def _ultimate(user) -> None:
             bonus = int(user.atk * 0.75)
-            user.atk += bonus
+            user.adjust_stat_on_gain("atk", bonus)
             buffs[id(user)] = (user, bonus)
 
         def _damage(target, attacker, amount) -> None:
@@ -32,7 +32,7 @@ class KillerInstinct(RelicBase):
 
         def _turn_end() -> None:
             for _, (member, bonus) in list(buffs.items()):
-                member.atk -= bonus
+                member.adjust_stat_on_loss("atk", bonus)
             buffs.clear()
 
         BUS.subscribe("ultimate_used", _ultimate)

--- a/backend/plugins/relics/soul_prism.py
+++ b/backend/plugins/relics/soul_prism.py
@@ -36,8 +36,10 @@ class SoulPrism(RelicBase):
                 member._soul_prism_hp = base
                 member.max_hp = int(base * multiplier)
                 member.hp = max(1, int(member.max_hp * 0.01))
-                member.defense = int(member.defense * (1 + buff))
-                member.mitigation *= 1 + buff
+                new_def = int(member.defense * (1 + buff))
+                member.adjust_stat_on_gain("defense", new_def - member.defense)
+                new_mit = member.mitigation * (1 + buff)
+                member.adjust_stat_on_gain("mitigation", new_mit - member.mitigation)
 
         BUS.subscribe("battle_end", _battle_end)
 

--- a/backend/plugins/relics/travelers_charm.py
+++ b/backend/plugins/relics/travelers_charm.py
@@ -36,15 +36,15 @@ class TravelersCharm(RelicBase):
                 member = next((m for m in party.members if id(m) == pid), None)
                 if member is None:
                     continue
-                member.defense += bdef
-                member.mitigation += bmit
+                member.adjust_stat_on_gain("defense", bdef)
+                member.adjust_stat_on_gain("mitigation", bmit)
                 active[pid] = (member, bdef, bmit)
             pending.clear()
 
         def _turn_end() -> None:
             for pid, (member, bdef, bmit) in list(active.items()):
-                member.defense -= bdef
-                member.mitigation -= bmit
+                member.adjust_stat_on_loss("defense", bdef)
+                member.adjust_stat_on_loss("mitigation", bmit)
             active.clear()
 
         BUS.subscribe("damage_taken", _hit)

--- a/backend/tests/test_stat_redirect.py
+++ b/backend/tests/test_stat_redirect.py
@@ -1,0 +1,20 @@
+from dataclasses import dataclass
+from dataclasses import field
+
+from plugins.players._base import PlayerBase
+
+
+@dataclass
+class RedirectPlayer(PlayerBase):
+    stat_gain_map: dict[str, str] = field(
+        default_factory=lambda: {"atk": "defense"}
+    )
+
+
+def test_adjust_redirects_attack_to_defense():
+    p = RedirectPlayer()
+    base_atk = p.atk
+    base_def = p.defense
+    p.adjust_stat_on_gain("atk", 5)
+    assert p.atk == base_atk
+    assert p.defense == base_def + 5


### PR DESCRIPTION
## Summary
- add adjust_stat_on_gain/adjust_stat_on_loss and level_up_gains map in Stats
- enable stat redirection via stat_gain_map/stat_loss_map for players and foes, with Carly redirecting attack gains to defense
- update relics, passives, and docs to use new stat adjustment helpers and document behavior

## Testing
- `./run-tests.sh` *(fails: backend tests/test_card_rewards.py, backend tests/test_enrage_stacking.py, backend tests/test_exp_leveling.py, backend tests/test_party_endpoint.py, backend tests/test_party_persistence.py, backend tests/test_player_editor.py, backend tests/test_random_player_foes.py, backend tests/test_save_management.py, backend tests/test_shadow_siphon.py, backend tests/test_stat_redirect.py; timed out: backend tests/test_app.py, backend tests/test_damage_type_on_action.py, backend tests/test_gacha.py, backend tests/test_rdr.py, backend tests/test_relic_rewards.py)*
- `uvx ruff check backend` *(fails: F841 Local variable `start` is assigned to but never used; F401 unused imports in backend/routes/runs.py)*
- `uv run pytest tests/test_stat_redirect.py`

------
https://chatgpt.com/codex/tasks/task_b_68ab5b8b262c832ca7dc5f5b7090a842