### PR TITLE
[CI] setup env before tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,10 +102,13 @@ Run the test suites before submitting changes with the helper script:
 ./run-tests.sh
 ```
 
-The script runs each backend `pytest` module via `uv` and then executes the
-frontend `bun test` files. Each test is given a 15-second timeout, and all tests
-are run regardless of failures. The script prints a summary of any failing or
-timed-out tests and exits with the first non-zero status code encountered.
+The script prepares the environments by creating and syncing a Python virtual
+environment in `backend/` (`uv venv && uv sync`) and installing frontend
+dependencies with `bun install` in `frontend/`. It then runs each backend
+`pytest` module via `uv` and executes the frontend `bun test` files. Each test
+is given a 15-second timeout, and all tests are run regardless of failures. The
+script prints a summary of any failing or timed-out tests and exits with the
+first non-zero status code encountered.
 
 ## Loot and Rare Drop Rate
 

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -30,6 +30,10 @@ echo "Starting test run"
 
 # Backend tests
 cd backend
+
+# Set up Python environment once
+uv venv && uv sync
+
 echo "Starting backend tests..."
 for file in $(find tests -maxdepth 1 -name "test_*.py" -type f -printf "%f\n" | sort); do
   echo "Running backend test: $file"
@@ -40,6 +44,10 @@ cd "$ROOT_DIR"
 
 # Frontend tests
 cd frontend
+
+# Install Node dependencies
+bun install
+
 echo "Starting frontend tests..."
 for file in $(find tests -maxdepth 1 -name "*.test.js" -type f -printf "%f\n" | sort); do
   echo "Running frontend test: $file"


### PR DESCRIPTION
## Summary
- setup Python venv and sync deps before backend tests
- install frontend deps before running bun tests
- document test environment setup steps

## Testing
- `./run-tests.sh` *(fails: backend tests/test_app.py ...)*

------
https://chatgpt.com/codex/tasks/task_b_68ad040efc5c832cba7e99680ba952b7