### PR TITLE
[DOC] document buffered logging usage

### DIFF
--- a/.codex/instructions/plugin-system.md
+++ b/.codex/instructions/plugin-system.md
@@ -56,6 +56,17 @@ registered plugin class.
 
 Templates in `plugins/templates/` provide starting points for new plugins.
 
+## Logging
+Plugins must use the standard logging module instead of `print`.
+
+```python
+import logging
+
+log = logging.getLogger(__name__)
+```
+
+Log messages are captured by the backend's buffered logger and written to `backend/logs/backend.log` roughly every 15 seconds. See `backend/.codex/implementation/logging.md` for more details and examples.
+
 ## Adding a New Plugin
 1. Copy a template into the target category folder, e.g. `plugins/weapons/`.
 2. Set `plugin_type` to match the category and provide a unique `id` string.

--- a/backend/.codex/implementation/logging.md
+++ b/backend/.codex/implementation/logging.md
@@ -1,0 +1,38 @@
+# Logging
+
+Battle modules and plugin packages should log through the shared backend logger.
+
+```python
+import logging
+
+log = logging.getLogger(__name__)
+```
+
+Use `log.debug`, `log.info`, and so on instead of `print`. Records propagate through the queued buffer and are written to `backend/logs/backend.log` roughly every 15 seconds.
+
+## Battle Modules
+
+```python
+from logging import getLogger
+
+log = getLogger(__name__)
+
+def attack(player, foe):
+    log.info("%s attacks %s", player.name, foe.name)
+    ...
+```
+
+## Plugins
+
+```python
+import logging
+
+log = logging.getLogger(__name__)
+
+class BurnRelic:
+    plugin_type = "relic"
+    id = "burn"
+
+    def apply(self, target):
+        log.debug("Applying burn to %s", target)
+```

--- a/backend/README.md
+++ b/backend/README.md
@@ -15,7 +15,12 @@ uv run app.py
 
 ## Logging
 
-Logs write to `logs/backend.log` using a buffered rotating file handler. The buffer flushes roughly every 15 seconds and a Rich handler keeps console output colorful.
+The backend uses a queued, buffered logging pipeline:
+
+- A `QueueHandler` forwards records to a `QueueListener`.
+- A `TimedMemoryHandler` buffers messages and flushes them to disk roughly every 15 seconds.
+- Records land in a rotating log file at `logs/backend.log`.
+- A `RichHandler` remains attached for colorful console output.
 
 The root endpoint returns a simple status payload including the configured flavor. Set `UV_EXTRA` (default `"default"`) to label this instance. Additional routes support
 starting runs with a seeded 45-room map, updating the party, retrieving floor


### PR DESCRIPTION
## Summary
- document queued file logging pipeline in backend README
- add logging guidelines for battle modules and plugins
- mention required logger usage in plugin system instructions

## Testing
- `./run-tests.sh` *(fails: backend test_card_rewards.py etc., timeouts: backend tests/test_app.py, backend tests/test_gacha.py)*

------
https://chatgpt.com/codex/tasks/task_b_68ac4c0a1fe8832cb011b1141cc7116f