### PR TITLE
Add packaging configs and CI integration

### DIFF
--- a/.github/workflows/build-aur.yml
+++ b/.github/workflows/build-aur.yml
@@ -1,0 +1,19 @@
+name: AUR Build
+
+on:
+  workflow_dispatch:
+
+jobs:
+  aur-build:
+    runs-on: ubuntu-latest
+    container:
+      image: archlinux:latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build PKGBUILD
+        working-directory: packaging/aur
+        run: |
+          pacman -Sy --noconfirm base-devel git
+          useradd -m build
+          chown -R build:build .
+          su build -c 'makepkg --printsrcinfo'

--- a/.github/workflows/build-debian.yml
+++ b/.github/workflows/build-debian.yml
@@ -1,0 +1,16 @@
+name: Debian Package Build
+
+on:
+  workflow_dispatch:
+
+jobs:
+  debian-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build Debian package
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential debhelper
+          cp -r packaging/debian debian
+          dpkg-buildpackage -b -us -uc

--- a/.github/workflows/build-flatpak.yml
+++ b/.github/workflows/build-flatpak.yml
@@ -1,0 +1,15 @@
+name: Flatpak Build
+
+on:
+  workflow_dispatch:
+
+jobs:
+  flatpak-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build Flatpak manifest
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y flatpak-builder
+          flatpak-builder --user --install --force-clean builddir packaging/flatpak/org.midori.ai.autofighter.yaml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,3 +104,4 @@ jobs:
       - name: Run frontend linting
         working-directory: frontend
         run: bunx eslint .
+

--- a/README.md
+++ b/README.md
@@ -96,6 +96,28 @@ Docker images for both services will be published to Docker Hub. Native
 dependencies are handled inside the images, so no manual wheel management is
 required.
 
+## Package Installation
+
+Install prebuilt packages when available:
+
+- **Flatpak**
+
+  ```bash
+  flatpak install org.midori.ai.autofighter
+  ```
+
+- **Arch Linux (AUR)**
+
+  ```bash
+  yay -S autofighter-git
+  ```
+
+- **Debian/Ubuntu**
+
+  ```bash
+  sudo apt install ./autofighter.deb
+  ```
+
 ## Desktop Builds
 
 Scripts under `desktop-builder/` package the app for Windows and Linux. Each

--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -1,0 +1,18 @@
+pkgname=autofighter-git
+pkgver=1.0
+pkgrel=1
+arch=('any')
+depends=('python' 'nodejs')
+source=('git+https://github.com/Midori-AI/Midori-AI-AutoFighter.git')
+md5sums=('SKIP')
+
+pkgver() {
+  cd Midori-AI-AutoFighter
+  git rev-list --count HEAD
+}
+
+package() {
+  cd Midori-AI-AutoFighter
+  install -d "$pkgdir/usr/share/autofighter"
+  cp -r backend frontend "$pkgdir/usr/share/autofighter/"
+}

--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -1,0 +1,12 @@
+Source: autofighter
+Section: games
+Priority: optional
+Maintainer: Midori AI <info@midori.ai>
+Standards-Version: 4.6.0
+Build-Depends: debhelper-compat (= 13), python3, nodejs
+
+Package: autofighter
+Architecture: any
+Depends: ${misc:Depends}, ${python3:Depends}, nodejs
+Description: Midori AI AutoFighter
+ Installs backend and frontend assets.

--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -1,0 +1,7 @@
+#!/usr/bin/make -f
+%:
+	dh $@
+
+override_dh_auto_install:
+	mkdir -p $(DESTDIR)/usr/share/autofighter
+	cp -r backend frontend $(DESTDIR)/usr/share/autofighter

--- a/packaging/flatpak/org.midori.ai.autofighter.yaml
+++ b/packaging/flatpak/org.midori.ai.autofighter.yaml
@@ -1,0 +1,16 @@
+app-id: org.midori.ai.autofighter
+runtime: org.freedesktop.Platform
+runtime-version: '23.08'
+sdk: org.freedesktop.Sdk
+command: bash
+modules:
+  - name: autofighter
+    buildsystem: simple
+    build-commands:
+      - mkdir -p /app/autofighter
+      - cp -r backend frontend /app/autofighter/
+    sources:
+      - type: dir
+        path: ../../
+finish-args:
+  - --share=network


### PR DESCRIPTION
## Summary
- add Flatpak, AUR, and Debian package definitions including backend and frontend assets
- document package installation commands
- expand CI to build package formats
- rename Flatpak manifest to `org.midori.ai.autofighter.yaml`
- split package build jobs into manual workflows

## Testing
- `uvx ruff check . --fix`
- `./run-tests.sh` *(fails: missing `llms` module, backend test assertion errors)*

------
https://chatgpt.com/codex/tasks/task_b_68af1901a610832ca10778df2ddac857