### PR TITLE
[REFACTOR] lazily initialize save manager

### DIFF
--- a/backend/.codex/implementation/save-manager.md
+++ b/backend/.codex/implementation/save-manager.md
@@ -2,6 +2,10 @@
 
 Wrapper around SQLCipher connections and database migrations.
 
+Use `get_save_manager()` from `game.py` to obtain an initialized instance. The
+function lazily constructs the manager, runs migrations, and performs initial
+setup so tests can override `AF_DB_PATH` and `AF_DB_KEY` before the first call.
+
 ## Migration safety
 - Migration filenames must start with a numeric prefix (`NNN_description.sql`).
 - Non-numeric prefixes are ignored to prevent executing unexpected scripts.

--- a/backend/app.py
+++ b/backend/app.py
@@ -8,7 +8,7 @@ from quart import Quart
 from quart import jsonify
 from quart import request
 
-from game import FERNET  # noqa: F401
+from game import get_fernet  # noqa: F401
 from game import load_map  # noqa: F401
 from game import save_map  # noqa: F401
 from game import load_party  # noqa: F401
@@ -16,7 +16,7 @@ from game import save_party  # noqa: F401
 from game import _run_battle  # noqa: F401
 from game import battle_tasks  # noqa: F401
 from game import GachaManager  # noqa: F401  # re-export for tests
-from game import SAVE_MANAGER  # noqa: F401
+from game import get_save_manager  # noqa: F401
 from game import _scale_stats  # noqa: F401
 from game import _passive_names  # noqa: F401
 from game import battle_snapshots  # noqa: F401

--- a/backend/routes/gacha.py
+++ b/backend/routes/gacha.py
@@ -8,14 +8,14 @@ from quart import request
 
 from autofighter.gacha import GachaManager
 
-from game import SAVE_MANAGER
+from game import get_save_manager
 
 bp = Blueprint("gacha", __name__)
 
 
 @bp.get("/gacha")
 async def gacha_state() -> tuple[str, int, dict[str, object]]:
-    manager = GachaManager(SAVE_MANAGER)
+    manager = GachaManager(get_save_manager())
     return jsonify(manager.get_state())
 
 
@@ -23,7 +23,7 @@ async def gacha_state() -> tuple[str, int, dict[str, object]]:
 async def gacha_pull() -> tuple[str, int, dict[str, object]]:
     data = await request.get_json(silent=True) or {}
     count = int(data.get("count", 1))
-    manager = GachaManager(SAVE_MANAGER)
+    manager = GachaManager(get_save_manager())
     try:
         results = manager.pull(count)
     except ValueError:
@@ -39,13 +39,13 @@ async def gacha_pull() -> tuple[str, int, dict[str, object]]:
 async def gacha_auto_craft() -> tuple[str, int, dict[str, object]]:
     data = await request.get_json(silent=True) or {}
     enabled = bool(data.get("enabled"))
-    manager = GachaManager(SAVE_MANAGER)
+    manager = GachaManager(get_save_manager())
     manager.set_auto_craft(enabled)
     return jsonify({"status": "ok", "auto_craft": enabled})
 
 
 @bp.post("/gacha/craft")
 async def gacha_craft() -> tuple[str, int, dict[str, object]]:
-    manager = GachaManager(SAVE_MANAGER)
+    manager = GachaManager(get_save_manager())
     items = manager.craft()
     return jsonify({"status": "ok", "items": items})

--- a/backend/routes/players.py
+++ b/backend/routes/players.py
@@ -12,7 +12,7 @@ from autofighter.stats import apply_status_hooks
 
 from plugins import players as player_plugins
 
-from game import SAVE_MANAGER
+from game import get_save_manager
 from game import _assign_damage_type
 from game import _load_player_customization
 from game import _apply_player_customization
@@ -21,7 +21,7 @@ bp = Blueprint("players", __name__)
 
 
 def _get_stat_refresh_rate() -> int:
-    with SAVE_MANAGER.connection() as conn:
+    with get_save_manager().connection() as conn:
         conn.execute(
             "CREATE TABLE IF NOT EXISTS options (key TEXT PRIMARY KEY, value TEXT)"
         )
@@ -38,7 +38,7 @@ def _get_stat_refresh_rate() -> int:
 
 @bp.get("/players")
 async def get_players() -> tuple[str, int, dict[str, str]]:
-    with SAVE_MANAGER.connection() as conn:
+    with get_save_manager().connection() as conn:
         cur = conn.execute("SELECT id FROM owned_players")
         owned = {row[0] for row in cur.fetchall()}
     roster = []
@@ -145,7 +145,7 @@ async def update_player_editor() -> tuple[str, int, dict[str, str]]:
         return jsonify({"error": "invalid damage type"}), 400
     if total > 100:
         return jsonify({"error": "over-allocation"}), 400
-    with SAVE_MANAGER.connection() as conn:
+    with get_save_manager().connection() as conn:
         conn.execute(
             "CREATE TABLE IF NOT EXISTS options (key TEXT PRIMARY KEY, value TEXT)"
         )

--- a/backend/routes/rooms.py
+++ b/backend/routes/rooms.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 import copy
-import time
 
 from quart import Blueprint
 from quart import jsonify
@@ -26,7 +25,7 @@ from game import load_party
 from game import save_party
 from game import _run_battle
 from game import battle_tasks
-from game import SAVE_MANAGER
+from game import get_save_manager
 from game import battle_snapshots
 
 bp = Blueprint("rooms", __name__)
@@ -34,7 +33,6 @@ bp = Blueprint("rooms", __name__)
 
 @bp.post("/rooms/<run_id>/battle")
 async def battle_room(run_id: str) -> tuple[str, int, dict[str, str]]:
-    start = time.perf_counter()
     data = await request.get_json(silent=True) or {}
     action = data.get("action", "")
     if action == "snapshot":
@@ -44,7 +42,7 @@ async def battle_room(run_id: str) -> tuple[str, int, dict[str, str]]:
         return jsonify(snap)
     party = await asyncio.to_thread(load_party, run_id)
     try:
-        with SAVE_MANAGER.connection() as conn:
+        with get_save_manager().connection() as conn:
             row = conn.execute(
                 "SELECT type FROM damage_types WHERE id = ?", ("player",)
             ).fetchone()

--- a/backend/routes/runs.py
+++ b/backend/routes/runs.py
@@ -14,13 +14,11 @@ from quart import request
 from plugins import players as player_plugins
 from autofighter.mapgen import MapGenerator
 
-from game import FERNET
+from game import get_fernet
 from game import load_map
 from game import save_map
-from game import load_party
-from game import save_party
 from game import battle_tasks
-from game import SAVE_MANAGER
+from game import get_save_manager
 from game import _passive_names
 from game import battle_snapshots
 from game import _assign_damage_type
@@ -40,7 +38,7 @@ async def start_run() -> tuple[str, int, dict[str, object]]:
         or len(set(members)) != len(members)
     ):
         return jsonify({"error": "invalid party"}), 400
-    with SAVE_MANAGER.connection() as conn:
+    with get_save_manager().connection() as conn:
         cur = conn.execute("SELECT id FROM owned_players")
         owned = {row[0] for row in cur.fetchall()}
     for mid in members:
@@ -50,7 +48,7 @@ async def start_run() -> tuple[str, int, dict[str, object]]:
         allowed = {"Light", "Dark", "Wind", "Lightning", "Fire", "Ice"}
         if damage_type not in allowed:
             return jsonify({"error": "invalid damage type"}), 400
-        with SAVE_MANAGER.connection() as conn:
+        with get_save_manager().connection() as conn:
             conn.execute(
                 "INSERT OR REPLACE INTO damage_types (id, type) VALUES (?, ?)",
                 ("player", damage_type),
@@ -67,7 +65,7 @@ async def start_run() -> tuple[str, int, dict[str, object]]:
         "awaiting_next": False,
     }
     pronouns, stats = _load_player_customization()
-    with SAVE_MANAGER.connection() as conn:
+    with get_save_manager().connection() as conn:
         cur = conn.execute(
             "SELECT type FROM damage_types WHERE id = ?",
             ("player",),
@@ -79,7 +77,7 @@ async def start_run() -> tuple[str, int, dict[str, object]]:
         "damage_type": player_type,
         "stats": stats,
     }
-    with SAVE_MANAGER.connection() as conn:
+    with get_save_manager().connection() as conn:
         conn.execute(
             "INSERT INTO runs (id, party, map) VALUES (?, ?, ?)",
             (
@@ -135,7 +133,7 @@ async def update_party(run_id: str) -> tuple[str, int, dict[str, object]]:
         or len(set(members)) != len(members)
     ):
         return jsonify({"error": "invalid party"}), 400
-    with SAVE_MANAGER.connection() as conn:
+    with get_save_manager().connection() as conn:
         cur = conn.execute("SELECT id FROM owned_players")
         owned = {row[0] for row in cur.fetchall()}
     for mid in members:
@@ -150,7 +148,7 @@ async def update_party(run_id: str) -> tuple[str, int, dict[str, object]]:
         "level": {pid: 1 for pid in members},
         "rdr": rdr,
     }
-    with SAVE_MANAGER.connection() as conn:
+    with get_save_manager().connection() as conn:
         conn.execute(
             "UPDATE runs SET party = ? WHERE id = ?",
             (json.dumps(party), run_id),
@@ -160,7 +158,7 @@ async def update_party(run_id: str) -> tuple[str, int, dict[str, object]]:
 
 @bp.get("/map/<run_id>")
 async def get_map(run_id: str) -> tuple[str, int, dict[str, object]]:
-    with SAVE_MANAGER.connection() as conn:
+    with get_save_manager().connection() as conn:
         cur = conn.execute("SELECT map, party FROM runs WHERE id = ?", (run_id,))
         row = cur.fetchone()
     if row is None:
@@ -183,7 +181,7 @@ async def end_run(run_id: str) -> tuple[str, int, dict[str, str]]:
     except Exception:
         pass
     battle_snapshots.pop(run_id, None)
-    with SAVE_MANAGER.connection() as conn:
+    with get_save_manager().connection() as conn:
         cur = conn.execute("DELETE FROM runs WHERE id = ?", (run_id,))
         if cur.rowcount == 0:
             return jsonify({"error": "run not found"}), 404
@@ -208,10 +206,11 @@ async def advance_room(run_id: str) -> tuple[str, int, dict[str, object]]:
 
 @bp.post("/save/wipe")
 async def wipe_save() -> tuple[str, int, dict[str, str]]:
-    SAVE_MANAGER.db_path.unlink(missing_ok=True)
-    SAVE_MANAGER.migrate(Path(__file__).resolve().parent / "migrations")
+    manager = get_save_manager()
+    manager.db_path.unlink(missing_ok=True)
+    manager.migrate(Path(__file__).resolve().parent / "migrations")
     persona = random.choice(["lady_darkness", "lady_light"])
-    with SAVE_MANAGER.connection() as conn:
+    with manager.connection() as conn:
         conn.execute("INSERT INTO owned_players (id) VALUES (?)", (persona,))
         conn.execute(
             "CREATE TABLE IF NOT EXISTS options (key TEXT PRIMARY KEY, value TEXT)"
@@ -224,7 +223,7 @@ async def wipe_save() -> tuple[str, int, dict[str, str]]:
 
 @bp.get("/save/backup")
 async def backup_save() -> tuple[bytes, int, dict[str, str]]:
-    with SAVE_MANAGER.connection() as conn:
+    with get_save_manager().connection() as conn:
         conn.execute(
             "CREATE TABLE IF NOT EXISTS options (key TEXT PRIMARY KEY, value TEXT)"
         )
@@ -238,7 +237,7 @@ async def backup_save() -> tuple[bytes, int, dict[str, str]]:
     data = json.dumps(payload)
     digest = hashlib.sha256(data.encode()).hexdigest()
     package = json.dumps({"hash": digest, "data": data}).encode()
-    token = FERNET.encrypt(package)
+    token = get_fernet().encrypt(package)
     headers = {
         "Content-Type": "application/octet-stream",
         "Content-Disposition": "attachment; filename=backup.afsave",
@@ -250,7 +249,7 @@ async def backup_save() -> tuple[bytes, int, dict[str, str]]:
 async def restore_save() -> tuple[str, int, dict[str, str]]:
     blob = await request.get_data()
     try:
-        package = FERNET.decrypt(blob)
+        package = get_fernet().decrypt(blob)
         obj = json.loads(package)
     except Exception:
         return jsonify({"error": "invalid backup"}), 400
@@ -259,7 +258,7 @@ async def restore_save() -> tuple[str, int, dict[str, str]]:
     if hashlib.sha256(data.encode()).hexdigest() != digest:
         return jsonify({"error": "hash mismatch"}), 400
     payload = json.loads(data)
-    with SAVE_MANAGER.connection() as conn:
+    with get_save_manager().connection() as conn:
         conn.execute("DELETE FROM runs")
         conn.execute(
             "CREATE TABLE IF NOT EXISTS options (key TEXT PRIMARY KEY, value TEXT)"

--- a/backend/tests/test_battle_defeat.py
+++ b/backend/tests/test_battle_defeat.py
@@ -57,7 +57,7 @@ async def test_run_battle_handles_defeat_cleanup(app_with_db, monkeypatch):
     task = app_module.battle_tasks[run_id]
     await task
 
-    with app_module.SAVE_MANAGER.connection() as conn:
+    with app_module.get_save_manager().connection() as conn:
         row = conn.execute("SELECT id FROM runs WHERE id = ?", (run_id,)).fetchone()
     assert row is None
     assert app_module.battle_snapshots[run_id]["ended"] is True

--- a/backend/tests/test_battle_loot_items.py
+++ b/backend/tests/test_battle_loot_items.py
@@ -77,7 +77,7 @@ async def test_battle_loot_items_update_inventory(app_with_db, monkeypatch):
     loot_items = data["loot"]["items"]
     assert loot_items
 
-    manager = app_module.GachaManager(app_module.SAVE_MANAGER)
+    manager = app_module.GachaManager(app_module.get_save_manager())
     items = manager._get_items()
 
     expected: dict[str, int] = {}

--- a/backend/tests/test_gacha.py
+++ b/backend/tests/test_gacha.py
@@ -19,7 +19,7 @@ def app_with_db(tmp_path, monkeypatch):
     assert spec.loader is not None
     spec.loader.exec_module(app_module)
     app_module.app.testing = True
-    manager = app_module.GachaManager(app_module.SAVE_MANAGER)
+    manager = app_module.GachaManager(app_module.get_save_manager())
     manager._set_items({"ticket": 1})
     return app_module.app, db_path
 


### PR DESCRIPTION
## Summary
- add `get_save_manager` and `get_fernet` to lazily set up database and crypto
- update routes, app, and tests to fetch the SaveManager via accessor
- document new accessor in save-manager notes

## Testing
- `uv run ruff check backend/game.py backend/routes/gacha.py backend/routes/rooms.py backend/routes/runs.py backend/routes/players.py backend/app.py backend/tests/test_gacha.py backend/tests/test_battle_loot_items.py backend/tests/test_battle_defeat.py`
- `./run-tests.sh` *(fails: Test run complete: failure)*

------
https://chatgpt.com/codex/tasks/task_b_68ad041c775c832ca3e11877116181c3