### PR TITLE
feat: add desktop builder tooling

### DIFF
--- a/.codex/instructions/building-desktop.md
+++ b/.codex/instructions/building-desktop.md
@@ -1,0 +1,19 @@
+# Building Desktop Packages
+
+Docker-based tooling in `desktop-builder/` produces native binaries for Windows and Linux.
+
+## Usage
+
+Run the helper scripts from the repository root:
+
+```bash
+./desktop-builder/build-windows.sh   # writes .exe to desktop-dist/windows
+./desktop-builder/build-linux.sh     # writes .AppImage and .tar.gz to desktop-dist/linux
+```
+
+Each script builds a container that:
+
+1. Compiles the Python backend with PyInstaller using `uv`.
+2. Bundles the Svelte frontend with Tauri and `bun`.
+
+Artifacts are copied to the `desktop-dist/` folder on the host.

--- a/README.md
+++ b/README.md
@@ -96,6 +96,19 @@ Docker images for both services will be published to Docker Hub. Native
 dependencies are handled inside the images, so no manual wheel management is
 required.
 
+## Desktop Builds
+
+Scripts under `desktop-builder/` package the app for Windows and Linux. Each
+script builds a Docker image that compiles the Python backend with PyInstaller
+and bundles the Svelte frontend with Tauri.
+
+```bash
+./desktop-builder/build-windows.sh   # outputs .exe to desktop-dist/windows
+./desktop-builder/build-linux.sh     # outputs .AppImage and .tar.gz to desktop-dist/linux
+```
+
+See `.codex/instructions/building-desktop.md` for details.
+
 ## Testing
 
 Run the test suites before submitting changes with the helper script:

--- a/desktop-builder/Dockerfile.linux
+++ b/desktop-builder/Dockerfile.linux
@@ -1,0 +1,39 @@
+FROM lunamidori5/pixelarch:topaz
+
+# Rename OS for clarity in image metadata
+RUN sudo sed -i 's/Topaz/Desktop-Builder/g' /etc/os-release
+
+# Install development tools, node, and rust
+RUN yay -Syu --noconfirm base-devel git nodejs npm curl wget unzip rust
+
+# Install uv and bun via package manager
+RUN yay -S --noconfirm uv bun-bin
+
+# Clean package cache
+RUN yay -Yccc --noconfirm
+
+# Install Tauri CLI
+RUN cargo install tauri-cli
+
+WORKDIR /workspace
+
+COPY backend ./backend
+COPY frontend ./frontend
+
+# Build the backend into a standalone binary
+WORKDIR /workspace/backend
+RUN uv sync
+RUN uv run pyinstaller --onefile app.py
+RUN mkdir -p /bundle/backend
+RUN mv dist/app /bundle/backend/app
+
+# Build the frontend and package with Tauri
+WORKDIR /workspace/frontend
+RUN bun install
+RUN bun run build
+RUN cargo tauri build
+RUN mkdir -p /bundle/frontend
+RUN cp src-tauri/target/release/bundle/appimage/*.AppImage /bundle/frontend/ || true
+RUN cp src-tauri/target/release/bundle/appimage/*.tar.gz /bundle/frontend/ || true
+
+CMD cp -r /bundle/* /output

--- a/desktop-builder/Dockerfile.windows
+++ b/desktop-builder/Dockerfile.windows
@@ -1,0 +1,52 @@
+FROM lunamidori5/pixelarch:topaz
+
+# Rename OS for clarity in image metadata
+RUN sudo sed -i 's/Topaz/Desktop-Builder/g' /etc/os-release
+
+# Install development tools, node, Wine, and rust
+RUN yay -Syu --noconfirm base-devel git nodejs npm curl wget unzip wine xvfb rust
+
+# Install uv and bun via package manager
+RUN yay -S --noconfirm uv bun-bin
+
+# Clean package cache
+RUN yay -Yccc --noconfirm
+
+# Install Tauri CLI
+RUN cargo install tauri-cli
+
+WORKDIR /workspace
+COPY backend ./backend
+COPY frontend ./frontend
+
+# Prepare Wine prefix with Windows Python
+ENV WINEPREFIX=/tmp/wine-python
+ENV WINEARCH=win64
+WORKDIR /tmp/wine-python
+RUN winecfg /v win10
+RUN wget "https://www.python.org/ftp/python/3.12.7/python-3.12.7-amd64.exe"
+RUN xvfb-run wine python-3.12.7-amd64.exe /quiet InstallAllUsers=1 PrependPath=1 Include_test=0
+
+# Export backend requirements and copy into Wine prefix
+WORKDIR /workspace/backend
+RUN uv export --no-dev --format requirements-txt > requirements.txt
+RUN cp -r /workspace/backend /tmp/wine-python/
+
+# Build the backend into a Windows executable using Wine
+WORKDIR /tmp/wine-python/backend
+RUN xvfb-run wine python -m ensurepip
+RUN xvfb-run wine python -m pip install --upgrade pip
+RUN xvfb-run wine python -m pip install -r requirements.txt pyinstaller
+RUN xvfb-run wine pyinstaller --onefile app.py
+RUN mkdir -p /bundle/backend
+RUN mv dist/app.exe /bundle/backend/app.exe
+
+# Build the frontend and package with Tauri
+WORKDIR /workspace/frontend
+RUN bun install
+RUN bun run build
+RUN cargo tauri build --target x86_64-pc-windows-gnu
+RUN mkdir -p /bundle/frontend
+RUN cp -r src-tauri/target/x86_64-pc-windows-gnu/release/bundle/msi /bundle/frontend || true
+
+CMD cp -r /bundle/* /output

--- a/desktop-builder/build-linux.sh
+++ b/desktop-builder/build-linux.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+mkdir -p "$ROOT_DIR/desktop-dist/linux"
+
+docker build -f desktop-builder/Dockerfile.linux -t autofighter-desktop-linux "$ROOT_DIR"
+docker run --rm -v "$ROOT_DIR/desktop-dist/linux:/output" autofighter-desktop-linux

--- a/desktop-builder/build-windows.sh
+++ b/desktop-builder/build-windows.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+mkdir -p "$ROOT_DIR/desktop-dist/windows"
+
+docker build -f desktop-builder/Dockerfile.windows -t autofighter-desktop-win "$ROOT_DIR"
+docker run --rm -v "$ROOT_DIR/desktop-dist/windows:/output" autofighter-desktop-win


### PR DESCRIPTION
## Summary
- add Docker-based desktop builder for Windows (.exe) and Linux (.AppImage/.tar.gz)
- document desktop build usage in README and `.codex`
- switch desktop builder to PixelArch base images
- install desktop builder toolchains with `yay` and split build steps into separate layers
- build Windows backend under Wine and use system `rust` package

## Testing
- `./run-tests.sh` (failures: tests/test_player_editor.py::test_player_editor_update_and_fetch, tests/test_player_editor.py::test_player_editor_snapshot_during_run, tests/test_relic_effects.py::test_vengeful_pendant_reflects, tests/test_relic_effects.py::test_vengeful_pendant_stacks, tests/test_relic_effects.py::test_shiny_pebble_first_hit_mitigation, tests/test_relic_effects.py::test_shiny_pebble_stacks, tests/test_relic_effects.py::test_threadbare_cloak_shield_stacks, tests/test_relic_effects.py::test_arcane_flask_shields, tests/test_relic_effects.py::test_echo_bell_repeats_first_action, tests/test_relic_effects_advanced.py::test_greed_engine_drains_and_rewards, tests/test_relic_effects_advanced.py::test_greed_engine_stacks, tests/test_relic_effects_advanced.py::test_echoing_drum_repeats_attack, tests/test_relic_effects_advanced.py::test_echoing_drum_stacks, tests/test_save_management.py::test_backup_restore_and_wipe, tests/test_save_management.py::test_wipe_allows_new_run, tests/test_save_management.py::test_wipe_seeds_random_persona)
- `uv run ruff check .` (warnings: Invalid rule code provided to `# noqa` at backend/options.py:6 and backend/options.py:18)


------
https://chatgpt.com/codex/tasks/task_b_68ae20039d88832c9bd7a216016cfe19