### PR TITLE
[FIX] Await passive healing and verify events

### DIFF
--- a/backend/autofighter/passives.py
+++ b/backend/autofighter/passives.py
@@ -12,7 +12,7 @@ class PassiveRegistry:
             for name in getattr(passive_plugins, "__all__", [])
         }
 
-    def trigger(self, event: str, target) -> None:
+    async def trigger(self, event: str, target) -> None:
         counts = Counter(target.passives)
         for pid, count in counts.items():
             cls = self._registry.get(pid)
@@ -20,4 +20,4 @@ class PassiveRegistry:
                 continue
             stacks = min(count, getattr(cls, "max_stacks", count))
             for _ in range(stacks):
-                cls().apply(target)
+                await cls().apply(target)

--- a/backend/autofighter/rooms/chat.py
+++ b/backend/autofighter/rooms/chat.py
@@ -17,7 +17,7 @@ class ChatRoom(Room):
     async def resolve(self, party: Party, data: dict[str, Any]) -> dict[str, Any]:
         registry = PassiveRegistry()
         for member in party.members:
-            registry.trigger("room_enter", member)
+            await registry.trigger("room_enter", member)
         message = data.get("message", "")
         party_data = [_serialize(p) for p in party.members]
         return {

--- a/backend/autofighter/rooms/rest.py
+++ b/backend/autofighter/rooms/rest.py
@@ -17,8 +17,8 @@ class RestRoom(Room):
     async def resolve(self, party: Party, data: dict[str, Any]) -> dict[str, Any]:
         registry = PassiveRegistry()
         for member in party.members:
-            registry.trigger("room_enter", member)
-            member.hp = member.max_hp
+            await registry.trigger("room_enter", member)
+            await member.apply_healing(member.max_hp)
         party_data = [_serialize(p) for p in party.members]
         return {
             "result": "rest",

--- a/backend/autofighter/rooms/shop.py
+++ b/backend/autofighter/rooms/shop.py
@@ -18,7 +18,7 @@ class ShopRoom(Room):
         registry = PassiveRegistry()
         heal = int(sum(m.max_hp for m in party.members) * 0.05)
         for member in party.members:
-            registry.trigger("room_enter", member)
+            await registry.trigger("room_enter", member)
             await member.apply_healing(heal)
         cost = int(data.get("cost", 0))
         item = data.get("item")

--- a/backend/plugins/passives/attack_up.py
+++ b/backend/plugins/passives/attack_up.py
@@ -9,5 +9,5 @@ class AttackUp:
     trigger = "battle_start"
     amount = 5
 
-    def apply(self, target) -> None:
+    async def apply(self, target) -> None:
         target.adjust_stat_on_gain("atk", self.amount)

--- a/backend/plugins/passives/room_heal.py
+++ b/backend/plugins/passives/room_heal.py
@@ -9,5 +9,5 @@ class RoomHeal:
     trigger = "battle_end"
     amount = 1
 
-    def apply(self, target) -> None:
-        target.hp = min(target.hp + self.amount, target.max_hp)
+    async def apply(self, target) -> None:
+        await target.apply_healing(self.amount)

--- a/backend/tests/test_passives.py
+++ b/backend/tests/test_passives.py
@@ -1,11 +1,16 @@
-from pathlib import Path
 import sys
+from pathlib import Path
+
+import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from autofighter.passives import PassiveRegistry
 from plugins import PluginLoader
+from autofighter.stats import BUS
 from plugins.players.player import Player
+from autofighter.passives import PassiveRegistry
+from autofighter.stats import set_enrage_percent
+from plugins.passives.room_heal import RoomHeal
 
 
 def test_passive_discovery():
@@ -15,18 +20,43 @@ def test_passive_discovery():
     assert "attack_up" in passives
 
 
-def test_passive_trigger_and_stack():
+@pytest.mark.asyncio
+async def test_passive_trigger_and_stack():
     registry = PassiveRegistry()
     player = Player()
     player.passives = ["attack_up"] * 5
-    registry.trigger("battle_start", player)
+    await registry.trigger("battle_start", player)
     assert player.atk == 100 + 5 * 5
 
 
-def test_room_heal_trigger():
+@pytest.mark.asyncio
+async def test_room_heal_trigger():
     registry = PassiveRegistry()
     player = Player()
     player.hp = 900
     player.passives = ["room_heal"] * 10
-    registry.trigger("battle_end", player)
+    await registry.trigger("battle_end", player)
     assert player.hp == 910
+
+
+@pytest.mark.asyncio
+async def test_room_heal_event_and_enrage(monkeypatch):
+    registry = PassiveRegistry()
+    player = Player()
+    player.hp = 90
+    player.max_hp = 100
+    player.passives = ["room_heal"]
+    amounts: list[int] = []
+
+    def _heal(target, healer, amount):
+        amounts.append(amount)
+
+    BUS.subscribe("heal_received", _heal)
+    monkeypatch.setattr(RoomHeal, "amount", 10, raising=False)
+    set_enrage_percent(0.5)
+    await registry.trigger("battle_end", player)
+    set_enrage_percent(0.0)
+    BUS.unsubscribe("heal_received", _heal)
+
+    assert amounts == [5]
+    assert player.hp == 95


### PR DESCRIPTION
## Summary
- switch RoomHeal passive to use async healing
- await passive triggers across rooms and battles
- test passive healing events and enrage reduction

## Testing
- `uv run ruff check backend/autofighter/passives.py backend/autofighter/rooms/battle.py backend/autofighter/rooms/rest.py backend/autofighter/rooms/shop.py backend/autofighter/rooms/chat.py backend/plugins/passives/attack_up.py backend/plugins/passives/room_heal.py backend/tests/test_passives.py`
- `./run-tests.sh` *(fails: Cannot find module 'svelte/store', error overlay test module missing; timed out backend tests/test_app.py, test_damage_type_on_action.py, test_rdr.py, test_relic_rewards.py)*

------
https://chatgpt.com/codex/tasks/task_b_68acfa0a7e20832c9ae31484e8088839