### PR TITLE
[fix] ensure cleanup after failed run termination

### DIFF
--- a/frontend/src/lib/SettingsMenu.svelte
+++ b/frontend/src/lib/SettingsMenu.svelte
@@ -71,8 +71,13 @@
 
   async function handleEndRun() {
     if (runId) {
-      await endRun(runId);
-      dispatch('endRun');
+      try {
+        await endRun(runId);
+      } catch (e) {
+        console.error('Failed to end run', e);
+      } finally {
+        dispatch('endRun');
+      }
     }
   }
 

--- a/frontend/tests/settingsmenu.test.js
+++ b/frontend/tests/settingsmenu.test.js
@@ -20,4 +20,22 @@ describe('SettingsMenu component', () => {
     expect(content).not.toContain('Save</button>');
     expect(content).not.toContain('alert(');
   });
+
+  test('dispatches endRun even if API call fails', async () => {
+    const source = readFileSync(join(import.meta.dir, '../src/lib/SettingsMenu.svelte'), 'utf8');
+    const start = source.indexOf('async function handleEndRun');
+    const brace = source.indexOf('{', start);
+    let depth = 1;
+    let i = brace + 1;
+    while (depth > 0 && i < source.length) {
+      if (source[i] === '{') depth++;
+      else if (source[i] === '}') depth--;
+      i++;
+    }
+    const body = source.slice(brace + 1, i - 1);
+    let fired = false;
+    const handler = new Function('runId', 'endRun', 'dispatch', `return (async () => {${body}})();`);
+    await handler('abc', async () => { throw new Error('fail'); }, () => { fired = true; });
+    expect(fired).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary
- always dispatch `endRun` after attempting backend run termination and log errors
- document `endRun` event propagation in viewport and page handlers
- test that failing run termination still dispatches `endRun`

## Testing
- `./run-tests.sh` *(multiple backend tests failed and timed out; see logs)*

------
https://chatgpt.com/codex/tasks/task_b_68acd5787aec832cb572f3b6a6dc5eae