### PR TITLE
[FIX] stop polling after run end errors

### DIFF
--- a/frontend/.codex/implementation/battle-polling.md
+++ b/frontend/.codex/implementation/battle-polling.md
@@ -9,3 +9,8 @@ snapshot, and logs a warning so the reward overlay or reset flow can proceed.
 If a snapshot includes an `error` field, polling halts immediately and the
 error state is surfaced without waiting for combat-over indicators.
 
+Network failures now cause `handleRunEnd` when the backend reports the run has
+ended. `pollBattle` watches for thrown errors whose message contains
+"run ended" or whose status code is `404` and stops polling without queuing
+another cycle. This prevents repeated error overlays once a run is gone.
+

--- a/frontend/.codex/implementation/run-helpers.md
+++ b/frontend/.codex/implementation/run-helpers.md
@@ -2,6 +2,9 @@
 
 - `src/lib/runState.js`: utilities for saving and loading run identifiers in `localStorage`.
 - `src/lib/runApi.js`: thin wrappers around backend endpoints used during a run (start, room actions, rewards).
+  `handleFetch` attaches HTTP status codes to thrown errors and suppresses
+  the error overlay on `404` responses so polling can end quietly when a run
+  disappears.
 - `src/lib/MainMenu.svelte`: renders the stained glass side menu from a list of items.
 - `src/lib/RunButtons.svelte`: module script exporting `buildRunMenu` for constructing the menu item list.
 - `src/lib/api.js`: `getBackendFlavor()` reports which backend flavor is active.

--- a/frontend/src/lib/runApi.js
+++ b/frontend/src/lib/runApi.js
@@ -13,8 +13,11 @@ async function handleFetch(url, options = {}) {
       try { data = await res.json(); } catch {}
       const message = data?.message || `HTTP error ${res.status}`;
       const traceback = data?.traceback || '';
-      openOverlay('error', { message, traceback });
+      if (res.status !== 404) {
+        openOverlay('error', { message, traceback });
+      }
       const err = new Error(message);
+      err.status = res.status;
       err.overlayShown = true;
       throw err;
     }

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -248,8 +248,11 @@
       } else {
         stalledTicks = 0;
       }
-    } catch {
-      /* ignore */
+    } catch (err) {
+      if (err?.message?.includes('run ended') || err?.status === 404) {
+        handleRunEnd();
+        return;
+      }
     }
     if (battleActive && !haltSync && runId) {
       battleTimer = setTimeout(pollBattle, 1000 / 60);

--- a/frontend/tests/battlepolling.test.js
+++ b/frontend/tests/battlepolling.test.js
@@ -1,6 +1,6 @@
 import { readFileSync } from 'fs';
 import { join } from 'path';
-import { describe, test, expect } from 'bun:test';
+import { describe, test, expect, mock } from 'bun:test';
 
 describe('battle polling', () => {
   test('stops on error snapshots', () => {
@@ -10,5 +10,46 @@ describe('battle polling', () => {
     );
     expect(content).toContain('if (snap?.error)');
     expect(content).toContain('battleActive = false');
+  });
+
+  test('halts on 404 without overlay spam', async () => {
+    let overlayCalls = 0;
+    mock.module('../src/lib/OverlayController.js', () => ({
+      openOverlay: () => { overlayCalls += 1; },
+      backOverlay: () => {},
+      homeOverlay: () => {}
+    }));
+
+    const { roomAction } = await import('../src/lib/runApi.js');
+    global.fetch = mock(async () => ({ ok: false, status: 404, json: async () => ({ message: 'run ended' }) }));
+
+    const content = readFileSync(join(import.meta.dir, '../src/routes/+page.svelte'), 'utf8');
+    const match = content.match(/async function pollBattle\(\)[\s\S]*?\n  }/);
+    const fnSource = match ? match[0] : '';
+
+    let setTimeoutCalled = false;
+    const ctx = {
+      battleActive: true,
+      haltSync: false,
+      runId: 'abc',
+      roomAction,
+      handleRunEnd: () => { ctx.battleActive = false; ctx.runId = ''; },
+      setTimeout: () => { setTimeoutCalled = true; },
+      mapStatuses: (x) => x,
+      hasRewards: () => false,
+      STALL_TICKS: 180,
+      stalledTicks: 0,
+      dev: false,
+      browser: true,
+      battleTimer: null
+    };
+
+    const poll = new Function('ctx', `with (ctx) { ${fnSource}; return pollBattle; }`)(ctx);
+    await poll();
+
+    expect(ctx.battleActive).toBe(false);
+    expect(ctx.runId).toBe('');
+    expect(setTimeoutCalled).toBe(false);
+    expect(overlayCalls).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary
- halt battle polling when roomAction 404s or emits "run ended"
- suppress error overlays on 404 responses
- cover run-ended polling behavior with tests and docs

## Testing
- `./run-tests.sh` *(fails: test_card_rewards.py::test_battle_offers_choices_and_applies_effect)*
- `cd frontend && bun test tests/battlepolling.test.js`


------
https://chatgpt.com/codex/tasks/task_b_68acd57a3b44832cba3d9a895311ffce