### PR TITLE
Add stat modifier effect for temporary buffs

### DIFF
--- a/backend/.codex/implementation/stat-modifiers.md
+++ b/backend/.codex/implementation/stat-modifiers.md
@@ -1,0 +1,18 @@
+# Stat modifiers
+
+Temporary buffs or debuffs adjust numeric fields on a `Stats` object.  The
+`StatModifier` effect tracks original values so changes can be reverted when the
+modifier expires.
+
+Use `create_stat_buff(stats, **changes)` to build a modifier without boilerplate.
+Keyword arguments ending with `_mult` multiply the associated stat; other keys
+apply additive deltas.  The factory applies the effect immediately and returns
+it for registration with an `EffectManager`:
+
+```python
+mod = create_stat_buff(target, atk=10, defense_mult=1.5, turns=2)
+manager.add_modifier(mod)
+```
+
+`EffectManager.tick()` decrements modifier durations alongside damage and
+healing effects, removing and restoring stats once turns reach zero.

--- a/backend/autofighter/stats.py
+++ b/backend/autofighter/stats.py
@@ -66,6 +66,7 @@ class Stats:
     passives: list[str] = field(default_factory=list)
     dots: list[str] = field(default_factory=list)
     hots: list[str] = field(default_factory=list)
+    mods: list[str] = field(default_factory=list)
 
     level_up_gains: dict[str, int] = field(
         default_factory=lambda: {"max_hp": 10, "atk": 5, "defense": 3}

--- a/backend/tests/test_effects.py
+++ b/backend/tests/test_effects.py
@@ -81,3 +81,24 @@ def test_dot_has_minimum_chance(monkeypatch):
     manager.maybe_inflict_dot(attacker, 10)
     assert target.dots
 
+
+@pytest.mark.asyncio
+async def test_stat_modifier_applies_and_expires():
+    stats = Stats(atk=10, defense=20)
+    stats.id = "s"
+    manager = EffectManager(stats)
+    mod = effects.create_stat_buff(
+        stats,
+        name="rally",
+        turns=1,
+        atk=5,
+        defense_mult=2,
+    )
+    manager.add_modifier(mod)
+    assert stats.atk == 15
+    assert stats.defense == 40
+    await manager.tick()
+    assert stats.atk == 10
+    assert stats.defense == 20
+    assert not stats.mods
+


### PR DESCRIPTION
## Summary
- add `StatModifier` effect with helper to create temporary buffs or debuffs
- track stat modifiers in `EffectManager` and `Stats`
- document stat modifiers

## Testing
- `uv run pytest tests/test_effects.py::test_stat_modifier_applies_and_expires -q`
- `uv run ruff check backend/autofighter/effects.py backend/autofighter/stats.py backend/tests/test_effects.py`
- `bash run-tests.sh` *(fails: test_app.py timeout, test_card_rewards.py, test_effect_serialization.py, test_effects.py, test_enrage_stacking.py, test_exp_leveling.py, test_fire_damage_scaling.py, test_frozen_wound.py, test_party_endpoint.py, test_party_persistence.py, test_player_editor.py, test_plugin_logging.py, test_random_player_foes.py, test_save_management.py, test_shadow_siphon.py, test_damage_type_on_action.py timeout, test_gacha.py timeout, test_rdr.py timeout, test_relic_rewards.py timeout)*

------
https://chatgpt.com/codex/tasks/task_b_68aced05fe44832cb9d34c051d013658