### PR TITLE
Use stat modifier buffs for themed adjectives

### DIFF
--- a/.codex/implementation/player-foe-reference.md
+++ b/.codex/implementation/player-foe-reference.md
@@ -47,7 +47,8 @@ from `plugins/themedadj` to a player name. Adjective plugins are
 auto-discovered based on files in that directory, so adding a new adjective
 requires only dropping a file into the folder. Each adjective class applies its own
 stat changes derived from the legacy project—for example, **Atrocious** boosts
-max HP by 90% and attack by 10%.
+max HP by 90% and attack by 10%. These adjustments are applied as persistent
+`StatModifier` buffs so base stats return to normal once the foe is defeated.
 
 Example: **Atrocious Luna** applies the adjective's stat bonuses to the base
 player stats and prefixes the foe's name, yielding a combatant whose title

--- a/README.md
+++ b/README.md
@@ -181,7 +181,9 @@ non-party player character scaled by floor, room, Pressure level, and loop
 count. Foes are procedurally named by prefixing a themed adjective plugin to a
 player name. Adjective plugins are auto-discovered from files in
 `plugins/themedadj`, allowing new adjectives to be added without modifying
-package code. Foes inherit from a dedicated `FoeBase` that mirrors player stats
+package code. Each adjective applies its stat tweaks through a persistent
+`StatModifier` buff so base values are restored when the foe falls. Foes inherit
+from a dedicated `FoeBase` that mirrors player stats
 but starts with negligible mitigation and vitality;
 the default `Slime` reduces them by 90% on spawn, while player-derived foes gain
 `FoeBase` behaviors like turn-based regeneration. The scene shows floating

--- a/backend/autofighter/effects.py
+++ b/backend/autofighter/effects.py
@@ -154,6 +154,11 @@ class EffectManager:
         self.hots: List[HealingOverTime] = []
         self.mods: List[StatModifier] = []
         self._console = Console()
+        for eff in getattr(stats, "_pending_mods", []):
+            self.mods.append(eff)
+            self.stats.mods.append(eff.id)
+        if hasattr(stats, "_pending_mods"):
+            delattr(stats, "_pending_mods")
 
     def add_dot(self, effect: DamageOverTime, max_stacks: Optional[int] = None) -> None:
         """Attach a DoT instance to the tracked stats.

--- a/backend/plugins/themedadj/__init__.py
+++ b/backend/plugins/themedadj/__init__.py
@@ -2,12 +2,57 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from autofighter.effects import create_stat_buff
 from plugins import PluginLoader
 
 
 loader = PluginLoader()
 loader.discover(str(Path(__file__).resolve().parent))
 _plugins = loader.get_plugins("themedadj")
+
+
+def stat_buff(cls):
+    """Wrap adjective apply methods to attach a lasting stat buff."""
+
+    original = cls.apply
+
+    def apply(self, target) -> None:  # type: ignore[override]
+        base_atk = getattr(target, "atk", None)
+        base_def = getattr(target, "defense", None)
+        base_hp = getattr(target, "max_hp", None)
+
+        original(self, target)
+
+        mults = {}
+        if base_atk is not None and target.atk != base_atk:
+            mults["atk_mult"] = target.atk / base_atk
+            target.atk = base_atk
+        if base_def is not None and target.defense != base_def:
+            mults["defense_mult"] = target.defense / base_def
+            target.defense = base_def
+        if base_hp is not None and target.max_hp != base_hp:
+            mults["max_hp_mult"] = target.max_hp / base_hp
+            target.max_hp = base_hp
+
+        if mults:
+            effect = create_stat_buff(
+                target,
+                name=getattr(self, "name", "buff"),
+                id=getattr(self, "id", "stat_buff"),
+                turns=9999,
+                **mults,
+            )
+            mgr = getattr(target, "effect_manager", None)
+            if mgr is not None:
+                mgr.add_modifier(effect)
+            else:
+                pending = getattr(target, "_pending_mods", [])
+                pending.append(effect)
+                target._pending_mods = pending
+
+    cls.apply = apply
+    return cls
+
 
 for cls in _plugins.values():
     globals()[cls.__name__] = cls

--- a/backend/plugins/themedadj/atrocious.py
+++ b/backend/plugins/themedadj/atrocious.py
@@ -1,6 +1,9 @@
 from dataclasses import dataclass
 
+from . import stat_buff
 
+
+@stat_buff
 @dataclass
 class Atrocious:
     plugin_type = "themedadj"

--- a/backend/plugins/themedadj/baneful.py
+++ b/backend/plugins/themedadj/baneful.py
@@ -1,6 +1,9 @@
 from dataclasses import dataclass
 
+from . import stat_buff
 
+
+@stat_buff
 @dataclass
 class Baneful:
     plugin_type = "themedadj"

--- a/backend/plugins/themedadj/barbaric.py
+++ b/backend/plugins/themedadj/barbaric.py
@@ -1,6 +1,9 @@
 from dataclasses import dataclass
 
+from . import stat_buff
 
+
+@stat_buff
 @dataclass
 class Barbaric:
     plugin_type = "themedadj"

--- a/backend/plugins/themedadj/beastly.py
+++ b/backend/plugins/themedadj/beastly.py
@@ -1,6 +1,9 @@
 from dataclasses import dataclass
 
+from . import stat_buff
 
+
+@stat_buff
 @dataclass
 class Beastly:
     plugin_type = "themedadj"

--- a/backend/plugins/themedadj/belligerent.py
+++ b/backend/plugins/themedadj/belligerent.py
@@ -1,6 +1,9 @@
 from dataclasses import dataclass
 
+from . import stat_buff
 
+
+@stat_buff
 @dataclass
 class Belligerent:
     plugin_type = "themedadj"

--- a/backend/plugins/themedadj/bloodthirsty.py
+++ b/backend/plugins/themedadj/bloodthirsty.py
@@ -1,6 +1,9 @@
 from dataclasses import dataclass
 
+from . import stat_buff
 
+
+@stat_buff
 @dataclass
 class Bloodthirsty:
     plugin_type = "themedadj"

--- a/backend/plugins/themedadj/brutal.py
+++ b/backend/plugins/themedadj/brutal.py
@@ -1,6 +1,9 @@
 from dataclasses import dataclass
 
+from . import stat_buff
 
+
+@stat_buff
 @dataclass
 class Brutal:
     plugin_type = "themedadj"

--- a/backend/plugins/themedadj/callous.py
+++ b/backend/plugins/themedadj/callous.py
@@ -1,6 +1,9 @@
 from dataclasses import dataclass
 
+from . import stat_buff
 
+
+@stat_buff
 @dataclass
 class Callous:
     plugin_type = "themedadj"

--- a/backend/plugins/themedadj/cannibalistic.py
+++ b/backend/plugins/themedadj/cannibalistic.py
@@ -1,6 +1,9 @@
 from dataclasses import dataclass
 
+from . import stat_buff
 
+
+@stat_buff
 @dataclass
 class Cannibalistic:
     plugin_type = "themedadj"

--- a/backend/plugins/themedadj/cowardly.py
+++ b/backend/plugins/themedadj/cowardly.py
@@ -1,6 +1,9 @@
 from dataclasses import dataclass
 
+from . import stat_buff
 
+
+@stat_buff
 @dataclass
 class Cowardly:
     plugin_type = "themedadj"

--- a/backend/plugins/themedadj/cruel.py
+++ b/backend/plugins/themedadj/cruel.py
@@ -1,6 +1,9 @@
 from dataclasses import dataclass
 
+from . import stat_buff
 
+
+@stat_buff
 @dataclass
 class Cruel:
     plugin_type = "themedadj"

--- a/backend/plugins/themedadj/cunning.py
+++ b/backend/plugins/themedadj/cunning.py
@@ -1,6 +1,9 @@
 from dataclasses import dataclass
 
+from . import stat_buff
 
+
+@stat_buff
 @dataclass
 class Cunning:
     plugin_type = "themedadj"

--- a/backend/plugins/themedadj/dangerous.py
+++ b/backend/plugins/themedadj/dangerous.py
@@ -1,6 +1,9 @@
 from dataclasses import dataclass
 
+from . import stat_buff
 
+
+@stat_buff
 @dataclass
 class Dangerous:
     plugin_type = "themedadj"

--- a/backend/plugins/themedadj/demonic.py
+++ b/backend/plugins/themedadj/demonic.py
@@ -1,6 +1,9 @@
 from dataclasses import dataclass
 
+from . import stat_buff
 
+
+@stat_buff
 @dataclass
 class Demonic:
     plugin_type = "themedadj"

--- a/backend/plugins/themedadj/depraved.py
+++ b/backend/plugins/themedadj/depraved.py
@@ -1,6 +1,9 @@
 from dataclasses import dataclass
 
+from . import stat_buff
 
+
+@stat_buff
 @dataclass
 class Depraved:
     plugin_type = "themedadj"

--- a/backend/plugins/themedadj/destructive.py
+++ b/backend/plugins/themedadj/destructive.py
@@ -1,6 +1,9 @@
 from dataclasses import dataclass
 
+from . import stat_buff
 
+
+@stat_buff
 @dataclass
 class Destructive:
     plugin_type = "themedadj"

--- a/backend/plugins/themedadj/diabolical.py
+++ b/backend/plugins/themedadj/diabolical.py
@@ -1,6 +1,9 @@
 from dataclasses import dataclass
 
+from . import stat_buff
 
+
+@stat_buff
 @dataclass
 class Diabolical:
     plugin_type = "themedadj"

--- a/backend/plugins/themedadj/disgusting.py
+++ b/backend/plugins/themedadj/disgusting.py
@@ -1,6 +1,9 @@
 from dataclasses import dataclass
 
+from . import stat_buff
 
+
+@stat_buff
 @dataclass
 class Disgusting:
     plugin_type = "themedadj"

--- a/backend/plugins/themedadj/dishonorable.py
+++ b/backend/plugins/themedadj/dishonorable.py
@@ -1,6 +1,9 @@
 from dataclasses import dataclass
 
+from . import stat_buff
 
+
+@stat_buff
 @dataclass
 class Dishonorable:
     plugin_type = "themedadj"

--- a/backend/plugins/themedadj/dreadful.py
+++ b/backend/plugins/themedadj/dreadful.py
@@ -1,6 +1,9 @@
 from dataclasses import dataclass
 
+from . import stat_buff
 
+
+@stat_buff
 @dataclass
 class Dreadful:
     plugin_type = "themedadj"

--- a/backend/plugins/themedadj/eerie.py
+++ b/backend/plugins/themedadj/eerie.py
@@ -1,6 +1,9 @@
 from dataclasses import dataclass
 
+from . import stat_buff
 
+
+@stat_buff
 @dataclass
 class Eerie:
     plugin_type = "themedadj"

--- a/backend/plugins/themedadj/evil.py
+++ b/backend/plugins/themedadj/evil.py
@@ -1,6 +1,9 @@
 from dataclasses import dataclass
 
+from . import stat_buff
 
+
+@stat_buff
 @dataclass
 class Evil:
     plugin_type = "themedadj"

--- a/backend/plugins/themedadj/execrable.py
+++ b/backend/plugins/themedadj/execrable.py
@@ -1,6 +1,9 @@
 from dataclasses import dataclass
 
+from . import stat_buff
 
+
+@stat_buff
 @dataclass
 class Execrable:
     plugin_type = "themedadj"

--- a/backend/plugins/themedadj/fiendish.py
+++ b/backend/plugins/themedadj/fiendish.py
@@ -1,6 +1,9 @@
 from dataclasses import dataclass
 
+from . import stat_buff
 
+
+@stat_buff
 @dataclass
 class Fiendish:
     plugin_type = "themedadj"

--- a/backend/plugins/themedadj/filthy.py
+++ b/backend/plugins/themedadj/filthy.py
@@ -1,6 +1,9 @@
 from dataclasses import dataclass
 
+from . import stat_buff
 
+
+@stat_buff
 @dataclass
 class Filthy:
     plugin_type = "themedadj"

--- a/backend/plugins/themedadj/foul.py
+++ b/backend/plugins/themedadj/foul.py
@@ -1,6 +1,9 @@
 from dataclasses import dataclass
 
+from . import stat_buff
 
+
+@stat_buff
 @dataclass
 class Foul:
     plugin_type = "themedadj"

--- a/backend/plugins/themedadj/frightening.py
+++ b/backend/plugins/themedadj/frightening.py
@@ -1,6 +1,9 @@
 from dataclasses import dataclass
 
+from . import stat_buff
 
+
+@stat_buff
 @dataclass
 class Frightening:
     plugin_type = "themedadj"

--- a/backend/plugins/themedadj/ghastly.py
+++ b/backend/plugins/themedadj/ghastly.py
@@ -1,6 +1,9 @@
 from dataclasses import dataclass
 
+from . import stat_buff
 
+
+@stat_buff
 @dataclass
 class Ghastly:
     plugin_type = "themedadj"

--- a/backend/plugins/themedadj/ghoulish.py
+++ b/backend/plugins/themedadj/ghoulish.py
@@ -1,6 +1,9 @@
 from dataclasses import dataclass
 
+from . import stat_buff
 
+
+@stat_buff
 @dataclass
 class Ghoulish:
     plugin_type = "themedadj"

--- a/backend/plugins/themedadj/gruesome.py
+++ b/backend/plugins/themedadj/gruesome.py
@@ -1,6 +1,9 @@
 from dataclasses import dataclass
 
+from . import stat_buff
 
+
+@stat_buff
 @dataclass
 class Gruesome:
     plugin_type = "themedadj"

--- a/backend/plugins/themedadj/heinous.py
+++ b/backend/plugins/themedadj/heinous.py
@@ -1,6 +1,9 @@
 from dataclasses import dataclass
 
+from . import stat_buff
 
+
+@stat_buff
 @dataclass
 class Heinous:
     plugin_type = "themedadj"

--- a/backend/plugins/themedadj/hideous.py
+++ b/backend/plugins/themedadj/hideous.py
@@ -1,6 +1,9 @@
 from dataclasses import dataclass
 
+from . import stat_buff
 
+
+@stat_buff
 @dataclass
 class Hideous:
     plugin_type = "themedadj"

--- a/backend/plugins/themedadj/homicidal.py
+++ b/backend/plugins/themedadj/homicidal.py
@@ -1,6 +1,9 @@
 from dataclasses import dataclass
 
+from . import stat_buff
 
+
+@stat_buff
 @dataclass
 class Homicidal:
     plugin_type = "themedadj"

--- a/backend/plugins/themedadj/horrible.py
+++ b/backend/plugins/themedadj/horrible.py
@@ -1,6 +1,9 @@
 from dataclasses import dataclass
 
+from . import stat_buff
 
+
+@stat_buff
 @dataclass
 class Horrible:
     plugin_type = "themedadj"

--- a/backend/plugins/themedadj/hostile.py
+++ b/backend/plugins/themedadj/hostile.py
@@ -1,6 +1,9 @@
 from dataclasses import dataclass
 
+from . import stat_buff
 
+
+@stat_buff
 @dataclass
 class Hostile:
     plugin_type = "themedadj"

--- a/backend/plugins/themedadj/inhumane.py
+++ b/backend/plugins/themedadj/inhumane.py
@@ -1,6 +1,9 @@
 from dataclasses import dataclass
 
+from . import stat_buff
 
+
+@stat_buff
 @dataclass
 class Inhumane:
     plugin_type = "themedadj"

--- a/backend/plugins/themedadj/insidious.py
+++ b/backend/plugins/themedadj/insidious.py
@@ -1,6 +1,9 @@
 from dataclasses import dataclass
 
+from . import stat_buff
 
+
+@stat_buff
 @dataclass
 class Insidious:
     plugin_type = "themedadj"

--- a/backend/plugins/themedadj/intimidating.py
+++ b/backend/plugins/themedadj/intimidating.py
@@ -1,6 +1,9 @@
 from dataclasses import dataclass
 
+from . import stat_buff
 
+
+@stat_buff
 @dataclass
 class Intimidating:
     plugin_type = "themedadj"

--- a/backend/plugins/themedadj/malevolent.py
+++ b/backend/plugins/themedadj/malevolent.py
@@ -1,6 +1,9 @@
 from dataclasses import dataclass
 
+from . import stat_buff
 
+
+@stat_buff
 @dataclass
 class Malevolent:
     plugin_type = "themedadj"

--- a/backend/plugins/themedadj/malicious.py
+++ b/backend/plugins/themedadj/malicious.py
@@ -1,6 +1,9 @@
 from dataclasses import dataclass
 
+from . import stat_buff
 
+
+@stat_buff
 @dataclass
 class Malicious:
     plugin_type = "themedadj"

--- a/backend/plugins/themedadj/monstrous.py
+++ b/backend/plugins/themedadj/monstrous.py
@@ -1,6 +1,9 @@
 from dataclasses import dataclass
 
+from . import stat_buff
 
+
+@stat_buff
 @dataclass
 class Monstrous:
     plugin_type = "themedadj"

--- a/backend/plugins/themedadj/murderous.py
+++ b/backend/plugins/themedadj/murderous.py
@@ -1,6 +1,9 @@
 from dataclasses import dataclass
 
+from . import stat_buff
 
+
+@stat_buff
 @dataclass
 class Murderous:
     plugin_type = "themedadj"

--- a/backend/plugins/themedadj/nasty.py
+++ b/backend/plugins/themedadj/nasty.py
@@ -1,6 +1,9 @@
 from dataclasses import dataclass
 
+from . import stat_buff
 
+
+@stat_buff
 @dataclass
 class Nasty:
     plugin_type = "themedadj"

--- a/backend/plugins/themedadj/nefarious.py
+++ b/backend/plugins/themedadj/nefarious.py
@@ -1,6 +1,9 @@
 from dataclasses import dataclass
 
+from . import stat_buff
 
+
+@stat_buff
 @dataclass
 class Nefarious:
     plugin_type = "themedadj"

--- a/backend/plugins/themedadj/noxious.py
+++ b/backend/plugins/themedadj/noxious.py
@@ -1,6 +1,9 @@
 from dataclasses import dataclass
 
+from . import stat_buff
 
+
+@stat_buff
 @dataclass
 class Noxious:
     plugin_type = "themedadj"

--- a/backend/plugins/themedadj/obscene.py
+++ b/backend/plugins/themedadj/obscene.py
@@ -1,6 +1,9 @@
 from dataclasses import dataclass
 
+from . import stat_buff
 
+
+@stat_buff
 @dataclass
 class Obscene:
     plugin_type = "themedadj"

--- a/backend/plugins/themedadj/odious.py
+++ b/backend/plugins/themedadj/odious.py
@@ -1,6 +1,9 @@
 from dataclasses import dataclass
 
+from . import stat_buff
 
+
+@stat_buff
 @dataclass
 class Odious:
     plugin_type = "themedadj"

--- a/backend/plugins/themedadj/ominous.py
+++ b/backend/plugins/themedadj/ominous.py
@@ -1,6 +1,9 @@
 from dataclasses import dataclass
 
+from . import stat_buff
 
+
+@stat_buff
 @dataclass
 class Ominous:
     plugin_type = "themedadj"

--- a/backend/plugins/themedadj/pernicious.py
+++ b/backend/plugins/themedadj/pernicious.py
@@ -1,6 +1,9 @@
 from dataclasses import dataclass
 
+from . import stat_buff
 
+
+@stat_buff
 @dataclass
 class Pernicious:
     plugin_type = "themedadj"

--- a/backend/plugins/themedadj/perverted.py
+++ b/backend/plugins/themedadj/perverted.py
@@ -1,6 +1,9 @@
 from dataclasses import dataclass
 
+from . import stat_buff
 
+
+@stat_buff
 @dataclass
 class Perverted:
     plugin_type = "themedadj"

--- a/backend/plugins/themedadj/poisonous.py
+++ b/backend/plugins/themedadj/poisonous.py
@@ -1,6 +1,9 @@
 from dataclasses import dataclass
 
+from . import stat_buff
 
+
+@stat_buff
 @dataclass
 class Poisonous:
     plugin_type = "themedadj"

--- a/backend/plugins/themedadj/predatory.py
+++ b/backend/plugins/themedadj/predatory.py
@@ -1,6 +1,9 @@
 from dataclasses import dataclass
 
+from . import stat_buff
 
+
+@stat_buff
 @dataclass
 class Predatory:
     plugin_type = "themedadj"

--- a/backend/plugins/themedadj/premeditated.py
+++ b/backend/plugins/themedadj/premeditated.py
@@ -1,6 +1,9 @@
 from dataclasses import dataclass
 
+from . import stat_buff
 
+
+@stat_buff
 @dataclass
 class Premeditated:
     plugin_type = "themedadj"

--- a/backend/plugins/themedadj/primal.py
+++ b/backend/plugins/themedadj/primal.py
@@ -1,6 +1,9 @@
 from dataclasses import dataclass
 
+from . import stat_buff
 
+
+@stat_buff
 @dataclass
 class Primal:
     plugin_type = "themedadj"

--- a/backend/plugins/themedadj/primitive.py
+++ b/backend/plugins/themedadj/primitive.py
@@ -1,6 +1,9 @@
 from dataclasses import dataclass
 
+from . import stat_buff
 
+
+@stat_buff
 @dataclass
 class Primitive:
     plugin_type = "themedadj"

--- a/backend/plugins/themedadj/profane.py
+++ b/backend/plugins/themedadj/profane.py
@@ -1,6 +1,9 @@
 from dataclasses import dataclass
 
+from . import stat_buff
 
+
+@stat_buff
 @dataclass
 class Profane:
     plugin_type = "themedadj"

--- a/backend/plugins/themedadj/psychopathic.py
+++ b/backend/plugins/themedadj/psychopathic.py
@@ -1,6 +1,9 @@
 from dataclasses import dataclass
 
+from . import stat_buff
 
+
+@stat_buff
 @dataclass
 class Psychopathic:
     plugin_type = "themedadj"

--- a/backend/plugins/themedadj/rabid.py
+++ b/backend/plugins/themedadj/rabid.py
@@ -1,6 +1,9 @@
 from dataclasses import dataclass
 
+from . import stat_buff
 
+
+@stat_buff
 @dataclass
 class Rabid:
     plugin_type = "themedadj"

--- a/backend/plugins/themedadj/relentless.py
+++ b/backend/plugins/themedadj/relentless.py
@@ -1,6 +1,9 @@
 from dataclasses import dataclass
 
+from . import stat_buff
 
+
+@stat_buff
 @dataclass
 class Relentless:
     plugin_type = "themedadj"

--- a/backend/plugins/themedadj/repulsive.py
+++ b/backend/plugins/themedadj/repulsive.py
@@ -1,6 +1,9 @@
 from dataclasses import dataclass
 
+from . import stat_buff
 
+
+@stat_buff
 @dataclass
 class Repulsive:
     plugin_type = "themedadj"

--- a/backend/plugins/themedadj/ruthless.py
+++ b/backend/plugins/themedadj/ruthless.py
@@ -1,6 +1,9 @@
 from dataclasses import dataclass
 
+from . import stat_buff
 
+
+@stat_buff
 @dataclass
 class Ruthless:
     plugin_type = "themedadj"

--- a/backend/plugins/themedadj/sadistic.py
+++ b/backend/plugins/themedadj/sadistic.py
@@ -1,6 +1,9 @@
 from dataclasses import dataclass
 
+from . import stat_buff
 
+
+@stat_buff
 @dataclass
 class Sadistic:
     plugin_type = "themedadj"

--- a/backend/plugins/themedadj/savage.py
+++ b/backend/plugins/themedadj/savage.py
@@ -1,6 +1,9 @@
 from dataclasses import dataclass
 
+from . import stat_buff
 
+
+@stat_buff
 @dataclass
 class Savage:
     plugin_type = "themedadj"

--- a/backend/plugins/themedadj/scary.py
+++ b/backend/plugins/themedadj/scary.py
@@ -1,6 +1,9 @@
 from dataclasses import dataclass
 
+from . import stat_buff
 
+
+@stat_buff
 @dataclass
 class Scary:
     plugin_type = "themedadj"

--- a/backend/plugins/themedadj/sinister.py
+++ b/backend/plugins/themedadj/sinister.py
@@ -1,6 +1,9 @@
 from dataclasses import dataclass
 
+from . import stat_buff
 
+
+@stat_buff
 @dataclass
 class Sinister:
     plugin_type = "themedadj"

--- a/backend/plugins/themedadj/sociopathic.py
+++ b/backend/plugins/themedadj/sociopathic.py
@@ -1,6 +1,9 @@
 from dataclasses import dataclass
 
+from . import stat_buff
 
+
+@stat_buff
 @dataclass
 class Sociopathic:
     plugin_type = "themedadj"

--- a/backend/plugins/themedadj/spiteful.py
+++ b/backend/plugins/themedadj/spiteful.py
@@ -1,6 +1,9 @@
 from dataclasses import dataclass
 
+from . import stat_buff
 
+
+@stat_buff
 @dataclass
 class Spiteful:
     plugin_type = "themedadj"

--- a/backend/plugins/themedadj/squalid.py
+++ b/backend/plugins/themedadj/squalid.py
@@ -1,6 +1,9 @@
 from dataclasses import dataclass
 
+from . import stat_buff
 
+
+@stat_buff
 @dataclass
 class Squalid:
     plugin_type = "themedadj"

--- a/backend/plugins/themedadj/terrifying.py
+++ b/backend/plugins/themedadj/terrifying.py
@@ -1,6 +1,9 @@
 from dataclasses import dataclass
 
+from . import stat_buff
 
+
+@stat_buff
 @dataclass
 class Terrifying:
     plugin_type = "themedadj"

--- a/backend/plugins/themedadj/threatening.py
+++ b/backend/plugins/themedadj/threatening.py
@@ -1,6 +1,9 @@
 from dataclasses import dataclass
 
+from . import stat_buff
 
+
+@stat_buff
 @dataclass
 class Threatening:
     plugin_type = "themedadj"

--- a/backend/plugins/themedadj/treacherous.py
+++ b/backend/plugins/themedadj/treacherous.py
@@ -1,6 +1,9 @@
 from dataclasses import dataclass
 
+from . import stat_buff
 
+
+@stat_buff
 @dataclass
 class Treacherous:
     plugin_type = "themedadj"

--- a/backend/plugins/themedadj/ugly.py
+++ b/backend/plugins/themedadj/ugly.py
@@ -1,6 +1,9 @@
 from dataclasses import dataclass
 
+from . import stat_buff
 
+
+@stat_buff
 @dataclass
 class Ugly:
     plugin_type = "themedadj"

--- a/backend/plugins/themedadj/unholy.py
+++ b/backend/plugins/themedadj/unholy.py
@@ -1,6 +1,9 @@
 from dataclasses import dataclass
 
+from . import stat_buff
 
+
+@stat_buff
 @dataclass
 class Unholy:
     plugin_type = "themedadj"

--- a/backend/plugins/themedadj/venomous.py
+++ b/backend/plugins/themedadj/venomous.py
@@ -1,6 +1,9 @@
 from dataclasses import dataclass
 
+from . import stat_buff
 
+
+@stat_buff
 @dataclass
 class Venomous:
     plugin_type = "themedadj"

--- a/backend/plugins/themedadj/vicious.py
+++ b/backend/plugins/themedadj/vicious.py
@@ -1,6 +1,9 @@
 from dataclasses import dataclass
 
+from . import stat_buff
 
+
+@stat_buff
 @dataclass
 class Vicious:
     plugin_type = "themedadj"

--- a/backend/plugins/themedadj/villainous.py
+++ b/backend/plugins/themedadj/villainous.py
@@ -1,6 +1,9 @@
 from dataclasses import dataclass
 
+from . import stat_buff
 
+
+@stat_buff
 @dataclass
 class Villainous:
     plugin_type = "themedadj"

--- a/backend/plugins/themedadj/violent.py
+++ b/backend/plugins/themedadj/violent.py
@@ -1,6 +1,9 @@
 from dataclasses import dataclass
 
+from . import stat_buff
 
+
+@stat_buff
 @dataclass
 class Violent:
     plugin_type = "themedadj"

--- a/backend/plugins/themedadj/wicked.py
+++ b/backend/plugins/themedadj/wicked.py
@@ -1,6 +1,9 @@
 from dataclasses import dataclass
 
+from . import stat_buff
 
+
+@stat_buff
 @dataclass
 class Wicked:
     plugin_type = "themedadj"

--- a/backend/plugins/themedadj/wrongful.py
+++ b/backend/plugins/themedadj/wrongful.py
@@ -1,6 +1,9 @@
 from dataclasses import dataclass
 
+from . import stat_buff
 
+
+@stat_buff
 @dataclass
 class Wrongful:
     plugin_type = "themedadj"

--- a/backend/plugins/themedadj/xenophobic.py
+++ b/backend/plugins/themedadj/xenophobic.py
@@ -1,6 +1,9 @@
 from dataclasses import dataclass
 
+from . import stat_buff
 
+
+@stat_buff
 @dataclass
 class Xenophobic:
     plugin_type = "themedadj"


### PR DESCRIPTION
## Summary
- wrap themed adjectives with a decorator that records stat multipliers and applies them as long-lived StatModifier buffs
- persist pending buffs in the EffectManager to cleanly remove them on foe defeat
- document adjective buff behavior in README and player/foe reference

## Testing
- [ ] Backend tests
- [ ] Frontend tests *(missing `svelte/store` module, plus failing SettingsMenu test)*
- [ ] Linting `uv run ruff check backend/plugins/themedadj/__init__.py`
- [ ] Doc sync updates (README and `.codex/implementation` docs)

------
https://chatgpt.com/codex/tasks/task_b_68acfa07a364832c8ddeb09f040129e8