### PR TITLE
Show crafting requirements in menu

### DIFF
--- a/.codex/implementation/crafting-menu.md
+++ b/.codex/implementation/crafting-menu.md
@@ -11,6 +11,11 @@ materials collapse into a single grid tile with an updated count. Names are
 normalized via `formatName` (e.g., `ice_4` → `Ice ★★★★`,
 `lightning_3` → `Lightning ★★★`) for readability in the detail panel.
 
+Selecting an item shows its current quantity alongside the amount required to
+craft (125 for 1★–3★ upgrades, 10 for converting 4★ items into a ticket). The
+Craft button remains disabled until at least one stack meets these thresholds,
+preventing accidental calls when nothing can be upgraded.
+
 Each grid tile displays an icon loaded from
 `frontend/src/lib/assets/items/{element}/generic{rank}.png` with a colored
 border and matching box shadow derived from the `--star-color` CSS variable

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -33,7 +33,9 @@ high‑contrast icon grid powered by `lucide-svelte`.
 - Pulls: Calls `/gacha/pull` so players can recruit 5★ or 6★ characters or
   earn 1★–4★ upgrade items between runs. Pity raises the odds of higher‑tier
   items; auto‑crafting is an optional toggle under Crafting.
-- Craft: Lists upgrade items and offers `/gacha/craft` and `/gacha/auto-craft`.
+- Craft: Lists upgrade items, shows 125×/10× requirements, and offers
+  `/gacha/craft` and `/gacha/auto-craft`. The Craft button is disabled until
+  enough materials exist.
 - Inventory: Moved to the in‑run top‑left NavBar (disabled during battles).
 - Feedback: Opens a pre‑filled GitHub issue in a new tab.
 During combat, party members appear in a left column and foes on the right,

--- a/frontend/src/lib/CraftingMenu.svelte
+++ b/frontend/src/lib/CraftingMenu.svelte
@@ -59,6 +59,8 @@
   let items = {};
   let autoCraft = false;
   let selected = null;
+  let craftable = false;
+  let selectedRequirement = 0;
 
   onMount(async () => {
     const state = await getGacha();
@@ -79,6 +81,20 @@
   function close() {
     dispatch('close');
   }
+
+  function getRequirement(key) {
+    const rank = parseInt(String(key).split('_')[1]);
+    if (rank >= 1 && rank <= 3) return 125;
+    if (rank === 4) return 10;
+    return 0;
+  }
+
+  $: craftable = Object.entries(items).some(([key, count]) => {
+    const req = getRequirement(key);
+    return req > 0 && count >= req;
+  });
+
+  $: selectedRequirement = selected ? getRequirement(selected) : 0;
 </script>
 
 <MenuPanel data-testid="crafting-menu">
@@ -112,7 +128,9 @@
           on:error={onIconError}
         />
         <div class="detail-name">{formatName(selected)}</div>
-        <div class="detail-count">x{items[selected]}</div>
+        <div class="detail-count">
+          x{items[selected]}{#if selectedRequirement} / {selectedRequirement}{/if}
+        </div>
       {:else}
         <p class="placeholder">Select an item</p>
       {/if}
@@ -123,7 +141,7 @@
       <input type="checkbox" bind:checked={autoCraft} on:change={toggleAuto} />
       Auto-craft
     </label>
-    <button on:click={craft}>Craft</button>
+    <button on:click={craft} disabled={!craftable}>Craft</button>
     <button on:click={close}>Done</button>
   </div>
 </MenuPanel>


### PR DESCRIPTION
## Summary
- disable Craft button unless enough materials exist and show required amounts for 125×/10× upgrades
- document crafting requirements and button behavior

## Testing
- [ ] Backend tests
- [ ] Frontend tests
- [ ] Linting
- [x] Doc sync updates (README and `.codex/implementation` docs; link tasks below)

## Checklist
- [ ] Linked or updated relevant `.codex/tasks` entries
- [ ] Updated player roster and foe docs if adding or modifying fighters or enemies

------
https://chatgpt.com/codex/tasks/task_b_68af6364032c832cbbea89fbbad9f57d