### PR TITLE
Use stat modifiers for Celestial Atrophy attack debuff

### DIFF
--- a/backend/plugins/dots/celestial_atrophy.py
+++ b/backend/plugins/dots/celestial_atrophy.py
@@ -1,4 +1,8 @@
+from typing import List
+
+from autofighter.effects import StatModifier
 from autofighter.effects import DamageOverTime
+from autofighter.effects import create_stat_buff
 
 
 class CelestialAtrophy(DamageOverTime):
@@ -7,7 +11,27 @@ class CelestialAtrophy(DamageOverTime):
 
     def __init__(self, damage: int, turns: int) -> None:
         super().__init__("Celestial Atrophy", damage, turns, self.id)
+        self._mods: List[StatModifier] = []
 
-    def tick(self, target, *_):
-        target.atk = max(target.atk - 1, 0)
-        return super().tick(target)
+    async def tick(self, target, *_):
+        manager = getattr(target, "effect_manager", None)
+        if manager is not None:
+            mod = create_stat_buff(
+                target,
+                name="Celestial Atrophy - Attack Down",
+                id=f"{self.id}_atk_down",
+                turns=self.turns,
+                atk=-1,
+            )
+            manager.add_modifier(mod)
+            self._mods.append(mod)
+        alive = await super().tick(target)
+        if not alive and manager is not None:
+            for mod in reversed(self._mods):
+                mod.remove()
+                if mod in manager.mods:
+                    manager.mods.remove(mod)
+                if mod.id in target.mods:
+                    target.mods.remove(mod.id)
+            self._mods.clear()
+        return alive

--- a/backend/tests/test_celestial_atrophy.py
+++ b/backend/tests/test_celestial_atrophy.py
@@ -1,0 +1,26 @@
+import pytest
+
+from autofighter.stats import Stats
+from autofighter.effects import EffectManager
+from plugins.dots.celestial_atrophy import CelestialAtrophy
+
+
+@pytest.mark.asyncio
+async def test_celestial_atrophy_stacks_and_cleans_up():
+    target = Stats(atk=10)
+    target.id = "t"
+    manager = EffectManager(target)
+    target.effect_manager = manager
+
+    dot = CelestialAtrophy(0, 3)
+    manager.add_dot(dot)
+
+    await manager.tick()
+    assert target.atk == 9
+
+    await manager.tick()
+    assert target.atk == 8
+
+    await manager.tick()
+    assert target.atk == 10
+    assert not target.mods


### PR DESCRIPTION
## Summary
- apply a stackable StatModifier to reduce attack each Celestial Atrophy tick
- add test ensuring debuff stacks and cleans up

## Testing
- `uvx ruff check backend/plugins/dots/celestial_atrophy.py backend/tests/test_celestial_atrophy.py`
- `./run-tests.sh` *(timeout: backend tests/test_app.py, backend tests/test_damage_type_on_action.py, backend tests/test_gacha.py, backend tests/test_rdr.py, backend tests/test_relic_rewards.py)*

------
https://chatgpt.com/codex/tasks/task_b_68acfa090f38832c8fbf88d08339e6ac