### PR TITLE
[build] use folderhash version identifiers

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "autofighter"
-version = "0.1.0"
+version = "0+46b3b6ae6dff630fbeea9172522e407b8c38867d2830c4c66e3da7761f88fa0e"
 description = "Quart backend for Midori AI AutoFighter"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/build/mobile/package.json
+++ b/build/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "autofighter-mobile",
-  "version": "0.1.0",
+  "version": "0.0.0+46b3b6ae6dff630fbeea9172522e407b8c38867d2830c4c66e3da7761f88fa0e",
   "private": true,
   "scripts": {
     "build:web": "cd ../../frontend && bun run build",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,29 +1,29 @@
 {
-	"name": "frontend",
-	"private": true,
-	"version": "0.0.1",
-	"type": "module",
-	"scripts": {
-		"dev": "vite dev --port 59001",
-		"build": "vite build",
-		"preview": "vite preview",
-		"prepare": "svelte-kit sync || echo ''",
-		"lint": "eslint src/",
-		"lint:fix": "eslint src/ --fix"
-	},
-	"devDependencies": {
-		"@eslint/js": "^9.34.0",
-		"@sveltejs/adapter-auto": "^6.0.0",
-		"@sveltejs/kit": "^2.22.0",
-		"@sveltejs/vite-plugin-svelte": "^6.0.0",
-		"eslint": "^9.34.0",
-		"globals": "^16.3.0",
-		"svelte": "^5.0.0",
-		"vite": "^7.0.4",
-		"vite-plugin-static-copy": "^3.1.2"
-	},
-	"dependencies": {
-		"@zaniar/effekseer-webgl-wasm": "^1.62.5000",
-		"lucide-svelte": "^0.539.0"
-	}
+  "name": "frontend",
+  "private": true,
+  "version": "0.0.0+46b3b6ae6dff630fbeea9172522e407b8c38867d2830c4c66e3da7761f88fa0e",
+  "type": "module",
+  "scripts": {
+    "dev": "vite dev --port 59001",
+    "build": "vite build",
+    "preview": "vite preview",
+    "prepare": "svelte-kit sync || echo ''",
+    "lint": "eslint src/",
+    "lint:fix": "eslint src/ --fix"
+  },
+  "devDependencies": {
+    "@eslint/js": "^9.34.0",
+    "@sveltejs/adapter-auto": "^6.0.0",
+    "@sveltejs/kit": "^2.22.0",
+    "@sveltejs/vite-plugin-svelte": "^6.0.0",
+    "eslint": "^9.34.0",
+    "globals": "^16.3.0",
+    "svelte": "^5.0.0",
+    "vite": "^7.0.4",
+    "vite-plugin-static-copy": "^3.1.2"
+  },
+  "dependencies": {
+    "@zaniar/effekseer-webgl-wasm": "^1.62.5000",
+    "lucide-svelte": "^0.539.0"
+  }
 }


### PR DESCRIPTION
## Summary
- derive backend, frontend, and mobile package versions from folder hash
- check repository for remaining hard-coded package versions

## Testing
- `ruff check . --fix`
- `bun run lint`
- `bun test` *(fails: PartyPicker orders stats correctly, PartyPicker uses element colors for icon and outline, PartyPicker roster layout snapshot, BattleView enrage indicator defines animation)*
- `./run-tests.sh` *(fails: test_many_dots_performance and numerous other backend tests; see logs)*

------
https://chatgpt.com/codex/tasks/task_b_68b08758b5dc832c93e85b04161292f7