### PR TITLE
[chore] resolve Pyflakes warnings in backend

### DIFF
--- a/backend/plugins/dots/abyssal_weakness.py
+++ b/backend/plugins/dots/abyssal_weakness.py
@@ -1,5 +1,4 @@
 from autofighter.effects import DamageOverTime
-from autofighter.effects import DamageOverTime
 
 
 class AbyssalWeakness(DamageOverTime):

--- a/backend/routes/rooms.py
+++ b/backend/routes/rooms.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 import copy
-import time
 
 from quart import Blueprint
 from quart import jsonify
@@ -34,7 +33,6 @@ bp = Blueprint("rooms", __name__)
 
 @bp.post("/rooms/<run_id>/battle")
 async def battle_room(run_id: str) -> tuple[str, int, dict[str, str]]:
-    start = time.perf_counter()
     data = await request.get_json(silent=True) or {}
     action = data.get("action", "")
     if action == "snapshot":

--- a/backend/routes/runs.py
+++ b/backend/routes/runs.py
@@ -17,8 +17,6 @@ from autofighter.mapgen import MapGenerator
 from game import FERNET
 from game import load_map
 from game import save_map
-from game import load_party
-from game import save_party
 from game import battle_tasks
 from game import SAVE_MANAGER
 from game import _passive_names


### PR DESCRIPTION
## Summary
- deduplicate DamageOverTime import in abyssal weakness plugin
- remove unused timer and imports in backend routes
- clean up routes imports for Pyflakes

## Testing
- `uvx ruff check backend`
- `uv run pytest` *(fails: ImportError: Failed to import plugin(s))*

------
https://chatgpt.com/codex/tasks/task_b_68ad041b13a8832c8b6f9ac5c63672e8