### PR TITLE
[FEAT] Add 3-star card plugins and tests

### DIFF
--- a/.codex/implementation/card-inventory.md
+++ b/.codex/implementation/card-inventory.md
@@ -42,3 +42,8 @@ when no cards are owned.
 - Guardian Shard – +2% DEF & +2% Mitigation
 - Sturdy Boots – +3% Dodge Odds & +3% DEF
 - Spiked Shield – +3% ATK & +3% DEF
+
+## 3★ Cards
+- Critical Overdrive – +255% ATK; while an ally has Critical Boost, they gain +10% Crit Rate and convert excess Crit Rate to +2% Crit Damage.
+- Iron Resurgence – +200% DEF & +200% HP; the first ally death revives at 10% HP and refreshes every 4 turns.
+- Arc Lightning – +255% ATK; every attack chains 50% damage to a random foe.

--- a/backend/plugins/cards/arc_lightning.py
+++ b/backend/plugins/cards/arc_lightning.py
@@ -1,0 +1,58 @@
+import asyncio
+from dataclasses import dataclass
+from dataclasses import field
+import random
+
+from autofighter.party import Party
+from autofighter.stats import BUS
+from plugins.cards._base import CardBase
+from plugins.foes._base import FoeBase
+
+
+@dataclass
+class ArcLightning(CardBase):
+    id: str = "arc_lightning"
+    name: str = "Arc Lightning"
+    stars: int = 3
+    effects: dict[str, float] = field(default_factory=lambda: {"atk": 2.55})
+    about: str = (
+        "+255% ATK; every attack chains 50% of dealt damage to a random foe."
+    )
+
+    async def apply(self, party: Party) -> None:
+        await super().apply(party)
+        foes: list[FoeBase] = []
+
+        def _battle_start(entity) -> None:
+            if isinstance(entity, FoeBase):
+                foes.append(entity)
+
+        def _battle_end(entity) -> None:
+            if isinstance(entity, FoeBase) and entity in foes:
+                foes.remove(entity)
+            if entity in party.members:
+                BUS.unsubscribe("hit_landed", _hit)
+                BUS.unsubscribe("battle_start", _battle_start)
+                BUS.unsubscribe("battle_end", _battle_end)
+
+        def _hit(attacker, target, amount, source, *_):
+            if attacker not in party.members or source != "attack":
+                return
+            valid = [f for f in foes if f.hp > 0 and f is not target]
+            if not valid:
+                return
+            extra = random.choice(valid)
+            extra_dmg = int(amount * 0.5)
+            asyncio.create_task(extra.apply_damage(extra_dmg, attacker, trigger_on_hit=False))
+            BUS.emit(
+                "card_effect",
+                self.id,
+                attacker,
+                "chain",
+                extra_dmg,
+                {"target": getattr(extra, "id", str(extra))},
+            )
+
+        BUS.subscribe("battle_start", _battle_start)
+        BUS.subscribe("battle_end", _battle_end)
+        BUS.subscribe("hit_landed", _hit)

--- a/backend/plugins/cards/critical_overdrive.py
+++ b/backend/plugins/cards/critical_overdrive.py
@@ -1,0 +1,74 @@
+from dataclasses import dataclass
+from dataclasses import field
+
+from autofighter.effects import create_stat_buff
+from autofighter.party import Party
+from autofighter.stats import BUS
+from plugins.cards._base import CardBase
+
+
+@dataclass
+class CriticalOverdrive(CardBase):
+    id: str = "critical_overdrive"
+    name: str = "Critical Overdrive"
+    stars: int = 3
+    effects: dict[str, float] = field(default_factory=lambda: {"atk": 2.55})
+    about: str = (
+        "+255% ATK; while an ally has Critical Boost, gain +10% Crit Rate and "
+        "convert excess Crit Rate to +2% Crit Damage."
+    )
+
+    async def apply(self, party: Party) -> None:
+        await super().apply(party)
+        state: dict[int, object] = {}
+
+        def _change(target, stacks) -> None:
+            if target not in party.members:
+                return
+            pid = id(target)
+            mod = state.pop(pid, None)
+            if mod is not None:
+                mod.remove()
+                if mod in target.effect_manager.mods:
+                    target.effect_manager.mods.remove(mod)
+            if stacks > 0:
+                extra_rate = 0.10
+                current = target.crit_rate
+                excess = max(0.0, current + extra_rate - 1.0)
+                new_mod = create_stat_buff(
+                    target,
+                    name=f"{self.id}_{pid}",
+                    turns=9999,
+                    crit_rate=extra_rate,
+                    crit_damage=excess * 2,
+                )
+                target.effect_manager.add_modifier(new_mod)
+                state[pid] = new_mod
+                BUS.emit(
+                    "card_effect",
+                    self.id,
+                    target,
+                    "crit_overdrive",
+                    int(excess * 200),
+                    {
+                        "extra_crit_rate": extra_rate * 100,
+                        "excess_crit_rate": excess * 100,
+                        "extra_crit_damage": excess * 200,
+                    },
+                )
+
+        def _battle_end(entity) -> None:
+            if entity not in party.members:
+                return
+            pid = id(entity)
+            mod = state.pop(pid, None)
+            if mod is not None:
+                mod.remove()
+                if mod in entity.effect_manager.mods:
+                    entity.effect_manager.mods.remove(mod)
+            if not state:
+                BUS.unsubscribe("critical_boost_change", _change)
+                BUS.unsubscribe("battle_end", _battle_end)
+
+        BUS.subscribe("critical_boost_change", _change)
+        BUS.subscribe("battle_end", _battle_end)

--- a/backend/plugins/cards/iron_resurgence.py
+++ b/backend/plugins/cards/iron_resurgence.py
@@ -1,0 +1,52 @@
+import asyncio
+from dataclasses import dataclass
+from dataclasses import field
+
+from autofighter.party import Party
+from autofighter.stats import BUS
+from plugins.cards._base import CardBase
+
+
+@dataclass
+class IronResurgence(CardBase):
+    id: str = "iron_resurgence"
+    name: str = "Iron Resurgence"
+    stars: int = 3
+    effects: dict[str, float] = field(default_factory=lambda: {"defense": 2.0, "max_hp": 2.0})
+    about: str = (
+        "+200% DEF & +200% HP; first ally death revives at 10% HP, refreshing every 4 turns."
+    )
+
+    async def apply(self, party: Party) -> None:
+        await super().apply(party)
+        state = {"cooldown": 0}
+
+        def _damage(victim, *_):
+            if victim not in party.members or victim.hp > 0 or state["cooldown"] > 0:
+                return
+            heal = max(int(victim.max_hp * 0.1), 1)
+            asyncio.create_task(victim.apply_healing(heal))
+            state["cooldown"] = 4
+            BUS.emit(
+                "card_effect",
+                self.id,
+                victim,
+                "revive",
+                heal,
+                {"cooldown": state["cooldown"]},
+            )
+
+        def _turn_start() -> None:
+            if state["cooldown"] > 0:
+                state["cooldown"] -= 1
+
+        def _battle_end(entity) -> None:
+            if entity not in party.members:
+                return
+            BUS.unsubscribe("damage_taken", _damage)
+            BUS.unsubscribe("turn_start", _turn_start)
+            BUS.unsubscribe("battle_end", _battle_end)
+
+        BUS.subscribe("damage_taken", _damage)
+        BUS.subscribe("turn_start", _turn_start)
+        BUS.subscribe("battle_end", _battle_end)

--- a/backend/plugins/effects/critical_boost.py
+++ b/backend/plugins/effects/critical_boost.py
@@ -27,6 +27,7 @@ class CriticalBoost:
         self.stacks += 1
         target.crit_rate += self.crit_rate_per_stack
         target.crit_damage += self.crit_damage_per_stack
+        BUS.emit("critical_boost_change", target, self.stacks)
 
     def _on_damage_taken(self, victim: Stats, *_: object) -> None:
         if victim is not self.target or self.target is None or self.stacks == 0:
@@ -34,5 +35,6 @@ class CriticalBoost:
         self.target.crit_rate -= self.crit_rate_per_stack * self.stacks
         self.target.crit_damage -= self.crit_damage_per_stack * self.stacks
         self.stacks = 0
+        BUS.emit("critical_boost_change", victim, 0)
         BUS.unsubscribe("damage_taken", self._on_damage_taken)
         self.target = None

--- a/backend/tests/test_arc_lightning.py
+++ b/backend/tests/test_arc_lightning.py
@@ -1,0 +1,30 @@
+import asyncio
+from unittest.mock import patch
+
+import pytest
+
+from autofighter.party import Party
+from autofighter.stats import BUS
+from plugins.cards.arc_lightning import ArcLightning
+import plugins.event_bus as event_bus_module
+from plugins.foes._base import FoeBase
+from plugins.players._base import PlayerBase
+
+
+@pytest.mark.asyncio
+async def test_arc_lightning_chains_damage() -> None:
+    event_bus_module.bus._subs.clear()
+    attacker = PlayerBase()
+    foe1 = FoeBase()
+    foe2 = FoeBase()
+    party = Party([attacker])
+    card = ArcLightning()
+    await card.apply(party)
+    BUS.emit("battle_start", foe1)
+    BUS.emit("battle_start", foe2)
+    BUS.emit("battle_start", attacker)
+    initial = foe2.hp
+    with patch("plugins.cards.arc_lightning.random.choice", return_value=foe2):
+        BUS.emit("hit_landed", attacker, foe1, 100, "attack")
+        await asyncio.sleep(0)
+    assert foe2.hp < initial

--- a/backend/tests/test_critical_overdrive.py
+++ b/backend/tests/test_critical_overdrive.py
@@ -1,0 +1,28 @@
+import asyncio
+
+import pytest
+
+from autofighter.party import Party
+from plugins.cards.critical_overdrive import CriticalOverdrive
+from plugins.effects.critical_boost import CriticalBoost
+import plugins.event_bus as event_bus_module
+from plugins.players._base import PlayerBase
+
+
+@pytest.mark.asyncio
+async def test_critical_overdrive_boosts_and_converts() -> None:
+    event_bus_module.bus._subs.clear()
+    member = PlayerBase()
+    party = Party([member])
+    card = CriticalOverdrive()
+    await card.apply(party)
+    boost = CriticalBoost()
+    for _ in range(200):
+        boost.apply(member)
+    assert member.atk == int(100 * 3.55)
+    assert member.crit_rate == pytest.approx(1.15)
+    assert member.crit_damage == pytest.approx(12.3)
+    boost._on_damage_taken(member)
+    await asyncio.sleep(0)
+    assert member.crit_rate == pytest.approx(0.05)
+    assert member.crit_damage == pytest.approx(2.0)

--- a/backend/tests/test_iron_resurgence.py
+++ b/backend/tests/test_iron_resurgence.py
@@ -1,0 +1,32 @@
+import asyncio
+
+import pytest
+
+from autofighter.party import Party
+from autofighter.stats import BUS
+from plugins.cards.iron_resurgence import IronResurgence
+import plugins.event_bus as event_bus_module
+from plugins.players._base import PlayerBase
+
+
+@pytest.mark.asyncio
+async def test_iron_resurgence_revives_and_cools_down() -> None:
+    event_bus_module.bus._subs.clear()
+    member = PlayerBase()
+    party = Party([member])
+    card = IronResurgence()
+    await card.apply(party)
+    assert member.defense == int(50 * 3)
+    assert member.max_hp == int(1000 * 3)
+    await member.apply_damage(member.max_hp)
+    await asyncio.sleep(0)
+    assert member.hp == int(member.max_hp * 0.1)
+    await member.apply_damage(member.hp)
+    await asyncio.sleep(0)
+    assert member.hp == 0
+    for _ in range(4):
+        BUS.emit("turn_start")
+    await member.apply_healing(member.max_hp)
+    await member.apply_damage(member.max_hp)
+    await asyncio.sleep(0)
+    assert member.hp == int(member.max_hp * 0.1)


### PR DESCRIPTION
## Summary
- implement Critical Overdrive, Iron Resurgence, and Arc Lightning card plugins
- document new 3★ cards
- add tests for critical boost stacking, revival cooldowns, and attack chaining

## Testing
- `./run-tests.sh` *(fails: ModuleNotFoundError: No module named 'battle_logging'; failing tests such as test_player_stats.py::test_player_stats_endpoint)*
- `uv run ruff check backend/plugins/effects/critical_boost.py backend/plugins/cards/critical_overdrive.py backend/plugins/cards/iron_resurgence.py backend/plugins/cards/arc_lightning.py backend/tests/test_critical_overdrive.py backend/tests/test_iron_resurgence.py backend/tests/test_arc_lightning.py --fix`


------
https://chatgpt.com/codex/tasks/task_b_68b11090da44832cb2e1631b7c5336bf