### PR TITLE
[ADD] Implement 4-star card plugins

### DIFF
--- a/.codex/implementation/card-inventory.md
+++ b/.codex/implementation/card-inventory.md
@@ -42,3 +42,8 @@ when no cards are owned.
 - Guardian Shard – +2% DEF & +2% Mitigation
 - Sturdy Boots – +3% Dodge Odds & +3% DEF
 - Spiked Shield – +3% ATK & +3% DEF
+
+## 4★ Cards
+- Overclock – +240% ATK & +240% Effect Hit Rate; at the start of each battle, all allies immediately take two actions back to back.
+- Iron Resolve – +240% DEF & +240% HP; the first time an ally dies, revive them at 30% HP. This effect refreshes every 3 turns.
+- Arcane Repeater – +240% ATK; each attack has a 30% chance to immediately repeat at 50% power.

--- a/backend/plugins/cards/arcane_repeater.py
+++ b/backend/plugins/cards/arcane_repeater.py
@@ -1,0 +1,45 @@
+import asyncio
+from dataclasses import dataclass
+from dataclasses import field
+import random
+
+from autofighter.stats import BUS
+from plugins.cards._base import CardBase
+
+
+@dataclass
+class ArcaneRepeater(CardBase):
+    """+240% ATK; 30% chance for attacks to repeat at 50% power."""
+
+    id: str = "arcane_repeater"
+    name: str = "Arcane Repeater"
+    stars: int = 4
+    effects: dict[str, float] = field(default_factory=lambda: {"atk": 2.4})
+    about: str = (
+        "+240% ATK; each attack has a 30% chance to immediately repeat at 50% power."
+    )
+
+    async def apply(self, party) -> None:  # type: ignore[override]
+        await super().apply(party)
+
+        def _attack(attacker, target, amount) -> None:
+            if attacker not in party.members:
+                return
+            if random.random() >= 0.30:
+                return
+            dmg = int(amount * 0.5)
+            BUS.emit(
+                "card_effect",
+                self.id,
+                attacker,
+                "repeat_attack",
+                dmg,
+                {
+                    "target": getattr(target, "id", str(target)),
+                    "damage": dmg,
+                    "original": amount,
+                },
+            )
+            asyncio.create_task(target.apply_damage(dmg, attacker=attacker))
+
+        BUS.subscribe("attack_used", _attack)

--- a/backend/plugins/cards/iron_resolve.py
+++ b/backend/plugins/cards/iron_resolve.py
@@ -1,0 +1,52 @@
+from dataclasses import dataclass
+from dataclasses import field
+
+from autofighter.stats import BUS
+from plugins.cards._base import CardBase
+
+
+@dataclass
+class IronResolve(CardBase):
+    """+240% DEF & HP; first death revives at 30% HP, recharging every 3 turns."""
+
+    id: str = "iron_resolve"
+    name: str = "Iron Resolve"
+    stars: int = 4
+    effects: dict[str, float] = field(
+        default_factory=lambda: {"defense": 2.4, "max_hp": 2.4}
+    )
+    about: str = (
+        "+240% DEF & +240% HP; the first time an ally dies, revive them at "
+        "30% HP. This effect refreshes every 3 turns."
+    )
+
+    async def apply(self, party) -> None:  # type: ignore[override]
+        await super().apply(party)
+
+        cooldowns: dict[int, int] = {id(m): 0 for m in party.members}
+
+        def _damage_taken(target, attacker, amount) -> None:
+            pid = id(target)
+            if target not in party.members:
+                return
+            if target.hp > 0 or cooldowns.get(pid, 0) > 0:
+                return
+            revive_hp = int(target.max_hp * 0.30)
+            target.hp = revive_hp
+            cooldowns[pid] = 3
+            BUS.emit(
+                "card_effect",
+                self.id,
+                target,
+                "revive",
+                revive_hp,
+                {"revive_hp": revive_hp, "cooldown": 3},
+            )
+
+        def _turn_end() -> None:
+            for pid in list(cooldowns):
+                if cooldowns[pid] > 0:
+                    cooldowns[pid] -= 1
+
+        BUS.subscribe("damage_taken", _damage_taken)
+        BUS.subscribe("turn_end", _turn_end)

--- a/backend/plugins/cards/overclock.py
+++ b/backend/plugins/cards/overclock.py
@@ -1,0 +1,54 @@
+import asyncio
+from dataclasses import dataclass
+from dataclasses import field
+import random
+
+from autofighter.stats import BUS
+from autofighter.stats import Stats
+from plugins.cards._base import CardBase
+
+
+@dataclass
+class Overclock(CardBase):
+    """+240% ATK & Effect Hit Rate; allies act twice at battle start."""
+
+    id: str = "overclock"
+    name: str = "Overclock"
+    stars: int = 4
+    effects: dict[str, float] = field(
+        default_factory=lambda: {"atk": 2.4, "effect_hit_rate": 2.4}
+    )
+    about: str = (
+        "+240% ATK & +240% Effect Hit Rate; at the start of each battle, "
+        "all allies immediately take two actions back to back."
+    )
+
+    async def apply(self, party) -> None:  # type: ignore[override]
+        await super().apply(party)
+
+        foes: list[Stats] = []
+
+        async def _double_act(ally: Stats) -> None:
+            for _ in range(2):
+                alive = [f for f in foes if f.hp > 0]
+                if ally.hp <= 0 or not alive:
+                    break
+                target = random.choice(alive)
+                dmg = await target.apply_damage(ally.atk, attacker=ally)
+                BUS.emit("attack_used", ally, target, dmg)
+                BUS.emit(
+                    "card_effect",
+                    self.id,
+                    ally,
+                    "extra_action",
+                    dmg,
+                    {"target": getattr(target, "id", str(target)), "damage": dmg},
+                )
+
+        def _battle_start(entity: Stats) -> None:
+            if entity in party.members:
+                asyncio.create_task(_double_act(entity))
+            else:
+                foes.append(entity)
+
+        BUS.subscribe("battle_start", _battle_start)

--- a/backend/tests/test_card_effects.py
+++ b/backend/tests/test_card_effects.py
@@ -1,0 +1,77 @@
+import asyncio
+from unittest.mock import patch
+
+from autofighter.cards import apply_cards
+from autofighter.cards import award_card
+from autofighter.party import Party
+from autofighter.stats import BUS
+from plugins.players._base import PlayerBase
+
+
+def setup_event_loop():
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    return loop
+
+
+def test_overclock_double_action():
+    loop = setup_event_loop()
+    party = Party()
+    ally = PlayerBase()
+    foe = PlayerBase()
+    ally.atk = 100
+    foe.hp = foe.max_hp = 1000
+    party.members.append(ally)
+    award_card(party, "overclock")
+    loop.run_until_complete(apply_cards(party))
+
+    BUS.emit("battle_start", foe)
+    BUS.emit("battle_start", ally)
+    loop.run_until_complete(asyncio.sleep(0))
+    expected = int(ally.atk * 2)
+    assert foe.hp == 1000 - expected
+
+
+def test_iron_resolve_revives_and_cooldown():
+    party = Party()
+    ally = PlayerBase()
+    enemy = PlayerBase()
+    ally.hp = ally.max_hp = 100
+    party.members.append(ally)
+    loop = setup_event_loop()
+    award_card(party, "iron_resolve")
+    loop.run_until_complete(apply_cards(party))
+
+    ally.hp = 0
+    BUS.emit("damage_taken", ally, enemy, 200)
+    assert ally.hp == int(ally.max_hp * 0.30)
+
+    ally.hp = 0
+    BUS.emit("damage_taken", ally, enemy, 200)
+    assert ally.hp == 0
+
+    for _ in range(3):
+        BUS.emit("turn_end")
+
+    ally.hp = 0
+    BUS.emit("damage_taken", ally, enemy, 200)
+    assert ally.hp == int(ally.max_hp * 0.30)
+
+
+def test_arcane_repeater_repeats_attack():
+    loop = setup_event_loop()
+    party = Party()
+    ally = PlayerBase()
+    foe = PlayerBase()
+    ally.atk = 100
+    foe.hp = foe.max_hp = 1000
+    party.members.append(ally)
+    award_card(party, "arcane_repeater")
+    loop.run_until_complete(apply_cards(party))
+
+    dmg = loop.run_until_complete(foe.apply_damage(ally.atk, attacker=ally))
+    with patch("random.random", return_value=0.1):
+        BUS.emit("attack_used", ally, foe, dmg)
+        loop.run_until_complete(asyncio.sleep(0))
+    expected = dmg + int(dmg * 0.5)
+    assert foe.hp == 1000 - expected


### PR DESCRIPTION
## Summary
- add Overclock card with start-of-battle double actions
- add Iron Resolve card that revives allies on a 3-turn cooldown
- add Arcane Repeater card granting attacks a 30% repeat chance
- document new 4★ cards and create tests for their effects

## Testing
- `bash run-tests.sh` *(fails: backend tests/test_app.py timed out; backend tests/test_gacha.py timed out; frontend tests/assets.test.js; frontend tests/battleview.test.js; frontend tests/floor-transition.test.js; frontend tests/partypicker.test.js)*

------
https://chatgpt.com/codex/tasks/task_b_68b110917348832cb17f218e4311cbb6