### PR TITLE
[FEAT] Implement shop stock and purchases

### DIFF
--- a/.codex/implementation/shop-room.md
+++ b/.codex/implementation/shop-room.md
@@ -7,4 +7,49 @@ Offers upgrade items and cards for gold with a reroll option.
 - **Persistence** – exiting saves remaining gold and acquired items through `save_player`.
 - **Spawn rules** – `ShopRoom.should_spawn` ensures at least two shops appear per floor by tracking spawns in `spawns_per_floor`.
 
+## Pricing
+
+Cards and relics share a star-based pricing table:
+
+| Stars | Price (gold) |
+| ----- | ------------ |
+| 1★    | 20           |
+| 2★    | 50           |
+| 3★    | 100          |
+| 4★    | 200          |
+| 5★    | 500          |
+
+These are base prices. Each pressure level multiplies the cost by **1.26**, and when
+pressure is above zero a final \u00b15\% variation is applied:
+
+```
+final_price = floor(base_price * (1.26 ** pressure) * rand(0.95, 1.05))
+```
+
+The reroll action always costs **10 gold** and is unaffected by pressure.
+
+### Star Modifiers
+
+Base star rolls are weighted toward low ranks (70% 1★, 20% 2★, 10% 3★). High party rare-drop rate (`rdr`) can promote an item to a higher star rank:
+
+- `rdr` ≥ 10 may raise the star level by one with a chance of `min(rdr / 100, 99%)`.
+- `rdr` ≥ 10,000 may raise it again with a chance of `min(rdr / 100000, 99%)`.
+
+These promotions are checked sequentially and cap at 5★.
+
+## Testing
+
+Run the backend test suite to verify pricing logic and stock updates:
+
+```bash
+uv run pytest backend/tests/test_shop_room.py
+```
+
+The frontend shop menu will gain automated coverage once implemented:
+
+```bash
+cd frontend
+bun test
+```
+
 The Svelte frontend exposes a stub `ShopMenu` built with `MenuPanel` that lists stock and provides **Buy**, **Reroll**, and **Leave** actions.

--- a/README.md
+++ b/README.md
@@ -267,7 +267,9 @@ join the roster immediately.
 Entering a shop heals the party by 5% of its combined max HP. Buy upgrade items
 or cards with star ratings. Inventory scales by floor, purchases add items to
 your inventory and disable the button, class-level tracking guarantees at least
-two shops per floor, and gold can reroll the current stock.
+two shops per floor, and gold can reroll the current stock. Gold prices per star
+rank, pressure-based cost scaling, and reroll rules are documented in
+[`./.codex/implementation/shop-room.md`](.codex/implementation/shop-room.md).
 
 ## Event and Chat Rooms
 

--- a/backend/autofighter/rooms/shop.py
+++ b/backend/autofighter/rooms/shop.py
@@ -1,12 +1,85 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+import random
 from typing import Any
 
+from ..cards import card_choices
 from ..party import Party
 from ..passives import PassiveRegistry
+from ..relics import relic_choices
 from . import Room
 from .utils import _serialize
+
+PRICE_BY_STARS = {1: 20, 2: 50, 3: 100, 4: 200, 5: 500}
+REROLL_COST = 10
+
+
+def _pressure_cost(base: int, pressure: int) -> int:
+    scale = 1.26 ** pressure
+    if pressure:
+        scale *= random.uniform(0.95, 1.05)
+    return int(base * scale)
+
+
+def _apply_rdr_to_stars(stars: int, rdr: float) -> int:
+    for threshold in (10.0, 10000.0):
+        if stars >= 5 or rdr < threshold:
+            break
+        chance = min(rdr / (threshold * 10.0), 0.99)
+        if random.random() < chance:
+            stars += 1
+        else:
+            break
+    return stars
+
+
+def _pick_shop_stars() -> int:
+    roll = random.random()
+    if roll < 0.7:
+        return 1
+    if roll < 0.9:
+        return 2
+    return 3
+
+
+def _generate_stock(party: Party, pressure: int) -> list[dict[str, Any]]:
+    stock: list[dict[str, Any]] = []
+    for _ in range(2):
+        stars = _apply_rdr_to_stars(_pick_shop_stars(), party.rdr)
+        choice = card_choices(party, stars, count=1)
+        if choice:
+            card = choice[0]
+            base = PRICE_BY_STARS.get(card.stars, 0)
+            cost = _pressure_cost(base, pressure)
+            stock.append(
+                {
+                    "id": card.id,
+                    "name": card.name,
+                    "stars": card.stars,
+                    "type": "card",
+                    "cost": cost,
+                    "price": cost,
+                }
+            )
+    stars = _apply_rdr_to_stars(_pick_shop_stars(), party.rdr)
+    choice = relic_choices(party, stars, count=1)
+    if choice:
+        relic = choice[0]
+        base = PRICE_BY_STARS.get(relic.stars, 0)
+        cost = _pressure_cost(base, pressure)
+        stock.append(
+            {
+                "id": relic.id,
+                "name": relic.name,
+                "stars": relic.stars,
+                "type": "relic",
+                "cost": cost,
+                "price": cost,
+            }
+        )
+    random.shuffle(stock)
+    return stock
 
 
 @dataclass
@@ -14,17 +87,42 @@ class ShopRoom(Room):
     """Shop rooms allow relic purchases and heal the party slightly."""
 
     async def resolve(self, party: Party, data: dict[str, Any]) -> dict[str, Any]:
+        action = data.get("action", "")
         registry = PassiveRegistry()
-        heal = int(sum(m.max_hp for m in party.members) * 0.05)
-        for member in party.members:
-            await registry.trigger("room_enter", member)
-            await member.apply_healing(heal)
-        cost = int(data.get("cost", 0))
-        item = data.get("item")
-        if cost > 0 and party.gold >= cost:
-            party.gold -= cost
-            if item:
-                party.relics.append(item)
+        if not getattr(self.node, "visited", False):
+            heal = int(sum(m.max_hp for m in party.members) * 0.05)
+            for member in party.members:
+                await registry.trigger("room_enter", member)
+                await member.apply_healing(heal)
+            self.node.visited = True
+
+        stock = getattr(self.node, "stock", [])
+        if not stock:
+            stock = _generate_stock(party, self.node.pressure)
+            self.node.stock = stock
+
+        if action == "reroll":
+            if party.gold >= REROLL_COST:
+                party.gold -= REROLL_COST
+                stock = _generate_stock(party, self.node.pressure)
+                self.node.stock = stock
+        else:
+            item_id = data.get("id") or data.get("item")
+            cost = int(data.get("cost") or data.get("price") or 0)
+            if item_id and cost:
+                entry = next(
+                    (s for s in stock if s["id"] == item_id and s["cost"] == cost),
+                    None,
+                )
+                if entry and party.gold >= cost:
+                    party.gold -= cost
+                    if entry["type"] == "card":
+                        party.cards.append(item_id)
+                    else:
+                        party.relics.append(item_id)
+                    stock.remove(entry)
+                    self.node.stock = stock
+
         party_data = [_serialize(p) for p in party.members]
         return {
             "result": "shop",
@@ -33,6 +131,7 @@ class ShopRoom(Room):
             "relics": party.relics,
             "cards": party.cards,
             "rdr": party.rdr,
+            "stock": stock,
             "card": None,
             "foes": [],
         }

--- a/backend/tests/test_shop_room.py
+++ b/backend/tests/test_shop_room.py
@@ -1,13 +1,21 @@
+import importlib.util
+from pathlib import Path
+import random
+
 import pytest
 
+from autofighter.mapgen import MapGenerator
 from autofighter.mapgen import MapNode
 from autofighter.party import Party
+from autofighter.rooms.shop import PRICE_BY_STARS
+from autofighter.rooms.shop import REROLL_COST
 from autofighter.rooms.shop import ShopRoom
 from plugins.players._base import PlayerBase
 
 
 @pytest.mark.asyncio
-async def test_shop_room_heals_and_tracks_inventory():
+async def test_shop_generate_buy_reroll():
+    random.seed(0)
     node = MapNode(room_id=1, room_type="shop", floor=1, index=1, loop=1, pressure=0)
     room = ShopRoom(node)
 
@@ -33,8 +41,126 @@ async def test_shop_room_heals_and_tracks_inventory():
 
     party = Party(members=[p1, p2, p3, p4], gold=100)
 
-    await room.resolve(party, {"cost": 20, "item": "amulet"})
-
+    first = await room.resolve(party, {"action": ""})
     assert [m.hp for m in party.members] == [100, 150, 50, 150]
-    assert party.gold == 80
-    assert party.relics == ["amulet"]
+    assert first["stock"]
+    initial_stock = first["stock"].copy()
+
+    purchase = initial_stock[0]
+    second = await room.resolve(party, purchase)
+    assert len(second["stock"]) == len(initial_stock) - 1
+    assert party.gold == 100 - purchase["cost"]
+    if purchase["type"] == "card":
+        assert purchase["id"] in party.cards
+    else:
+        assert purchase["id"] in party.relics
+
+    third = await room.resolve(party, {"action": "reroll"})
+    assert party.gold == 100 - purchase["cost"] - REROLL_COST
+    assert third["stock"]
+    assert third["stock"] != second["stock"]
+
+
+@pytest.mark.asyncio
+async def test_shop_cost_scales_with_pressure():
+    random.seed(0)
+    pressure = 3
+    node = MapNode(room_id=1, room_type="shop", floor=1, index=1, loop=1, pressure=pressure)
+    room = ShopRoom(node)
+
+    p = PlayerBase()
+    p.id = "p"
+    p.max_hp = 100
+    p.hp = 100
+
+    party = Party(members=[p], gold=5000)
+
+    first = await room.resolve(party, {"action": ""})
+    assert first["stock"]
+    for item in first["stock"]:
+        base = PRICE_BY_STARS[item["stars"]]
+        min_cost = int(base * (1.26 ** pressure) * 0.95)
+        max_cost = int(base * (1.26 ** pressure) * 1.05)
+        assert min_cost <= item["cost"] <= max_cost
+
+
+@pytest.fixture()
+def app_with_shop(tmp_path, monkeypatch):
+    db_path = tmp_path / "save.db"
+    monkeypatch.setenv("AF_DB_PATH", str(db_path))
+    monkeypatch.setenv("AF_DB_KEY", "testkey")
+    monkeypatch.syspath_prepend(Path(__file__).resolve().parents[1])
+    spec = importlib.util.spec_from_file_location(
+        "app", Path(__file__).resolve().parents[1] / "app.py",
+    )
+    app_module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(app_module)
+    app_module.app.testing = True
+
+    def fake_generate_floor(self):
+        return [
+            MapNode(0, "start", 1, 0, 1, 0),
+            MapNode(1, "shop", 1, 1, 1, 0),
+            MapNode(2, "battle-weak", 1, 2, 1, 0),
+        ]
+
+    monkeypatch.setattr(MapGenerator, "generate_floor", fake_generate_floor)
+    return app_module.app, db_path
+
+
+@pytest.mark.asyncio
+async def test_shop_allows_multiple_actions(app_with_shop):
+    app, _ = app_with_shop
+    client = app.test_client()
+
+    start = await client.post("/run/start", json={"party": ["player"]})
+    run_id = (await start.get_json())["run_id"]
+    await client.put(
+        f"/party/{run_id}", json={"party": ["player"], "gold": 300},
+    )
+
+    first = await client.post(f"/rooms/{run_id}/shop")
+    data = await first.get_json()
+    assert data["stock"]
+    gold = data["gold"]
+
+    item1 = data["stock"][0]
+    buy1 = await client.post(
+        f"/rooms/{run_id}/shop", json={"id": item1["id"], "cost": item1["cost"]}
+    )
+    data = await buy1.get_json()
+    spent = item1["cost"]
+    assert data["gold"] == gold - spent
+
+    reroll1 = await client.post(
+        f"/rooms/{run_id}/shop", json={"action": "reroll"}
+    )
+    data = await reroll1.get_json()
+    spent += REROLL_COST
+    assert data["gold"] == gold - spent
+
+    item2 = data["stock"][0]
+    buy2 = await client.post(
+        f"/rooms/{run_id}/shop", json={"id": item2["id"], "cost": item2["cost"]}
+    )
+    data = await buy2.get_json()
+    spent += item2["cost"]
+    assert data["gold"] == gold - spent
+
+    reroll2 = await client.post(
+        f"/rooms/{run_id}/shop", json={"action": "reroll"}
+    )
+    data = await reroll2.get_json()
+    spent += REROLL_COST
+    assert data["gold"] == gold - spent
+
+    next_attempt = await client.post(f"/run/{run_id}/next")
+    assert next_attempt.status_code == 400
+
+    leave = await client.post(f"/rooms/{run_id}/shop", json={"action": "leave"})
+    leave_data = await leave.get_json()
+    assert "next_room" in leave_data
+
+    final = await client.post(f"/run/{run_id}/next")
+    assert final.status_code == 200


### PR DESCRIPTION
## Summary
- add card/relic stock generation with pricing, purchase, and reroll logic
- persist shop stock between requests
- test shop stock generation, buying, rerolling, repeated shop actions, and pressure-scaled pricing
- document star-based shop pricing, pressure scaling, and link from README

## Testing
- `ruff check backend/autofighter/rooms/shop.py backend/routes/rooms.py backend/tests/test_shop_room.py --fix`
- `uv run pytest tests/test_shop_room.py` *(ModuleNotFoundError: No module named 'llms')*
- `./run-tests.sh` *(fails: missing asset files, animation expectations, timed-out backend tests)*

------
https://chatgpt.com/codex/tasks/task_b_68b0b40310ac832c9e9c8880a7decfdc