### PR TITLE
[LOG] add plugin debug logging

### DIFF
--- a/backend/plugins/cards/_base.py
+++ b/backend/plugins/cards/_base.py
@@ -1,7 +1,12 @@
+import logging
+
 from dataclasses import dataclass
 from dataclasses import field
 
 from autofighter.party import Party
+
+
+log = logging.getLogger(__name__)
 
 
 @dataclass
@@ -24,14 +29,25 @@ class CardBase:
             self.about = ", ".join(parts)
 
     def apply(self, party: Party) -> None:
+        log.info("Applying card %s to party", self.id)
         for member in party.members:
+            log.debug("Applying effects to %s", getattr(member, "id", "member"))
             for attr, pct in self.effects.items():
                 if attr == "max_hp":
                     member.max_hp = type(member.max_hp)(member.max_hp * (1 + pct))
                     member.hp = type(member.hp)(member.hp * (1 + pct))
+                    log.debug(
+                        "Updated %s max_hp and hp", getattr(member, "id", "member")
+                    )
                 else:
                     value = getattr(member, attr, None)
                     if value is None:
                         continue
                     new_value = type(value)(value * (1 + pct))
                     setattr(member, attr, new_value)
+                    log.debug(
+                        "Updated %s %s to %s",
+                        getattr(member, "id", "member"),
+                        attr,
+                        new_value,
+                    )

--- a/backend/plugins/damage_effects.py
+++ b/backend/plugins/damage_effects.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import logging
+
 from typing import Callable, Dict, Optional
 
 from autofighter.effects import DamageOverTime, HealingOverTime
@@ -13,7 +15,11 @@ from plugins.dots.shadow_siphon import ShadowSiphon
 from plugins.hots.radiant_regeneration import RadiantRegeneration
 
 
+log = logging.getLogger(__name__)
+
+
 def _set_source(effect: DamageOverTime | HealingOverTime, source) -> object:
+    log.debug("Setting source %s on effect %s", source, effect.id)
     effect.source = source
     return effect
 
@@ -36,19 +42,23 @@ SHADOW_SIPHON_ID = ShadowSiphon.id
 
 
 def create_shadow_siphon(damage: int, source) -> DamageOverTime:
+    log.info("Creating Shadow Siphon with %s damage", damage)
     return _set_source(ShadowSiphon(damage), source)
 
 
 def create_dot(damage_type: str, damage: float, source) -> Optional[DamageOverTime]:
+    log.debug("Creating DoT for type %s with damage %s", damage_type, damage)
     factory = DOT_FACTORIES.get(damage_type)
     if factory is None:
+        log.debug("No DoT factory for type %s", damage_type)
         return None
     return factory(damage, source)
 
 
 def create_hot(damage_type: str, source) -> Optional[HealingOverTime]:
+    log.debug("Creating HoT for type %s", damage_type)
     factory = HOT_FACTORIES.get(damage_type)
     if factory is None:
+        log.debug("No HoT factory for type %s", damage_type)
         return None
     return factory(source)
-

--- a/backend/plugins/damage_types/_base.py
+++ b/backend/plugins/damage_types/_base.py
@@ -1,12 +1,17 @@
 from __future__ import annotations
 
+import logging
+
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 from typing import Optional
-from dataclasses import dataclass
 
 if TYPE_CHECKING:
     from autofighter.stats import Stats
     from autofighter.effects import DamageOverTime
+
+
+log = logging.getLogger(__name__)
 
 
 @dataclass
@@ -26,6 +31,12 @@ class DamageTypeBase:
         return type_check == self.id or self.id == "Generic"
 
     def damage_mod(self, incoming_damage: float, incoming_type: str) -> float:
+        log.debug(
+            "%s modifying damage %s from %s",
+            self.id,
+            incoming_damage,
+            incoming_type,
+        )
         if self.is_weak(incoming_type):
             return incoming_damage * 1.25
         if self.is_resistance(incoming_type):
@@ -46,15 +57,18 @@ class DamageTypeBase:
 
     def on_hit(self, attacker: Stats, target: Stats) -> None:
         """Called when ``attacker`` successfully hits ``target``."""
+        log.debug("%s hit %s", attacker.id, target.id)
 
     def on_damage(self, damage: float, attacker: Stats, target: Stats) -> float:
         """Called before damage is applied; return the modified ``damage``."""
 
+        log.debug("%s on_damage %s -> %s", attacker.id, target.id, damage)
         return damage
 
     def on_damage_taken(self, damage: float, attacker: Stats, target: Stats) -> float:
         """Called when ``target`` takes damage; return the modified ``damage``."""
 
+        log.debug("%s on_damage_taken %s -> %s", attacker.id, target.id, damage)
         return damage
 
     def on_dot_damage_taken(
@@ -62,6 +76,7 @@ class DamageTypeBase:
     ) -> float:
         """Called when ``target`` takes DoT damage; return the modified ``damage``."""
 
+        log.debug("%s on_dot_damage_taken %s -> %s", attacker.id, target.id, damage)
         return damage
 
     def on_party_damage_taken(
@@ -69,6 +84,7 @@ class DamageTypeBase:
     ) -> float:
         """Called when a party member takes damage; return the modified ``damage``."""
 
+        log.debug("%s on_party_damage_taken %s -> %s", attacker.id, target.id, damage)
         return damage
 
     def on_party_dot_damage_taken(
@@ -76,31 +92,35 @@ class DamageTypeBase:
     ) -> float:
         """Called when a party member takes DoT damage; return the modified ``damage``."""
 
+        log.debug(
+            "%s on_party_dot_damage_taken %s -> %s", attacker.id, target.id, damage
+        )
         return damage
 
     def on_death(self, attacker: Stats, target: Stats) -> None:
         """Called when ``target`` dies."""
+        log.info("%s killed %s", attacker.id, target.id)
 
     def on_party_member_death(self, attacker: Stats, target: Stats) -> None:
         """Called when a party member dies."""
+        log.info("Party member %s died to %s", target.id, attacker.id)
 
     def on_heal(self, heal: float, healer: Stats, target: Stats) -> float:
         """Called before healing is applied; return the modified ``heal``."""
 
+        log.debug("%s on_heal %s -> %s", healer.id, target.id, heal)
         return heal
 
-    def on_heal_received(
-        self, heal: float, healer: Stats, target: Stats
-    ) -> float:
+    def on_heal_received(self, heal: float, healer: Stats, target: Stats) -> float:
         """Called when ``target`` is healed; return the modified ``heal``."""
 
+        log.debug("%s on_heal_received %s -> %s", healer.id, target.id, heal)
         return heal
 
-    def on_hot_heal_received(
-        self, heal: float, healer: Stats, target: Stats
-    ) -> float:
+    def on_hot_heal_received(self, heal: float, healer: Stats, target: Stats) -> float:
         """Called when ``target`` receives HoT healing; return the modified ``heal``."""
 
+        log.debug("%s on_hot_heal_received %s -> %s", healer.id, target.id, heal)
         return heal
 
     def on_party_heal_received(
@@ -108,6 +128,7 @@ class DamageTypeBase:
     ) -> float:
         """Called when a party member is healed; return the modified ``heal``."""
 
+        log.debug("%s on_party_heal_received %s -> %s", healer.id, target.id, heal)
         return heal
 
     def on_party_hot_heal_received(
@@ -115,11 +136,11 @@ class DamageTypeBase:
     ) -> float:
         """Called when a party member receives HoT healing; return the modified ``heal``."""
 
+        log.debug("%s on_party_hot_heal_received %s -> %s", healer.id, target.id, heal)
         return heal
 
-    def create_dot(
-        self, damage: float, source: Stats
-    ) -> Optional["DamageOverTime"]:
+    def create_dot(self, damage: float, source: Stats) -> Optional["DamageOverTime"]:
         """Return a DoT effect based on ``damage`` or ``None`` to skip."""
 
+        log.debug("%s create_dot %s", self.id, damage)
         return None

--- a/backend/plugins/foes/_base.py
+++ b/backend/plugins/foes/_base.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import logging
+
 from dataclasses import dataclass
 from dataclasses import field
 
@@ -7,6 +9,9 @@ from autofighter.stats import Stats
 from autofighter.character import CharacterType
 from plugins.damage_types import random_damage_type
 from plugins.damage_types._base import DamageTypeBase
+
+
+log = logging.getLogger(__name__)
 
 
 @dataclass
@@ -54,10 +59,22 @@ class FoeBase(Stats):
 
     def adjust_stat_on_gain(self, stat_name: str, amount: int) -> None:
         target = self.stat_gain_map.get(stat_name, stat_name)
+        log.debug(
+            "%s gaining %s: %s",
+            getattr(self, "id", type(self).__name__),
+            target,
+            amount,
+        )
         super().adjust_stat_on_gain(target, amount)
 
     def adjust_stat_on_loss(self, stat_name: str, amount: int) -> None:
         target = self.stat_loss_map.get(stat_name, stat_name)
+        log.debug(
+            "%s losing %s: %s",
+            getattr(self, "id", type(self).__name__),
+            target,
+            amount,
+        )
         super().adjust_stat_on_loss(target, amount)
 
     async def maybe_regain(self, turn: int) -> None:  # noqa: D401
@@ -67,10 +84,21 @@ class FoeBase(Stats):
         bonus = max(self.regain - 100, 0) * 0.00005
         percent = (0.01 + bonus) / 100
         heal = int(self.max_hp * percent)
+        log.debug(
+            "%s regains %s HP on turn %s",
+            getattr(self, "id", type(self).__name__),
+            heal,
+            turn,
+        )
         await self.apply_healing(heal)
 
     def _on_level_up(self) -> None:  # noqa: D401
         """Apply base bonuses then boost mitigation and vitality."""
+        log.info(
+            "%s leveled up to %s",
+            getattr(self, "id", type(self).__name__),
+            self.level + 1,
+        )
         super()._on_level_up()
         self.adjust_stat_on_gain("mitigation", 0.0001)
         self.adjust_stat_on_gain("vitality", 0.0001)

--- a/backend/plugins/players/_base.py
+++ b/backend/plugins/players/_base.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import logging
+
 from dataclasses import dataclass
 from dataclasses import field
 
@@ -7,6 +9,10 @@ from autofighter.stats import Stats
 from autofighter.character import CharacterType
 from plugins.damage_types import random_damage_type
 from plugins.damage_types._base import DamageTypeBase
+
+
+log = logging.getLogger(__name__)
+
 
 @dataclass
 class PlayerBase(Stats):
@@ -52,9 +58,20 @@ class PlayerBase(Stats):
 
     def adjust_stat_on_gain(self, stat_name: str, amount: int) -> None:
         target = self.stat_gain_map.get(stat_name, stat_name)
+        log.debug(
+            "%s gaining %s: %s",
+            getattr(self, "id", type(self).__name__),
+            target,
+            amount,
+        )
         super().adjust_stat_on_gain(target, amount)
 
     def adjust_stat_on_loss(self, stat_name: str, amount: int) -> None:
         target = self.stat_loss_map.get(stat_name, stat_name)
+        log.debug(
+            "%s losing %s: %s",
+            getattr(self, "id", type(self).__name__),
+            target,
+            amount,
+        )
         super().adjust_stat_on_loss(target, amount)
-

--- a/backend/plugins/relics/_base.py
+++ b/backend/plugins/relics/_base.py
@@ -1,7 +1,12 @@
+import logging
+
 from dataclasses import dataclass
 from dataclasses import field
 
 from autofighter.party import Party
+
+
+log = logging.getLogger(__name__)
 
 
 @dataclass
@@ -15,13 +20,21 @@ class RelicBase:
     about: str = ""
 
     def apply(self, party: Party) -> None:
+        log.info("Applying relic %s to party", self.id)
         for member in party.members:
+            log.debug("Applying relic to %s", getattr(member, "id", "member"))
             for attr, pct in self.effects.items():
                 value = getattr(member, attr, None)
                 if value is None:
                     continue
                 new_value = type(value)(value * (1 + pct))
                 setattr(member, attr, new_value)
+                log.debug(
+                    "Updated %s %s to %s",
+                    getattr(member, "id", "member"),
+                    attr,
+                    new_value,
+                )
 
     def describe(self, stacks: int) -> str:
         return self.about

--- a/backend/plugins/templates/card_plugin.py
+++ b/backend/plugins/templates/card_plugin.py
@@ -1,7 +1,12 @@
+import logging
+
 from dataclasses import dataclass
 from dataclasses import field
 
 from plugins.cards._base import CardBase
+
+
+log = logging.getLogger(__name__)
 
 
 @dataclass

--- a/backend/plugins/templates/relic_plugin.py
+++ b/backend/plugins/templates/relic_plugin.py
@@ -1,7 +1,12 @@
+import logging
+
 from dataclasses import dataclass
 from dataclasses import field
 
 from plugins.relics._base import RelicBase
+
+
+log = logging.getLogger(__name__)
 
 
 @dataclass

--- a/backend/tests/test_plugin_logging.py
+++ b/backend/tests/test_plugin_logging.py
@@ -1,0 +1,15 @@
+import logging
+
+from logging_config import configure_logging
+from plugins.damage_effects import create_dot
+
+
+def test_plugin_logging_capture():
+    listener = configure_logging()
+    try:
+        logging.getLogger().setLevel(logging.DEBUG)
+        create_dot("Fire", 10, object())
+        buffer = listener.handlers[0].buffer
+        assert any("Creating DoT" in record.getMessage() for record in buffer)
+    finally:
+        listener.stop()


### PR DESCRIPTION
## Summary
- trace DoT and HoT creation and apply calls in plugin base modules
- instrument card and relic bases plus templates with structured debug logs
- test that plugin logs flow through buffered logging configuration

## Testing
- `PYTHONPATH=backend uv run pytest backend/tests/test_plugin_logging.py -q`
- `PYTHONPATH=backend uv run pytest backend/tests/test_app.py::test_run_flow -q`


------
https://chatgpt.com/codex/tasks/task_b_68ac47f51e40832c9859370195c9033e