### PR TITLE
[FIX] Avoid event loop starvation in battle turns

### DIFF
--- a/backend/autofighter/rooms/battle.py
+++ b/backend/autofighter/rooms/battle.py
@@ -203,6 +203,7 @@ class BattleRoom(Room):
         ):
             for member_effect, member in zip(party_effects, combat_party.members, strict=False):
                 if member.hp <= 0:
+                    await asyncio.sleep(0)
                     continue
                 turn += 1
                 if turn > threshold:
@@ -260,6 +261,8 @@ class BattleRoom(Room):
                     elapsed = time.perf_counter() - turn_start
                     if elapsed < 0.5:
                         await asyncio.sleep(0.5 - elapsed)
+                    else:
+                        await asyncio.sleep(0)
                     continue
                 proceed = await member_effect.on_action()
                 if proceed is None:
@@ -289,6 +292,8 @@ class BattleRoom(Room):
                     elapsed = time.perf_counter() - turn_start
                     if elapsed < 0.5:
                         await asyncio.sleep(0.5 - elapsed)
+                    else:
+                        await asyncio.sleep(0)
                     continue
                 dmg = await tgt_foe.apply_damage(member.atk, attacker=member)
                 if dmg <= 0:
@@ -299,6 +304,7 @@ class BattleRoom(Room):
                 if getattr(member.damage_type, "id", "").lower() == "wind":
                     for extra_idx, extra_foe in enumerate(foes):
                         if extra_idx == tgt_idx or extra_foe.hp <= 0:
+                            await asyncio.sleep(0)
                             continue
                         extra_dmg = await extra_foe.apply_damage(
                             member.atk, attacker=member
@@ -381,12 +387,16 @@ class BattleRoom(Room):
                     elapsed = time.perf_counter() - turn_start
                     if elapsed < 0.5:
                         await asyncio.sleep(0.5 - elapsed)
+                    else:
+                        await asyncio.sleep(0)
                     if all(f.hp <= 0 for f in foes):
                         break
+                    await asyncio.sleep(0)
                     continue
                 # Foe actions are handled after all party members act
                 # in a dedicated loop per living foe.
                 # Continue to next party member.
+                await asyncio.sleep(0)
                 continue
             # End of party member loop
             # If party wiped during this round, stop taking actions
@@ -395,6 +405,7 @@ class BattleRoom(Room):
             # Foes: each living foe takes exactly one action per round
             for foe_idx, acting_foe in enumerate(foes):
                 if acting_foe.hp <= 0:
+                    await asyncio.sleep(0)
                     continue
                 alive_targets = [
                     (idx, m)
@@ -416,6 +427,7 @@ class BattleRoom(Room):
                 await foe_mgr.tick(target_effect)
                 if acting_foe.hp <= 0:
                     await registry.trigger("turn_end", acting_foe)
+                    await asyncio.sleep(0)
                     continue
                 proceed = await foe_mgr.on_action()
                 if proceed is None:
@@ -428,6 +440,9 @@ class BattleRoom(Room):
                     elapsed = time.perf_counter() - turn_start
                     if elapsed < 0.5:
                         await asyncio.sleep(0.5 - elapsed)
+                    else:
+                        await asyncio.sleep(0)
+                    await asyncio.sleep(0)
                     continue
                 dmg = await target.apply_damage(acting_foe.atk, attacker=acting_foe)
                 if dmg <= 0:
@@ -439,6 +454,8 @@ class BattleRoom(Room):
                 elapsed = time.perf_counter() - turn_start
                 if elapsed < 0.5:
                     await asyncio.sleep(0.5 - elapsed)
+                else:
+                    await asyncio.sleep(0)
         # Signal completion as soon as the loop ends to help UIs stop polling
         # immediately, even before rewards are fully computed.
         if progress is not None:


### PR DESCRIPTION
## Summary
- yield control to event loop whenever battle turns exceed the frame budget
- pause before early `continue` branches to keep loop responsive

## Testing
- `uv run ruff check autofighter/rooms/battle.py --fix`
- `./run-tests.sh` *(fails: backend tests/test_app.py, backend tests/test_gacha.py timed out; frontend tests/battleview.test.js, frontend tests/partypicker.test.js failed)*

------
https://chatgpt.com/codex/tasks/task_b_68af67be7528832ca5062912897b6385