### PR TITLE
[FEAT] persist player customization effects

### DIFF
--- a/backend/.codex/implementation/player-editor-endpoint.md
+++ b/backend/.codex/implementation/player-editor-endpoint.md
@@ -10,5 +10,9 @@ even if a run is active; when a new run begins the current pronouns, damage
 type, and stat distribution are snapshot into the run so later edits do not
 affect the active session.
 
+These allocations persist as an effect descriptor rather than by mutating the
+player's base stats. When a run loads, the saved parameters rebuild a
+long-lived `StatModifier` to apply the chosen multipliers.
+
 ## Testing
 - `uv run pytest backend/tests/test_player_editor.py`

--- a/backend/.codex/implementation/stat-modifiers.md
+++ b/backend/.codex/implementation/stat-modifiers.md
@@ -16,3 +16,7 @@ manager.add_modifier(mod)
 
 `EffectManager.tick()` decrements modifier durations alongside damage and
 healing effects, removing and restoring stats once turns reach zero.
+
+Player customization applies a long-lived `StatModifier` rather than modifying
+baseline stats. The customization parameters are persisted separately so the
+effect can be recreated when loading a run.

--- a/backend/app.py
+++ b/backend/app.py
@@ -9,20 +9,20 @@ from quart import jsonify
 from quart import request
 
 from game import FERNET  # noqa: F401
+from game import load_map  # noqa: F401
+from game import save_map  # noqa: F401
+from game import load_party  # noqa: F401
+from game import save_party  # noqa: F401
+from game import _run_battle  # noqa: F401
+from game import battle_tasks  # noqa: F401
 from game import GachaManager  # noqa: F401  # re-export for tests
 from game import SAVE_MANAGER  # noqa: F401
-from game import _apply_player_stats  # noqa: F401
+from game import _scale_stats  # noqa: F401
+from game import _passive_names  # noqa: F401
+from game import battle_snapshots  # noqa: F401
 from game import _assign_damage_type  # noqa: F401
 from game import _load_player_customization  # noqa: F401
-from game import _passive_names  # noqa: F401
-from game import _run_battle  # noqa: F401
-from game import _scale_stats  # noqa: F401
-from game import battle_snapshots  # noqa: F401
-from game import battle_tasks  # noqa: F401
-from game import load_map  # noqa: F401
-from game import load_party  # noqa: F401
-from game import save_map  # noqa: F401
-from game import save_party  # noqa: F401
+from game import _apply_player_customization  # noqa: F401
 from routes.runs import bp as runs_bp
 from routes.gacha import bp as gacha_bp
 from routes.rooms import bp as rooms_bp

--- a/backend/routes/players.py
+++ b/backend/routes/players.py
@@ -13,9 +13,9 @@ from autofighter.stats import apply_status_hooks
 from plugins import players as player_plugins
 
 from game import SAVE_MANAGER
-from game import _apply_player_stats
 from game import _assign_damage_type
 from game import _load_player_customization
+from game import _apply_player_customization
 
 bp = Blueprint("players", __name__)
 
@@ -47,7 +47,7 @@ async def get_players() -> tuple[str, int, dict[str, str]]:
         inst = cls()
         _assign_damage_type(inst)
         if inst.id == "player":
-            _apply_player_stats(inst)
+            _apply_player_customization(inst)
         stats = asdict(inst)
         stats["char_type"] = inst.char_type.name
         stats["damage_type"] = inst.element_id
@@ -69,7 +69,7 @@ async def player_stats() -> tuple[str, int, dict[str, object]]:
     refresh = _get_stat_refresh_rate()
     player = player_plugins.player.Player()
     _assign_damage_type(player)
-    _apply_player_stats(player)
+    _apply_player_customization(player)
     apply_status_hooks(player)
     stats = {
         "core": {


### PR DESCRIPTION
## Summary
- attach persistent stat modifier for player customization instead of mutating base stats
- store and reload player customizations as effect descriptors
- document long-lived customization effects

## Testing
- `uv run ruff check backend` *(fails: F811/F841/F401 errors)*
- `./run-tests.sh` *(fails: test_app.py, test_damage_type_on_action.py, test_gacha.py, test_rdr.py, test_relic_rewards.py timed out)*

------
https://chatgpt.com/codex/tasks/task_b_68acfa0ba644832c9fd0557cad7f4038