### PR TITLE
[FIX] update stat key names

### DIFF
--- a/frontend/src/lib/StatTabs.svelte
+++ b/frontend/src/lib/StatTabs.svelte
@@ -55,13 +55,13 @@
         {:else if activeTab === 'Offense'}
           <div><span>ATK</span><span>{sel.stats.atk ?? '-'}</span></div>
           <div><span>CRIT Rate</span><span>{(sel.stats.critRate ?? sel.stats.crit_rate ?? 0) + '%'}</span></div>
-          <div><span>CRIT DMG</span><span>{(sel.stats.critDamage ?? sel.stats.crit_dmg ?? 0) + '%'}</span></div>
-          <div><span>Effect Hit Rate</span><span>{(sel.stats.effectHit ?? sel.stats.effect_hit ?? 0) + '%'}</span></div>
+          <div><span>CRIT DMG</span><span>{(sel.stats.critDamage ?? sel.stats.crit_damage ?? 0) + '%'}</span></div>
+          <div><span>Effect Hit Rate</span><span>{(sel.stats.effectHit ?? sel.stats.effect_hit_rate ?? 0) + '%'}</span></div>
         {:else if activeTab === 'Defense'}
           <div><span>DEF</span><span>{sel.stats.defense ?? '-'}</span></div>
           <div><span>Mitigation</span><span>{sel.stats.mitigation ?? '-'}</span></div>
-          <div><span>Dodge Odds</span><span>{sel.stats.dodge ?? sel.stats.dodgeOdds ?? '-'}</span></div>
-          <div><span>Effect Resist</span><span>{sel.stats.effectResist ?? sel.stats.effect_res ?? '-'}</span></div>
+          <div><span>Dodge Odds</span><span>{sel.stats.dodge_odds ?? '-'}</span></div>
+          <div><span>Effect Resist</span><span>{sel.stats.effectResist ?? sel.stats.effect_resistance ?? '-'}</span></div>
         {/if}
       </div>
     {/each}

--- a/frontend/tests/partypicker.test.js
+++ b/frontend/tests/partypicker.test.js
@@ -13,6 +13,14 @@ describe('PartyPicker component', () => {
     expect(content).toContain('Add to party');
   });
 
+  test('references updated stat keys', () => {
+    const content = readFileSync(join(import.meta.dir, '../src/lib/StatTabs.svelte'), 'utf8');
+    expect(content).toContain('crit_damage');
+    expect(content).toContain('effect_hit_rate');
+    expect(content).toContain('dodge_odds');
+    expect(content).toContain('effect_resistance');
+  });
+
   test('filters unowned characters and normalizes element names', () => {
     const content = readFileSync(join(import.meta.dir, '../src/lib/PartyPicker.svelte'), 'utf8');
     expect(content).toContain('filter((p) => p.owned || p.is_player)');


### PR DESCRIPTION
## Summary
- fix stat tabs to read crit_damage, effect_hit_rate, dodge_odds, effect_resistance
- test that StatTabs references updated stat keys

## Testing
- `bun test frontend/tests/partypicker.test.js`


------
https://chatgpt.com/codex/tasks/task_b_68ad28b62b38832c813cfff576dc4330