### PR TITLE
[ENH] apply stat modifiers for relic buffs

### DIFF
--- a/backend/plugins/relics/_base.py
+++ b/backend/plugins/relics/_base.py
@@ -4,6 +4,8 @@ from dataclasses import dataclass
 from dataclasses import field
 
 from autofighter.party import Party
+from autofighter.effects import EffectManager
+from autofighter.effects import create_stat_buff
 
 
 log = logging.getLogger(__name__)
@@ -21,20 +23,25 @@ class RelicBase:
 
     def apply(self, party: Party) -> None:
         log.info("Applying relic %s to party", self.id)
+        mods = []
         for member in party.members:
             log.debug("Applying relic to %s", getattr(member, "id", "member"))
-            for attr, pct in self.effects.items():
-                value = getattr(member, attr, None)
-                if value is None:
-                    continue
-                new_value = type(value)(value * (1 + pct))
-                setattr(member, attr, new_value)
-                log.debug(
-                    "Updated %s %s to %s",
-                    getattr(member, "id", "member"),
-                    attr,
-                    new_value,
-                )
+            mgr = getattr(member, "effect_manager", None)
+            if mgr is None:
+                mgr = EffectManager(member)
+                member.effect_manager = mgr
+            changes = {f"{attr}_mult": 1 + pct for attr, pct in self.effects.items()}
+            if not changes:
+                continue
+            mod = create_stat_buff(member, name=self.id, turns=9999, **changes)
+            mgr.add_modifier(mod)
+            mods.append(mod)
+        self._mods = mods
+
+    def remove(self) -> None:
+        for mod in getattr(self, "_mods", []):
+            mod.remove()
+        self._mods = []
 
     def describe(self, stacks: int) -> str:
         return self.about

--- a/backend/plugins/relics/bent_dagger.py
+++ b/backend/plugins/relics/bent_dagger.py
@@ -1,8 +1,9 @@
 from dataclasses import dataclass
 from dataclasses import field
 
-from plugins.relics._base import RelicBase
 from autofighter.stats import BUS
+from plugins.relics._base import RelicBase
+from autofighter.effects import create_stat_buff
 
 
 @dataclass
@@ -22,7 +23,8 @@ class BentDagger(RelicBase):
             if target in party.members or target.hp > 0:
                 return
             for member in party.members:
-                member.atk = int(member.atk * 1.01)
+                mod = create_stat_buff(member, name=f"{self.id}_kill", atk_mult=1.01, turns=9999)
+                member.effect_manager.add_modifier(mod)
 
         BUS.subscribe("damage_taken", _on_death)
 

--- a/backend/plugins/relics/guardian_charm.py
+++ b/backend/plugins/relics/guardian_charm.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 from dataclasses import field
 
 from plugins.relics._base import RelicBase
+from autofighter.effects import create_stat_buff
 
 
 @dataclass
@@ -15,10 +16,12 @@ class GuardianCharm(RelicBase):
     about: str = "At battle start, grants +20% DEF to the lowest-HP ally per stack."
 
     def apply(self, party) -> None:
+        super().apply(party)
         if not party.members:
             return
         member = min(party.members, key=lambda m: m.hp)
-        member.defense = int(member.defense * 1.2)
+        mod = create_stat_buff(member, name=self.id, defense_mult=1.2, turns=9999)
+        member.effect_manager.add_modifier(mod)
 
     def describe(self, stacks: int) -> str:
         pct = 20 * stacks

--- a/backend/plugins/relics/null_lantern.py
+++ b/backend/plugins/relics/null_lantern.py
@@ -3,6 +3,7 @@ from dataclasses import field
 
 from autofighter.stats import BUS
 from plugins.relics._base import RelicBase
+from autofighter.effects import create_stat_buff
 
 
 @dataclass
@@ -32,10 +33,16 @@ class NullLantern(RelicBase):
 
             if isinstance(entity, FoeBase):
                 mult = 1 + 1.5 * state["cleared"]
-                entity.atk = int(entity.atk * mult)
-                entity.defense = int(entity.defense * mult)
-                entity.max_hp = int(entity.max_hp * mult)
-                entity.hp = entity.max_hp
+                mod = create_stat_buff(
+                    entity,
+                    name=f"{self.id}_foe_{state['cleared']}",
+                    turns=9999,
+                    atk_mult=mult,
+                    defense_mult=mult,
+                    max_hp_mult=mult,
+                    hp_mult=mult,
+                )
+                entity.effect_manager.add_modifier(mod)
 
         def _battle_end(entity) -> None:
             from plugins.foes._base import FoeBase

--- a/backend/plugins/relics/shiny_pebble.py
+++ b/backend/plugins/relics/shiny_pebble.py
@@ -1,8 +1,9 @@
-from dataclasses import field
 from dataclasses import dataclass
+from dataclasses import field
 
 from autofighter.stats import BUS
 from plugins.relics._base import RelicBase
+from autofighter.effects import create_stat_buff
 
 
 @dataclass
@@ -20,25 +21,37 @@ class ShinyPebble(RelicBase):
     def apply(self, party) -> None:
         super().apply(party)
 
-        triggered: set[int] = set()
-        to_remove: dict[int, object] = {}
-        stacks = party.relics.count(self.id)
-        mit_mult = 1 + 0.03 * stacks
+        state = getattr(party, "_shiny_pebble_state", None)
+        if state is None:
+            state = {"active": {}, "triggered": set()}
+            party._shiny_pebble_state = state
 
-        def _first_hit(target, attacker, amount) -> None:
-            if target not in party.members or id(target) in triggered:
-                return
-            triggered.add(id(target))
-            to_remove[id(target)] = target
-            target.mitigation *= mit_mult
+            def _first_hit(target, attacker, amount) -> None:
+                if target not in party.members or id(target) in state["triggered"]:
+                    return
+                state["triggered"].add(id(target))
+                stacks = party.relics.count(self.id)
+                mit_mult = (1 + 0.03 * stacks) ** stacks
+                mod = create_stat_buff(
+                    target,
+                    name=f"{self.id}_{id(target)}",
+                    mitigation=target.mitigation * (mit_mult - 1),
+                    turns=1,
+                )
+                target.effect_manager.add_modifier(mod)
+                state["active"][id(target)] = (target, mod)
 
-        def _reset(*_) -> None:
-            for key, member in list(to_remove.items()):
-                member.mitigation /= mit_mult
-                to_remove.pop(key, None)
+            def _reset(*_) -> None:
+                for key, (member, mod) in list(state["active"].items()):
+                    mod.remove()
+                    if mod in member.effect_manager.mods:
+                        member.effect_manager.mods.remove(mod)
+                    if mod.id in member.mods:
+                        member.mods.remove(mod.id)
+                    state["active"].pop(key, None)
 
-        BUS.subscribe("damage_taken", _first_hit)
-        BUS.subscribe("turn_start", _reset)
+            BUS.subscribe("damage_taken", _first_hit)
+            BUS.subscribe("turn_start", _reset)
 
     def describe(self, stacks: int) -> str:
         defense = 3 * stacks

--- a/backend/plugins/relics/soul_prism.py
+++ b/backend/plugins/relics/soul_prism.py
@@ -3,6 +3,7 @@ from dataclasses import field
 
 from autofighter.stats import BUS
 from plugins.relics._base import RelicBase
+from autofighter.effects import create_stat_buff
 
 
 @dataclass
@@ -36,10 +37,14 @@ class SoulPrism(RelicBase):
                 member._soul_prism_hp = base
                 member.max_hp = int(base * multiplier)
                 member.hp = max(1, int(member.max_hp * 0.01))
-                new_def = int(member.defense * (1 + buff))
-                member.adjust_stat_on_gain("defense", new_def - member.defense)
-                new_mit = member.mitigation * (1 + buff)
-                member.adjust_stat_on_gain("mitigation", new_mit - member.mitigation)
+                mod = create_stat_buff(
+                    member,
+                    name=f"{self.id}_{id(member)}",
+                    defense_mult=1 + buff,
+                    mitigation_mult=1 + buff,
+                    turns=9999,
+                )
+                member.effect_manager.add_modifier(mod)
 
         BUS.subscribe("battle_end", _battle_end)
 

--- a/backend/plugins/relics/stellar_compass.py
+++ b/backend/plugins/relics/stellar_compass.py
@@ -3,6 +3,7 @@ from dataclasses import field
 
 from autofighter.stats import BUS
 from plugins.relics._base import RelicBase
+from autofighter.effects import create_stat_buff
 
 
 @dataclass
@@ -27,7 +28,13 @@ class StellarCompass(RelicBase):
                 if attacker not in party.members:
                     return
                 copies = party.relics.count(self.id)
-                attacker.atk = int(attacker.atk * (1.015 ** copies))
+                mod = create_stat_buff(
+                    attacker,
+                    name=f"{self.id}_crit",
+                    atk_mult=1.015 ** copies,
+                    turns=9999,
+                )
+                attacker.effect_manager.add_modifier(mod)
                 state["gold"] += 0.015 * copies
 
             def _gold(amount: int) -> None:

--- a/backend/plugins/relics/tattered_flag.py
+++ b/backend/plugins/relics/tattered_flag.py
@@ -1,8 +1,9 @@
 from dataclasses import dataclass
 from dataclasses import field
 
-from plugins.relics._base import RelicBase
 from autofighter.stats import BUS
+from plugins.relics._base import RelicBase
+from autofighter.effects import create_stat_buff
 
 
 @dataclass
@@ -23,7 +24,8 @@ class TatteredFlag(RelicBase):
                 return
             for member in party.members:
                 if member is not target and member.hp > 0:
-                    member.atk = int(member.atk * 1.03)
+                    mod = create_stat_buff(member, name=f"{self.id}_buff", atk_mult=1.03, turns=9999)
+                    member.effect_manager.add_modifier(mod)
 
         BUS.subscribe("damage_taken", _fallen)
 

--- a/backend/tests/test_relic_effects.py
+++ b/backend/tests/test_relic_effects.py
@@ -183,6 +183,8 @@ def test_shiny_pebble_stacks():
     apply_relics(party)
     BUS.emit("damage_taken", ally, enemy, 10)
     assert isclose(ally.mitigation, 112.36, rel_tol=1e-4)
+    BUS.emit("turn_start")
+    assert isclose(ally.mitigation, 100)
 
 
 def test_threadbare_cloak_shield_stacks():

--- a/backend/tests/test_relic_effects_advanced.py
+++ b/backend/tests/test_relic_effects_advanced.py
@@ -75,13 +75,16 @@ def test_killer_instinct_grants_extra_turn():
     party.members.append(a)
     award_relic(party, "killer_instinct")
     apply_relics(party)
+    base = a.atk
     BUS.emit("ultimate_used", a)
+    assert a.atk > base
     turns: list[PlayerBase] = []
     BUS.subscribe("extra_turn", lambda m: turns.append(m))
     b.hp = 0
     BUS.emit("damage_taken", b, a, 10)
     BUS.emit("turn_end")
     assert turns == [a]
+    assert a.atk == base
 
 
 def test_travelers_charm_buff():


### PR DESCRIPTION
## Summary
- replace direct stat tweaks in relics with StatModifier helpers
- register modifiers with each member's EffectManager for automatic cleanup
- add regression tests ensuring buffs reset to baseline

## Testing
- `uv run pytest tests/test_relic_effects.py tests/test_relic_effects_advanced.py`


------
https://chatgpt.com/codex/tasks/task_b_68acfa06547c832c8a7b1a07ac1a41f1