### PR TITLE
[DOCS] Add Luna item prompt list

### DIFF
--- a/luna_items_prompts.txt
+++ b/luna_items_prompts.txt
@@ -1,0 +1,64 @@
+=== Cards ===
+Adamantine Band: Luna slipping on an adamantine band, a dark steel ring engraved with tiny sigils, shimmering with unyielding, rock-hard resilience.
+Balanced Diet: Luna enjoying a balanced diet, holding a rustic plate stacked with colorful vegetables, golden grains, and succulent fruits, each morsel radiating vitality.
+Battle Meditation: Luna seated cross-legged, battle meditation flowing, a faint aura swirling around her as she grips a carved wooden focus, channeling calm amid chaos.
+Bulwark Totem: Luna planting a bulwark totem, a stout wooden pillar studded with iron nails and protective runes, its base rooted in the earth like a guardian.
+Calm Beads: Luna fingering calm beads, a string of smooth jade spheres that glint softly, their surface polished by centuries of gentle prayers.
+Coated Armor: Luna fastening coated armor, plates of dark steel lacquered with glossy protective resin, each panel reflecting a hardened, weather-proof sheen.
+Enduring Charm: Luna clasping an enduring charm, a silver amulet shaped like an infinity loop, its surface engraved with patient, looping patterns.
+Enduring Will: Luna gripping an enduring will talisman, a small iron emblem shaped like a steadfast flame, radiating stubborn, unwavering energy.
+Energizing Tea: Luna sipping energizing tea from a steaming porcelain cup, fragrant mint leaves swirling in amber liquid, warmth flowing through her limbs.
+Expert Manual: Luna studying an expert manual, a hefty leather-bound tome whose pages overflow with crisp diagrams and meticulous notes in fine ink.
+Farsight Scope: Luna peering through a farsight scope, a polished brass spyglass with tiny adjustment knobs and etched distance markings along its long barrel.
+Fortified Plating: Luna bolting on fortified plating, overlapping slabs of iron reinforced with riveted ribs, giving her armor a layered, tank-like profile.
+Guardian Shard: Luna cradling a guardian shard, a translucent crystal shard that pulses with soft blue light, like a fragment of a protective barrier.
+Guiding Compass: Luna consulting a guiding compass, a brass instrument whose needle spins over an intricate star map etched under a glass dome.
+Honed Point: Luna polishing a honed point, a narrow spear tip sharpened to a gleaming edge, sparks leaping as stone meets metal.
+Inspiring Banner: Luna waving an inspiring banner, a long cloth standard painted with bold colors and heroic sigils, fluttering high in a sudden breeze.
+Keen Goggles: Luna adjusting keen goggles, sleek leather eyewear with crystal lenses and tiny gears, magnifying distant threats with crisp clarity.
+Lightweight Boots: Luna lacing lightweight boots, supple leather footwear trimmed with airy fabric, soles barely touching the ground as if she floats.
+Lucky Coin: Luna flipping a lucky coin, a worn brass piece with a hole in its center and faintly smiling faces stamped on either side.
+Micro Blade: Luna brandishing a micro blade, a finger-length dagger of gleaming steel, its needle-fine edge reflecting light like a shard of ice.
+Mindful Tassel: Luna fastening a mindful tassel to her belt, threads of crimson and gold dangling from a carved wooden bead, swaying with every mindful breath.
+Polished Shield: Luna raising a polished shield, a broad disc of mirror-bright metal edged in gold filigree, reflecting foes like a shining mirror.
+Precision Sights: Luna aligning precision sights, a metal scope with crosshair lenses and fine-tuning knobs, locked atop a sleek firearm barrel.
+Reinforced Cloak: Luna wrapping herself in a reinforced cloak, heavy canvas lined with chain links and leather patches, draping like a protective curtain.
+Rejuvenating Tonic: Luna uncorking a rejuvenating tonic, a glass vial of effervescent emerald liquid that bubbles with restorative sparkles.
+Sharpening Stone: Luna grinding a blade against a sharpening stone, the gray whetstone slick with water, gritty edges leaving thin trails of metallic dust.
+Spiked Shield: Luna bracing a spiked shield, a round barrier studded with iron spikes protruding like a hedgehog, each point dulling on impact.
+Steady Grip: Luna tightening a steady grip glove, leather palm pads and knuckle straps securing her hold with unshakeable firmness.
+Steel Bangles: Luna wearing steel bangles, thick rings of brushed metal clinking softly on her wrists, each one etched with protective runes.
+Sturdy Boots: Luna stomping in sturdy boots, heavy leather footwear with reinforced toe caps and thick treaded soles stained by countless journeys.
+Sturdy Vest: Luna donning a sturdy vest, quilted leather panels stitched with crosshatched fibers, fitting snugly like a second hide.
+Swift Bandanna: Luna tying a swift bandanna around her brow, a scarlet cloth trailing in the wind, emphasizing her sharp, focused gaze.
+Tactical Kit: Luna spreading out a tactical kit, a compact roll of tools—lockpicks, screwdrivers, tiny wrenches—each nestled in a canvas pocket.
+Thick Skin: Luna coating herself with thick skin, a tough hide-like armor grafted to her flesh, textured like rugged bark yet flexible.
+Vital Core: Luna holding a vital core, a luminous orb encased in a metal cage, throbbing with rhythmic pulses like a mechanical heart.
+
+=== Relics ===
+Arcane Flask: Luna swirling an arcane flask, a crystalline bottle filled with swirling violet energy, corked with a rune-carved stopper.
+Bent Dagger: Luna inspecting a bent dagger, a once-straight blade now curved like a hook, its edge nicked yet still gleaming wickedly.
+Echo Bell: Luna ringing an echo bell, a tiny silver bell whose chime reverberates impossibly long, shimmering in concentric waves.
+Echoing Drum: Luna beating an echoing drum, a hide-covered drum with bronze studs, each strike sending rolling echoes across the field.
+Ember Stone: Luna clutching an ember stone, a coal-red gem that radiates gentle heat and flickers like an eternal coal.
+Frost Sigil: Luna tracing a frost sigil, an icy rune etched on a metal plate, exhaling mist and rimed with delicate snow crystals.
+Greed Engine: Luna examining a greed engine, a brass contraption of spinning gears and coin slots, humming with avaricious intent.
+Guardian Charm: Luna pinning a guardian charm to her cloak, a shield-shaped brooch of jade and gold, emanating a protective aura.
+Herbal Charm: Luna weaving an herbal charm, bundles of dried herbs and fragrant flowers tied with twine, releasing calming scents.
+Killer Instinct: Luna activating a killer instinct token, a jagged tooth pendant dripping crimson energy, sharpening her predatory focus.
+Lucky Button: Luna stroking a lucky button, an oversized pearly button with carved clovers, hanging from a thread like a talisman.
+Null Lantern: Luna carrying a null lantern, a black iron lamp whose interior glows with void-dark light that swallows surrounding shadows.
+Old Coin: Luna flipping an old coin, a tarnished silver disc worn smooth by time, edges dented from countless hands.
+Omega Core: Luna harnessing an omega core, a dense metallic sphere with glowing seams arranged in an omega symbol, humming powerfully.
+Paradox Hourglass: Luna turning a paradox hourglass, twin glass bulbs filled with shimmering sand that flows upward and downward simultaneously.
+Pocket Manual: Luna flipping through a pocket manual, a palm-sized booklet with dog-eared pages and tiny hand-sketched diagrams.
+Rusty Buckle: Luna fastening a rusty buckle, a corroded iron clasp flecked with orange rust, squeaking as it snaps shut.
+Shiny Pebble: Luna admiring a shiny pebble, a smooth stone polished to mirror brightness, catching sunlight with a dazzling gleam.
+Soul Prism: Luna holding a soul prism, a multifaceted crystal prism refracting ethereal light into rainbow beams that dance around her.
+Stellar Compass: Luna plotting with a stellar compass, a celestial instrument studded with tiny star gems, its needle pointing toward distant constellations.
+Tattered Flag: Luna waving a tattered flag, a faded cloth banner riddled with holes, edges frayed by wind and battle.
+Threadbare Cloak: Luna wrapping a threadbare cloak around her shoulders, fabric so thin it is almost translucent, patched in several places.
+Timekeeper's Hourglass: Luna guarding a timekeeper's hourglass, a brass-framed glass timer whose sand glows golden and falls in measured, audible ticks.
+Traveler's Charm: Luna clutching a traveler's charm, a circular pendant with engraved maps and a tiny compass spinning inside.
+Vengeful Pendant: Luna brandishing a vengeful pendant, a dark gemstone hung from a chain, pulsing with crimson light that seethes with anger.
+Wooden Idol: Luna holding a wooden idol, a small hand-carved figure with exaggerated features and offerings tied at its base.


### PR DESCRIPTION
## Summary
- add prompts describing Luna using each card and relic

## Testing
- [ ] Backend tests (fail: missing dependencies, see run output)
- [ ] Frontend tests
- [x] Linting (`uv run ruff check . --fix`)
- [ ] Doc sync updates (README and `.codex/implementation` docs; link tasks below)

## Checklist
- [ ] Linked or updated relevant `.codex/tasks` entries
- [ ] Updated player roster and foe docs if adding or modifying fighters or enemies

------
https://chatgpt.com/codex/tasks/task_b_68b0949426a0832c92f50a25c9d930ea