### PR TITLE
Gracefully handle optional LLM dependencies

### DIFF
--- a/backend/.codex/implementation/llm-loader.md
+++ b/backend/.codex/implementation/llm-loader.md
@@ -13,6 +13,11 @@ The loader in `backend/llms/loader.py` wraps several LangChain-compatible backen
 
 `load_llm()` returns an object exposing `async generate_stream(text: str) -> AsyncIterator[str]`.
 
+Optional dependencies such as PyTorch and Transformers are imported lazily. If
+these packages are absent, `load_llm()` raises a `RuntimeError` when called
+instead of failing during module import, allowing the rest of the backend to
+run without LLM features.
+
 ## Resource Checks
 
 `backend/llms/safety.py` inspects available system memory and GPU VRAM before

--- a/backend/.codex/implementation/lrm-config.md
+++ b/backend/.codex/implementation/lrm-config.md
@@ -7,5 +7,9 @@ The configuration routes expose and persist language reasoning model choices.
 - `POST /config/lrm` persists the selected model string in the `options` table.
 - `POST /config/lrm/test` runs the stored model on a provided prompt without memory and returns the raw reply.
 
+The import of `load_llm` is deferred inside the `/config/lrm/test` endpoint so
+the other configuration routes remain operational even when optional LLM
+dependencies are missing.
+
 ## Chat Rooms
 `ChatRoom.resolve()` reads the persisted model via `options.get_option`, loads it with `load_llm`, and sends the user's message and serialized party context to the model. The LRM's reply is returned as `response` alongside existing room data.

--- a/backend/routes/config.py
+++ b/backend/routes/config.py
@@ -2,14 +2,13 @@ from __future__ import annotations
 
 import json
 
-from quart import Blueprint
 from quart import jsonify
 from quart import request
+from quart import Blueprint
 
-from llms.loader import ModelName
-from llms.loader import load_llm
 from options import get_option
 from options import set_option
+from llms.loader import ModelName
 
 bp = Blueprint("config", __name__, url_prefix="/config")
 
@@ -35,6 +34,8 @@ async def set_lrm_model() -> tuple[str, int, dict[str, str]]:
 
 @bp.post("/lrm/test")
 async def test_lrm_model() -> tuple[str, int, dict[str, str]]:
+    from llms.loader import load_llm
+
     data = await request.get_json()
     prompt = data.get("prompt", "")
     model = get_option(_OPTION_KEY, ModelName.DEEPSEEK.value)

--- a/backend/routes/players.py
+++ b/backend/routes/players.py
@@ -58,6 +58,7 @@ async def get_players() -> tuple[str, int, dict[str, str]]:
         if inst.id == "player":
             await asyncio.to_thread(_apply_player_customization, inst)
         stats = asdict(inst)
+        stats.pop("lrm_memory", None)
         stats["char_type"] = inst.char_type.name
         stats["damage_type"] = inst.element_id
         roster.append(

--- a/backend/tests/test_app_without_llm_deps.py
+++ b/backend/tests/test_app_without_llm_deps.py
@@ -1,0 +1,47 @@
+import builtins
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture()
+def app_without_llm(tmp_path, monkeypatch):
+    db_path = tmp_path / "save.db"
+    monkeypatch.setenv("AF_DB_PATH", str(db_path))
+    monkeypatch.setenv("AF_DB_KEY", "testkey")
+
+    original_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "torch":
+            raise ImportError("No module named 'torch'")
+        return original_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    monkeypatch.syspath_prepend(Path(__file__).resolve().parents[1])
+    spec = importlib.util.spec_from_file_location(
+        "app", Path(__file__).resolve().parents[1] / "app.py",
+    )
+    app_module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(app_module)
+    app_module.app.testing = True
+    return app_module.app
+
+
+@pytest.mark.asyncio
+async def test_non_llm_endpoints_work_without_deps(app_without_llm):
+    app = app_without_llm
+    client = app.test_client()
+
+    status_resp = await client.get("/")
+    assert status_resp.status_code == 200
+
+    config_resp = await client.get("/config/lrm")
+    assert config_resp.status_code == 200
+    data = await config_resp.get_json()
+    assert "available_models" in data
+
+    players_resp = await client.get("/players")
+    assert players_resp.status_code == 200

--- a/backend/tests/test_config_lrm.py
+++ b/backend/tests/test_config_lrm.py
@@ -1,10 +1,10 @@
-from __future__ import annotations
-
+import sys
 import importlib.util
 from pathlib import Path
 
 import pytest
 
+sys.path.append(str(Path(__file__).resolve().parents[1]))
 from llms.loader import ModelName
 
 
@@ -49,7 +49,7 @@ async def test_lrm_config_endpoints(app_with_db, monkeypatch):
         calls["model"] = model
         return FakeLLM()
 
-    monkeypatch.setattr("routes.config.load_llm", fake_loader)
+    monkeypatch.setattr("llms.loader.load_llm", fake_loader)
     resp = await client.post("/config/lrm/test", json={"prompt": "hi"})
     data = await resp.get_json()
     assert data["response"] == "echo:hi"


### PR DESCRIPTION
## Summary
- Avoid importing heavy LLM deps until needed and provide clear runtime error when missing
- Load LLM helper only within the LRM test route so other config endpoints work without extras
- Strip non-serializable LRM memory from player stats so roster endpoint works without torch
- Add tests ensuring backend starts and non-LLM routes operate without optional packages

## Testing
- `PYTHONPATH=. uv run pytest tests/test_config_lrm.py tests/test_llm_loader.py tests/test_app_without_llm_deps.py`
- `./run-tests.sh` *(fails: backend tests/test_app.py, backend tests/test_battle_defeat.py, backend tests/test_battle_error_snapshot.py, backend tests/test_battle_loot_items.py, backend tests/test_battle_rewards.py, backend tests/test_battle_snapshot_consistency.py, backend tests/test_battle_timing.py, backend tests/test_card_rewards.py, backend tests/test_chat_room.py, backend tests/test_damage_type_assignment.py, backend tests/test_damage_type_on_action.py, backend tests/test_effect_serialization.py, backend tests/test_enrage_stacking.py, backend tests/test_exp_leveling.py, backend tests/test_fire_damage_scaling.py, backend tests/test_frozen_wound.py, backend tests/test_loot_summary.py, backend tests/test_party_endpoint.py, backend tests/test_party_persistence.py, backend tests/test_player_editor.py, backend tests/test_plugin_logging.py, backend tests/test_pressure_scaling.py, backend tests/test_rdr.py, backend tests/test_relic_effects.py, backend tests/test_relic_effects_advanced.py, backend tests/test_relic_rewards.py, backend tests/test_save_management.py, backend tests/test_shop_room.py, backend tests/test_wind_multi_target.py; timed out backend tests/test_gacha.py)*

------
https://chatgpt.com/codex/tasks/task_b_68ae1606f028832cb34394889cbe48c1