### PR TITLE
[BUGFIX] Clean up zero-count items after crafting

### DIFF
--- a/.codex/implementation/crafting-menu.md
+++ b/.codex/implementation/crafting-menu.md
@@ -11,6 +11,10 @@ materials collapse into a single grid tile with an updated count. Names are
 normalized via `formatName` (e.g., `ice_4` → `Ice ★★★★`,
 `lightning_3` → `Lightning ★★★`) for readability in the detail panel.
 
+During crafting, any inventory entries that drop to zero are purged on the
+backend, and `stackItems` filters out non-positive counts so empty slots never
+render in the menu.
+
 Each grid tile displays an icon loaded from
 `frontend/src/lib/assets/items/{element}/generic{rank}.png` with a colored
 border and matching box shadow derived from the `--star-color` CSS variable

--- a/backend/autofighter/gacha.py
+++ b/backend/autofighter/gacha.py
@@ -122,6 +122,9 @@ class GachaManager:
                 items[f"{element}_4"] -= 10
                 items["ticket"] = items.get("ticket", 0) + 1
 
+        for key in [k for k, v in items.items() if v == 0]:
+            del items[key]
+
     def craft(self) -> dict[str, int]:
         items = self._get_items()
         self._auto_craft(items)

--- a/backend/game.py
+++ b/backend/game.py
@@ -106,7 +106,7 @@ def _apply_player_customization(
     effect: dict[str, object] | None = None,
 ) -> None:
     """Apply player customization effects.
-    
+
     For the base player (id="player"), customization is now applied during instantiation
     so this function only handles saved effects from old save files for backwards compatibility.
     For other players, this still applies mods as before.
@@ -115,7 +115,7 @@ def _apply_player_customization(
         # Base player customization is now handled during instantiation
         log.debug("Skipping mod-based customization for base player (already applied during instantiation)")
         return
-        
+
     # Handle saved effects for backwards compatibility or other players
     if effect is None:
         _, loaded = _load_player_customization()
@@ -131,7 +131,7 @@ def _apply_player_customization(
             "atk_mult": mults.get("atk", 1),
             "defense_mult": mults.get("defense", 1),
         }
-    
+
     # Debug logging to help identify issues
     log.debug(
         "Applying player customization: player_id=%s, loaded_effect=%s, multipliers=%s",
@@ -139,14 +139,14 @@ def _apply_player_customization(
         effect is not None,
         multipliers,
     )
-    
+
     if all(v == 1 for v in multipliers.values()):
         log.debug("No customizations to apply (all multipliers are 1)")
         return
-        
+
     # Store original stats for debugging
     orig_stats = (player.max_hp, player.atk, player.defense)
-    
+
     mod = create_stat_buff(
         player,
         name="customization",
@@ -155,7 +155,7 @@ def _apply_player_customization(
         **multipliers,
     )
     player.mods.append(mod.id)
-    
+
     # Log the stat changes for debugging
     log.debug(
         "Player customization applied: stats changed from %s to (%d, %d, %d)",

--- a/frontend/src/lib/craftingUtils.js
+++ b/frontend/src/lib/craftingUtils.js
@@ -7,8 +7,13 @@ export function stackItems(raw) {
     }
   } else {
     for (const [key, value] of Object.entries(raw)) {
-      result[key] = (result[key] || 0) + Number(value);
+      const num = Number(value);
+      if (num <= 0) continue;
+      result[key] = (result[key] || 0) + num;
     }
+  }
+  for (const [key, value] of Object.entries(result)) {
+    if (value === 0) delete result[key];
   }
   return result;
 }


### PR DESCRIPTION
## Summary
- purge items with zero counts after auto crafting
- hide non-positive counts in stackItems
- document zero-count purge for crafting menu

## Testing
- `uv run ruff check backend/autofighter/gacha.py backend/game.py --fix`
- `./run-tests.sh` *(failed: backend tests/test_app.py, backend tests/test_gacha.py timed out; frontend tests/battleview.test.js, frontend tests/partypicker.test.js failed)*

------
https://chatgpt.com/codex/tasks/task_b_68af6363932c832c9950a5f138d5593c