### PR TITLE
[FEAT] Add LLM memory safety checks

### DIFF
--- a/backend/.codex/implementation/llm-loader.md
+++ b/backend/.codex/implementation/llm-loader.md
@@ -12,3 +12,14 @@ The loader in `backend/llms/loader.py` wraps several LangChain-compatible backen
 - `AF_GGUF_PATH` provides the path to the GGUF file when using `gguf`.
 
 `load_llm()` returns an object exposing `async generate_stream(text: str) -> AsyncIterator[str]`.
+
+## Resource Checks
+
+`backend/llms/safety.py` inspects available system memory and GPU VRAM before
+loading a model. Memory requirements for Hugging Face models are derived from
+the reported weight file sizes, removing the need for hard‑coded numbers. When a
+GPU is present the Hugging Face pipeline uses `device_map="auto"` so layers that
+do not fit in VRAM are automatically offloaded to system RAM. When overall RAM
+is insufficient a `RuntimeError` is raised with a descriptive message. GGUF
+models estimate requirements from the file size and compute how many layers to
+run on the GPU based on available VRAM, sharding the remainder to the CPU.

--- a/backend/llms/safety.py
+++ b/backend/llms/safety.py
@@ -1,0 +1,122 @@
+import os
+from typing import Any
+
+try:
+    import torch
+except Exception:  # pragma: no cover - optional dependency
+    torch = None
+
+try:
+    import psutil
+except Exception:  # pragma: no cover - optional dependency
+    psutil = None
+
+try:
+    from huggingface_hub import HfApi
+except Exception:  # pragma: no cover - optional dependency
+    HfApi = None
+
+try:  # pragma: no cover - optional dependency
+    import gguf  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    gguf = None
+
+
+def get_available_memory() -> int:
+    """Return available system memory in bytes."""
+    if psutil is not None:
+        return int(psutil.virtual_memory().available)
+    if hasattr(os, "sysconf"):
+        page_size = os.sysconf("SC_PAGE_SIZE")
+        avail_pages = os.sysconf("SC_AVPHYS_PAGES")
+        return int(page_size * avail_pages)
+    return 0
+
+
+def get_available_vram() -> int | None:
+    """Return total VRAM for CUDA device 0 in bytes, if available."""
+    if torch is not None and torch.cuda.is_available():
+        return int(torch.cuda.get_device_properties(0).total_memory)
+    return None
+
+
+def ensure_ram(required: int) -> None:
+    """Raise RuntimeError when available RAM is below ``required`` bytes."""
+    available = get_available_memory()
+    if available < required:
+        msg = (
+            f"{required / 2**30:.1f}GB system memory required, "
+            f"but only {available / 2**30:.1f}GB detected"
+        )
+        raise RuntimeError(msg)
+
+
+def pick_device(min_vram: int | None = None) -> int:
+    """Return 0 for GPU if ``min_vram`` satisfied, else -1 for CPU."""
+    available_vram = get_available_vram()
+    if available_vram is not None and (min_vram is None or available_vram >= min_vram):
+        return 0
+    if min_vram is not None:
+        msg = (
+            f"{min_vram / 2**30:.1f}GB VRAM required, "
+            f"but only {(available_vram or 0) / 2**30:.1f}GB detected"
+        )
+        raise RuntimeError(msg)
+    return -1
+
+
+def model_memory_requirements(model: str) -> tuple[int, int]:
+    """Estimate RAM and VRAM requirements in bytes for a Hugging Face model."""
+    if HfApi is None:
+        return 0, 0
+    api = HfApi()
+    try:  # pragma: no cover - network dependent
+        info = api.model_info(model, files_metadata=True)
+    except Exception:  # pragma: no cover - network dependent
+        return 0, 0
+    size = 0
+    for file in info.siblings:
+        if file.rfilename.endswith((".safetensors", ".bin")) and file.size is not None:
+            size += file.size
+    if size == 0:
+        return 0, 0
+    return int(size * 2), int(size)
+
+
+def _layer_count(path: str) -> int:
+    """Return transformer layer count if metadata is available."""
+    if gguf is None:
+        return 0
+    try:  # pragma: no cover - optional dependency
+        reader = gguf.GGUFReader(path)
+        return int(reader.get_meta("llama.block_count", 0))
+    except Exception:  # pragma: no cover - optional dependency
+        return 0
+
+
+def gguf_strategy(path: str) -> dict[str, Any]:
+    """Select LlamaCpp kwargs based on available memory."""
+    try:
+        size = os.path.getsize(path)
+    except OSError:
+        size = 0
+    ensure_ram(size)
+    vram = get_available_vram()
+    if vram is None or size == 0:
+        return {"n_gpu_layers": 0}
+    if vram >= size:
+        return {"n_gpu_layers": -1}
+    layers = _layer_count(path)
+    per_layer = size / (layers or 100)
+    n_gpu_layers = int(vram / per_layer)
+    return {"n_gpu_layers": max(0, n_gpu_layers)}
+
+
+__all__ = [
+    "ensure_ram",
+    "get_available_memory",
+    "get_available_vram",
+    "gguf_strategy",
+    "model_memory_requirements",
+    "pick_device",
+]

--- a/backend/tests/test_llm_loader.py
+++ b/backend/tests/test_llm_loader.py
@@ -1,5 +1,4 @@
 import asyncio
-
 import pytest
 
 from llms.loader import ModelName
@@ -33,8 +32,12 @@ async def _collect(llm) -> str:
 
 @pytest.mark.asyncio
 async def test_deepseek_loader(monkeypatch: pytest.MonkeyPatch) -> None:
-    def fake_pipeline(task: str, *, model: str) -> FakePipeline:
+    monkeypatch.setattr("llms.loader.model_memory_requirements", lambda name: (0, 0))
+    monkeypatch.setattr("llms.loader.ensure_ram", lambda required: None)
+    monkeypatch.setattr("llms.loader.pick_device", lambda: -1)
+    def fake_pipeline(task: str, *, model: str, **kwargs: object) -> FakePipeline:
         assert model == ModelName.DEEPSEEK.value
+        assert kwargs.get("device") == -1
         return FakePipeline(" ds")
 
     monkeypatch.setattr("llms.loader.pipeline", fake_pipeline)
@@ -45,8 +48,12 @@ async def test_deepseek_loader(monkeypatch: pytest.MonkeyPatch) -> None:
 
 @pytest.mark.asyncio
 async def test_gemma_loader(monkeypatch: pytest.MonkeyPatch) -> None:
-    def fake_pipeline(task: str, *, model: str) -> FakePipeline:
+    monkeypatch.setattr("llms.loader.model_memory_requirements", lambda name: (0, 0))
+    monkeypatch.setattr("llms.loader.ensure_ram", lambda required: None)
+    monkeypatch.setattr("llms.loader.pick_device", lambda: -1)
+    def fake_pipeline(task: str, *, model: str, **kwargs: object) -> FakePipeline:
         assert model == ModelName.GEMMA.value
+        assert kwargs.get("device") == -1
         return FakePipeline(" gm")
 
     monkeypatch.setattr("llms.loader.pipeline", fake_pipeline)
@@ -57,6 +64,9 @@ async def test_gemma_loader(monkeypatch: pytest.MonkeyPatch) -> None:
 
 @pytest.mark.asyncio
 async def test_gguf_loader(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("llms.loader.model_memory_requirements", lambda name: (0, 0))
+    monkeypatch.setattr("llms.loader.ensure_ram", lambda required: None)
+    monkeypatch.setattr("llms.loader.pick_device", lambda: -1)
     monkeypatch.setattr("llms.loader.LlamaCpp", FakeLlama)
     llm = load_llm(ModelName.GGUF.value, gguf_path="path/to/model.gguf")
     result = await _collect(llm)


### PR DESCRIPTION
## Summary
- derive RAM/VRAM requirements for Hugging Face models from weight metadata
- offload GGUF layers to GPU based on available VRAM or fall back to CPU
- load Hugging Face models with `device_map="auto"` so excess layers spill to system RAM

## Testing
- `uv venv`
- `uv sync`
- `bun install`
- `./run-tests.sh` *(fails: backend tests/test_app.py, tests/test_damage_type_on_action.py, tests/test_gacha.py, tests/test_rdr.py, tests/test_relic_rewards.py timed out)*

------
https://chatgpt.com/codex/tasks/task_b_68ad2f3bf638832ca9536febeeef2aa5