### PR TITLE
Make card effects asynchronous

### DIFF
--- a/backend/autofighter/cards.py
+++ b/backend/autofighter/cards.py
@@ -30,9 +30,9 @@ def award_card(party: Party, card_id: str) -> CardBase | None:
     party.cards.append(card_id)
     return card_cls()
 
-def apply_cards(party: Party) -> None:
+async def apply_cards(party: Party) -> None:
     registry = _registry()
     for cid in party.cards:
         card_cls = registry.get(cid)
         if card_cls:
-            card_cls().apply(party)
+            await card_cls().apply(party)

--- a/backend/autofighter/rooms/battle.py
+++ b/backend/autofighter/rooms/battle.py
@@ -151,7 +151,7 @@ class BattleRoom(Room):
             cards=party.cards,
             rdr=party.rdr,
         )
-        apply_cards(combat_party)
+        await apply_cards(combat_party)
         apply_relics(combat_party)
         party.rdr = combat_party.rdr
 

--- a/backend/plugins/cards/_base.py
+++ b/backend/plugins/cards/_base.py
@@ -29,7 +29,7 @@ class CardBase:
                 parts.append(f"{sign}{pct * 100:.0f}% {pretty}")
             self.about = ", ".join(parts)
 
-    def apply(self, party: Party) -> None:
+    async def apply(self, party: Party) -> None:
         log.info("Applying card %s to party", self.id)
         for member in party.members:
             log.debug("Applying effects to %s", getattr(member, "id", "member"))
@@ -46,11 +46,11 @@ class CardBase:
                 if attr == "max_hp":
                     heal = int(getattr(member, "hp", 0) * pct)
                     try:
-                        loop = asyncio.get_running_loop()
+                        asyncio.get_running_loop()
                     except RuntimeError:
-                        asyncio.run(member.apply_healing(heal))
+                        await member.apply_healing(heal)
                     else:
-                        loop.create_task(member.apply_healing(heal))
+                        asyncio.create_task(member.apply_healing(heal))
                     log.debug(
                         "Updated %s max_hp and healed %s",
                         getattr(member, "id", "member"),

--- a/backend/tests/test_card_rewards.py
+++ b/backend/tests/test_card_rewards.py
@@ -115,13 +115,14 @@ async def test_battle_offers_choices_and_applies_effect(app_with_db, monkeypatch
 
 
 @pytest.mark.parametrize("card_id,effects", NEW_CARDS)
-def test_award_and_apply_new_cards(card_id, effects):
+@pytest.mark.asyncio
+async def test_award_and_apply_new_cards(card_id, effects):
     member = Stats()
     member.id = "m1"
     party = Party(members=[member])
     baseline = {attr: getattr(member, attr) for attr in effects}
     assert award_card(party, card_id) is not None
-    cards_module.apply_cards(party)
+    await cards_module.apply_cards(party)
     for attr, pct in effects.items():
         value = getattr(member, attr)
         expected = type(baseline[attr])(baseline[attr] * (1 + pct))


### PR DESCRIPTION
## Summary
- make `CardBase.apply` an async method and use `asyncio.create_task` for healing
- require `apply_cards` to be awaited and update battle room and tests

## Testing
- `uvx ruff check backend/plugins/cards/_base.py backend/autofighter/cards.py backend/autofighter/rooms/battle.py backend/tests/test_card_rewards.py --fix`
- `./run-tests.sh` *(fail: frontend tests/battleview.test.js, frontend tests/partypicker.test.js; timed out: backend tests/test_app.py, backend tests/test_gacha.py)*

------
https://chatgpt.com/codex/tasks/task_b_68af67def52c832cbea65e386ea791c2