### PR TITLE
Remove legacy stats compatibility tests

### DIFF
--- a/backend/tests/test_base_runtime_stats.py
+++ b/backend/tests/test_base_runtime_stats.py
@@ -1,18 +1,18 @@
 """Test the new base stats vs runtime stats system."""
 
-import pytest
-from autofighter.stats import Stats, StatEffect
+from autofighter.stats import StatEffect
+from autofighter.stats import Stats
 
 
 def test_base_stats_initialization():
     """Test that base stats are properly initialized."""
     stats = Stats()
-    
+
     # Check that base stats are set
     assert stats.get_base_stat("max_hp") == 1000
     assert stats.get_base_stat("atk") == 200
     assert stats.get_base_stat("defense") == 200
-    
+
     # Check that runtime stats match base stats initially
     assert stats.max_hp == 1000
     assert stats.atk == 200
@@ -22,11 +22,11 @@ def test_base_stats_initialization():
 def test_stat_effects():
     """Test that effects modify runtime stats without affecting base stats."""
     stats = Stats()
-    
+
     # Store initial base stats
     base_atk = stats.get_base_stat("atk")
     base_defense = stats.get_base_stat("defense")
-    
+
     # Add an effect that increases attack
     attack_effect = StatEffect(
         name="weapon_boost",
@@ -34,11 +34,11 @@ def test_stat_effects():
         source="test_weapon"
     )
     stats.add_effect(attack_effect)
-    
+
     # Runtime stats should be modified
     assert stats.atk == base_atk + 50
     assert stats.defense == base_defense - 10
-    
+
     # Base stats should remain unchanged
     assert stats.get_base_stat("atk") == base_atk
     assert stats.get_base_stat("defense") == base_defense
@@ -47,10 +47,10 @@ def test_stat_effects():
 def test_effect_removal():
     """Test that removing effects restores original runtime stats."""
     stats = Stats()
-    
+
     original_atk = stats.atk
     original_defense = stats.defense
-    
+
     # Add effect
     effect = StatEffect(
         name="temporary_boost",
@@ -58,14 +58,14 @@ def test_effect_removal():
         source="test_card"
     )
     stats.add_effect(effect)
-    
+
     # Verify effect is applied
     assert stats.atk == original_atk + 100
     assert stats.defense == original_defense + 50
-    
+
     # Remove effect
     stats.remove_effect_by_name("temporary_boost")
-    
+
     # Runtime stats should return to original values
     assert stats.atk == original_atk
     assert stats.defense == original_defense
@@ -74,9 +74,9 @@ def test_effect_removal():
 def test_multiple_effects():
     """Test that multiple effects stack correctly."""
     stats = Stats()
-    
+
     original_atk = stats.atk
-    
+
     # Add multiple effects
     effect1 = StatEffect(
         name="effect1",
@@ -84,14 +84,14 @@ def test_multiple_effects():
         source="source1"
     )
     effect2 = StatEffect(
-        name="effect2", 
+        name="effect2",
         stat_modifiers={"atk": 30},
         source="source2"
     )
-    
+
     stats.add_effect(effect1)
     stats.add_effect(effect2)
-    
+
     # Effects should stack
     assert stats.atk == original_atk + 20 + 30
 
@@ -99,9 +99,9 @@ def test_multiple_effects():
 def test_effect_replacement():
     """Test that adding an effect with the same name replaces the old one."""
     stats = Stats()
-    
+
     original_atk = stats.atk
-    
+
     # Add first effect
     effect1 = StatEffect(
         name="weapon_damage",
@@ -110,7 +110,7 @@ def test_effect_replacement():
     )
     stats.add_effect(effect1)
     assert stats.atk == original_atk + 20
-    
+
     # Add effect with same name but different value
     effect2 = StatEffect(
         name="weapon_damage",
@@ -118,7 +118,7 @@ def test_effect_replacement():
         source="weapon"
     )
     stats.add_effect(effect2)
-    
+
     # Should replace, not stack
     assert stats.atk == original_atk + 50
 
@@ -126,23 +126,23 @@ def test_effect_replacement():
 def test_remove_by_source():
     """Test removing all effects from a specific source."""
     stats = Stats()
-    
+
     original_atk = stats.atk
     original_defense = stats.defense
-    
+
     # Add effects from different sources
     card_effect1 = StatEffect("card1", {"atk": 10}, source="card")
     card_effect2 = StatEffect("card2", {"defense": 15}, source="card")
     relic_effect = StatEffect("relic1", {"atk": 5}, source="relic")
-    
+
     stats.add_effect(card_effect1)
     stats.add_effect(card_effect2)
     stats.add_effect(relic_effect)
-    
+
     # Remove all card effects
     removed_count = stats.remove_effect_by_source("card")
     assert removed_count == 2
-    
+
     # Only relic effect should remain
     assert stats.atk == original_atk + 5
     assert stats.defense == original_defense
@@ -151,9 +151,9 @@ def test_remove_by_source():
 def test_temporary_effects():
     """Test temporary effects with duration."""
     stats = Stats()
-    
+
     original_atk = stats.atk
-    
+
     # Add temporary effect
     temp_effect = StatEffect(
         name="temp_boost",
@@ -163,11 +163,11 @@ def test_temporary_effects():
     )
     stats.add_effect(temp_effect)
     assert stats.atk == original_atk + 25
-    
+
     # Tick once
     stats.tick_effects()
     assert stats.atk == original_atk + 25  # Still active
-    
+
     # Tick again
     stats.tick_effects()
     assert stats.atk == original_atk  # Should be expired and removed
@@ -176,34 +176,14 @@ def test_temporary_effects():
 def test_base_stat_modification():
     """Test that base stats can be modified for permanent changes like leveling."""
     stats = Stats()
-    
+
     original_base_atk = stats.get_base_stat("atk")
     original_runtime_atk = stats.atk
-    
+
     # Modify base stat (simulating level up)
     stats.modify_base_stat("atk", 10)
-    
+
     # Both base and runtime should change
     assert stats.get_base_stat("atk") == original_base_atk + 10
     assert stats.atk == original_runtime_atk + 10
 
-
-def test_legacy_compatibility():
-    """Test that legacy adjust_stat methods work but use effects."""
-    stats = Stats()
-    
-    original_atk = stats.atk
-    
-    # Use legacy method
-    stats.adjust_stat_on_gain("atk", 15)
-    
-    # Should modify runtime stat via effect
-    assert stats.atk == original_atk + 15
-    
-    # Base stat should be unchanged
-    assert stats.get_base_stat("atk") == 200  # Default base value
-    
-    # Should create a legacy effect
-    effects = stats.get_active_effects()
-    assert len(effects) == 1
-    assert effects[0].source == "legacy_adjustment"

--- a/backend/tests/test_stats_integration.py
+++ b/backend/tests/test_stats_integration.py
@@ -6,10 +6,12 @@ correctly across all components of the system.
 """
 
 import sys
+
 sys.path.append('.')
 
-from autofighter.stats import Stats, StatEffect
 from autofighter.effects import create_stat_buff
+from autofighter.stats import StatEffect
+from autofighter.stats import Stats
 from plugins.players._base import PlayerBase
 
 
@@ -37,7 +39,7 @@ def test_complete_stats_system():
     # Test 2: PlayerBase functionality
     print('2. Testing PlayerBase class:')
     player = PlayerBase()
-    
+
     # Test permanent base stat change (like leveling)
     original_base = player.get_base_stat('atk')
     player.modify_base_stat('atk', 10)
@@ -56,10 +58,10 @@ def test_complete_stats_system():
     print('3. Testing StatModifier integration:')
     initial_effects = len(player.get_active_effects())
     modifier = create_stat_buff(player, name='weapon_enchant', atk=20, defense_mult=1.5)
-    
+
     new_effects = len(player.get_active_effects())
     assert new_effects > initial_effects, "StatModifier should create effects"
-    
+
     # Cleanup
     modifier.remove()
     player.remove_effect_by_name('battle_buff')
@@ -68,21 +70,9 @@ def test_complete_stats_system():
     assert final_atk == expected_final, f"After cleanup, should have {expected_final} atk"
     print('   ✓ Effect cleanup working correctly\n')
 
-    # Test 4: Legacy compatibility
-    print('4. Testing legacy compatibility:')
-    pre_legacy_base = player.get_base_stat('atk')
-    pre_legacy_runtime = player.atk
-    
-    player.adjust_stat_on_gain('atk', 12)  # Legacy method
-    
-    # Base should be unchanged, runtime should be modified via effect
-    assert player.get_base_stat('atk') == pre_legacy_base, "Legacy method should not modify base stats"
-    assert player.atk == pre_legacy_runtime + 12, "Legacy method should modify runtime via effect"
-    print('   ✓ Legacy compatibility working correctly\n')
-
     print('=== ALL INTEGRATION TESTS PASSED ===\n')
     print('🎉 STATS REFACTORING SUCCESSFULLY IMPLEMENTED! 🎉\n')
-    
+
     return True
 
 


### PR DESCRIPTION
## Summary
- clean up legacy stats checks in integration and unit tests

## Testing
- [x] Backend tests
- [ ] Frontend tests
- [x] Linting
- [ ] Doc sync updates (README and `.codex/implementation` docs; link tasks below)

## Checklist
- [ ] Linked or updated relevant `.codex/tasks` entries
- [ ] Updated player roster and foe docs if adding or modifying fighters or enemies

------
https://chatgpt.com/codex/tasks/task_b_68b0841be580832cbee60221c2a560b5