### PR TITLE
[CLEANUP] remove legacy StatModifier fallback

### DIFF
--- a/.codex/implementation/stats-and-effects.md
+++ b/.codex/implementation/stats-and-effects.md
@@ -39,6 +39,7 @@ Stat changes may be applied in two ways:
 - **Percentage:** float fields such as `crit_rate`, `crit_damage`, `effect_hit_rate`, `effect_resistance`, `vitality`, and `exp_multiplier` represent percentage modifiers.
 
 Effects and passives mutate these fields directly. Percentage values are expressed as decimals (e.g., `0.05` for +5%).
+Stat modifiers are applied through the `Stats.add_effect` API; direct legacy mutations are no longer supported.
 
 ### Player Customization
 Player customization works differently from other stat modifiers. Instead of being applied as temporary effects or mods, customization values are applied directly to base stats during player instantiation. This permanent application prevents stat accumulation bugs while maintaining the intended customization experience. See `player-customization.md` for implementation details.

--- a/backend/autofighter/rooms/battle.py
+++ b/backend/autofighter/rooms/battle.py
@@ -7,7 +7,6 @@ import copy
 from dataclasses import dataclass
 import logging
 import random
-import time
 from typing import Any
 
 from autofighter.cards import apply_cards
@@ -241,7 +240,6 @@ class BattleRoom(Room):
                 else:
                     # Not enraged yet; ensure percent is zero
                     set_enrage_percent(0.0)
-                turn_start = time.perf_counter()
                 await registry.trigger("turn_start", member)
                 log.debug("%s turn start", member.id)
                 await member.maybe_regain(turn)
@@ -258,7 +256,6 @@ class BattleRoom(Room):
                 await member_effect.tick(tgt_mgr)
                 if member.hp <= 0:
                     await registry.trigger("turn_end", member)
-                    elapsed = time.perf_counter() - turn_start
                     await asyncio.sleep(0.001)
                     continue
                 proceed = await member_effect.on_action()
@@ -286,7 +283,6 @@ class BattleRoom(Room):
                                 "rdr": party.rdr,
                             }
                         )
-                    elapsed = time.perf_counter() - turn_start
                     await asyncio.sleep(0.001)
                     continue
                 dmg = await tgt_foe.apply_damage(member.atk, attacker=member)
@@ -378,7 +374,6 @@ class BattleRoom(Room):
                                 m.exp_multiplier += 0.025
                     except Exception:
                         pass
-                    elapsed = time.perf_counter() - turn_start
                     await asyncio.sleep(0.001)
                     if all(f.hp <= 0 for f in foes):
                         break
@@ -428,7 +423,6 @@ class BattleRoom(Room):
                     proceed = True if res is None else bool(res)
                 if not proceed:
                     await registry.trigger("turn_end", acting_foe)
-                    elapsed = time.perf_counter() - turn_start
                     await asyncio.sleep(0.001)
                     await asyncio.sleep(0.001)
                     continue
@@ -439,7 +433,6 @@ class BattleRoom(Room):
                     log.info("%s hits %s for %s", acting_foe.id, target.id, dmg)
                 target_effect.maybe_inflict_dot(acting_foe, dmg)
                 await registry.trigger("turn_end", acting_foe)
-                elapsed = time.perf_counter() - turn_start
                 await asyncio.sleep(0.001)
         # Signal completion as soon as the loop ends to help UIs stop polling
         # immediately, even before rewards are fully computed.


### PR DESCRIPTION
## Summary
- drop legacy StatModifier fallback and rely on Stats.add_effect
- note effect system usage in stats-and-effects doc
- trim unused timing code in battle loop

## Testing
- `uvx ruff check backend/autofighter/effects.py backend/autofighter/rooms/battle.py --fix`
- `./run-tests.sh` *(fails: frontend tests/battleview.test.js, frontend tests/partypicker.test.js)*

------
https://chatgpt.com/codex/tasks/task_b_68b08404dd88832cb006209d11249bc6