### PR TITLE
[FEAT] conditionally render LRM settings

### DIFF
--- a/frontend/.codex/implementation/settings-menu.md
+++ b/frontend/.codex/implementation/settings-menu.md
@@ -1,0 +1,9 @@
+# Settings Menu
+
+The settings overlay exposes audio, system, and gameplay options.
+
+- `SettingsMenu.svelte` receives `backendFlavor` from the page and
+  checks it for `"llm"` to decide whether language reasoning model
+  controls should appear.
+- When the flavor string omits `"llm"`, the component skips
+  `getLrmConfig()` and hides the LRM model selector and test button.

--- a/frontend/src/lib/GameViewport.svelte
+++ b/frontend/src/lib/GameViewport.svelte
@@ -34,6 +34,7 @@
   export let editorState = {};
   export let battleActive = false;
   export let selected = [];
+  export let backendFlavor = '';
 
   let randomBg = '';
   let roster = [];
@@ -168,24 +169,25 @@
     {:else if runId}
       <div class="placeholder">Awaiting next room...</div>
     {/if}
-    <OverlayHost
-      bind:selected
-      {runId}
-      {roomData}
-      {editorState}
-      {sfxVolume}
-      {musicVolume}
-      {voiceVolume}
-      {framerate}
-      {autocraft}
-      {reducedMotion}
-      {selectedParty}
-      {battleActive}
-      on:saveParty={() => dispatch('saveParty')}
-      on:startRun={() => dispatch('startRun')}
-      on:back={() => dispatch('back')}
-      on:rewardSelect={(e) => dispatch('rewardSelect', e.detail)}
-      on:nextRoom={() => dispatch('nextRoom')}
+      <OverlayHost
+        bind:selected
+        {runId}
+        {roomData}
+        {editorState}
+        {sfxVolume}
+        {musicVolume}
+        {voiceVolume}
+        {framerate}
+        {autocraft}
+        {reducedMotion}
+        {selectedParty}
+        {battleActive}
+        {backendFlavor}
+        on:saveParty={() => dispatch('saveParty')}
+        on:startRun={() => dispatch('startRun')}
+        on:back={() => dispatch('back')}
+        on:rewardSelect={(e) => dispatch('rewardSelect', e.detail)}
+        on:nextRoom={() => dispatch('nextRoom')}
       on:editorSave={(e) => dispatch('editorSave', e.detail)}
       on:saveSettings={(e) => ({ sfxVolume, musicVolume, voiceVolume, framerate, autocraft, reducedMotion } = e.detail)}
       on:endRun={() => dispatch('endRun')}

--- a/frontend/src/lib/OverlayHost.svelte
+++ b/frontend/src/lib/OverlayHost.svelte
@@ -35,6 +35,7 @@
   export let reducedMotion = false;
   export let selectedParty = [];
   export let battleActive = false;
+  export let backendFlavor = '';
 
   const dispatch = createEventDispatcher();
   // Determine whether to show rewards overlay based on raw room data.
@@ -170,6 +171,7 @@
       {autocraft}
       {reducedMotion}
       {runId}
+      {backendFlavor}
       on:save={(e) => dispatch('saveSettings', e.detail)}
       on:endRun={() => dispatch('endRun')}
     />

--- a/frontend/src/lib/SettingsMenu.svelte
+++ b/frontend/src/lib/SettingsMenu.svelte
@@ -13,6 +13,10 @@
   export let reducedMotion = false;
   export let lrmModel = '';
   export let runId = '';
+  export let backendFlavor = typeof window !== 'undefined' ? window.backendFlavor || '' : '';
+
+  let showLrm = false;
+  $: showLrm = (backendFlavor || '').toLowerCase().includes('llm');
 
   let saveStatus = '';
   let saveTimeout;
@@ -33,13 +37,15 @@
     } catch {
       /* ignore network/backend issues; leave local state */
     }
-    try {
-      const cfg = await getLrmConfig();
-      lrmOptions = cfg?.available_models || [];
-      lrmModel = cfg?.current_model || lrmModel;
-      saveSettings({ lrmModel });
-    } catch {
-      /* ignore */
+    if (showLrm) {
+      try {
+        const cfg = await getLrmConfig();
+        lrmOptions = cfg?.available_models || [];
+        lrmModel = cfg?.current_model || lrmModel;
+        saveSettings({ lrmModel });
+      } catch {
+        /* ignore */
+      }
     }
   });
 
@@ -190,20 +196,22 @@
         <label>Reduced Motion</label>
         <input type="checkbox" bind:checked={reducedMotion} on:change={scheduleSave} />
       </div>
-      <div class="control" title="Select language reasoning model.">
-        <label>LRM Model</label>
-        <select bind:value={lrmModel} on:change={handleModelChange}>
-          {#each lrmOptions as opt}
-            <option value={opt}>{opt}</option>
-          {/each}
-        </select>
-      </div>
-      <div class="control" title="Send a sample prompt to the selected model.">
-        <label>Test Model</label>
-        <button on:click={handleTestModel}>Test</button>
-      </div>
-      {#if testReply}
-        <p class="status" data-testid="lrm-test-reply">{testReply}</p>
+      {#if showLrm}
+        <div class="control" title="Select language reasoning model.">
+          <label>LRM Model</label>
+          <select bind:value={lrmModel} on:change={handleModelChange}>
+            {#each lrmOptions as opt}
+              <option value={opt}>{opt}</option>
+            {/each}
+          </select>
+        </div>
+        <div class="control" title="Send a sample prompt to the selected model.">
+          <label>Test Model</label>
+          <button on:click={handleTestModel}>Test</button>
+        </div>
+        {#if testReply}
+          <p class="status" data-testid="lrm-test-reply">{testReply}</p>
+        {/if}
       {/if}
       <div class="control" title="Clear all save data.">
         <Trash2 />

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -602,6 +602,7 @@
     items={items}
     editorState={editorState}
     battleActive={battleActive}
+    backendFlavor={backendFlavor}
     on:startRun={handleStart}
     on:editorSave={(e) => handleEditorSave(e)}
     on:openInventory={openInventory}

--- a/frontend/tests/settingsmenu.test.js
+++ b/frontend/tests/settingsmenu.test.js
@@ -19,6 +19,9 @@ describe('SettingsMenu component', () => {
     expect(content).toContain('data-testid="save-status"');
     expect(content).toContain('LRM Model');
     expect(content).toContain('Test Model');
+    expect(content).toContain('backendFlavor');
+    expect(content).toContain('{#if showLrm}');
+    expect(content).toContain('if (showLrm)');
     expect(content).not.toContain('Save</button>');
     expect(content).not.toContain('alert(');
   });


### PR DESCRIPTION
## Summary
- conditionally load LRM configuration based on backend flavor
- plumb backendFlavor from page to SettingsMenu and hide LRM controls when flavor lacks `llm`
- document Settings menu behavior

## Testing
- `uv run ruff check backend` *(fails: Import block is un-sorted or un-formatted, etc.)*
- `./run-tests.sh` *(fails: backend tests/test_app.py timed out, backend tests/test_gacha.py timed out, frontend tests/battleview.test.js, frontend tests/partypicker.test.js)*
- `bun test tests/battleview.test.js` *(fails: enrage indicator defines animation)*
- `bun test tests/partypicker.test.js` *(fails: roster layout snapshot)*

------
https://chatgpt.com/codex/tasks/task_b_68b0a0056cd4832c80253feaa6cc0534