### PR TITLE
[DOCS] remind to sync version fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ legacy/     # Previous Pygame version (read-only)
 
 1. Install [uv](https://github.com/astral-sh/uv) and
    [bun](https://bun.sh/).
+
+   > **Reminder:** Keep the `version` fields in [`backend/pyproject.toml`](backend/pyproject.toml) and [`frontend/package.json`](frontend/package.json) in sync with the repository `folderhash`; update them with every change.
 2. Start both services with Docker Compose (bind-mounted source):
 
 ```bash


### PR DESCRIPTION
## Summary
- note to keep backend and frontend version fields in sync with folderhash

## Testing
- `ruff check . --fix`
- `./run-tests.sh` *(fails: multiple backend tests missing dependencies and assertions)*

------
https://chatgpt.com/codex/tasks/task_b_68b08e2361d4832c8eed609a2959d680