### PR TITLE
Fix plugin loader package resolution for nested plugins

### DIFF
--- a/backend/plugins/themedadj/__init__.py
+++ b/backend/plugins/themedadj/__init__.py
@@ -6,11 +6,6 @@ from autofighter.effects import create_stat_buff
 from plugins import PluginLoader
 
 
-loader = PluginLoader()
-loader.discover(str(Path(__file__).resolve().parent))
-_plugins = loader.get_plugins("themedadj")
-
-
 def stat_buff(cls):
     """Wrap adjective apply methods to attach a lasting stat buff."""
 
@@ -53,6 +48,10 @@ def stat_buff(cls):
     cls.apply = apply
     return cls
 
+
+loader = PluginLoader()
+loader.discover(str(Path(__file__).resolve().parent))
+_plugins = loader.get_plugins("themedadj")
 
 for cls in _plugins.values():
     globals()[cls.__name__] = cls

--- a/backend/tests/test_themedadj_plugins.py
+++ b/backend/tests/test_themedadj_plugins.py
@@ -1,0 +1,23 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from autofighter.stats import Stats
+from plugins.themedadj import Atrocious, loader
+
+
+def test_themed_adjectives_import_and_decorate() -> None:
+    plugins = loader.get_plugins("themedadj")
+    assert "atrocious" in plugins
+
+    target = Stats()
+    Atrocious().apply(target)
+
+    assert target.atk == 220
+    assert target.max_hp == 1900
+    assert hasattr(target, "_pending_mods")
+    mod = target._pending_mods[0]
+    assert mod.multipliers["atk"] == 1.1
+    assert mod.multipliers["max_hp"] == 1.9
+


### PR DESCRIPTION
## Summary
- resolve plugin module names relative to `plugins` root
- ensure themed adjective plugins load with stat buff decoration
- cover themed adjective import behavior with regression test

## Testing
- `uv run pytest tests/test_themedadj_plugins.py tests/test_player_plugins.py`


------
https://chatgpt.com/codex/tasks/task_b_68ad15d4d840832c9fd252a3a42ed11f