### PR TITLE
Add ultimate charge system with Ice ally bonuses

### DIFF
--- a/.codex/implementation/stats-and-effects.md
+++ b/.codex/implementation/stats-and-effects.md
@@ -11,6 +11,7 @@ The `Stats` dataclass stores core attributes for both players and foes:
 - **Vitality & Advanced:** `vitality`, `action_points`, `damage_taken`, `damage_dealt`, `kills`
 - **Status Lists:** `passives`, `dots`, `hots`, `relics`
 - **Party:** `gold`, `rdr` – run-wide currency and rare drop rate multiplier applied to gold, upgrade item counts, relic odds, pull ticket chances, and (at extreme values) can roll to raise relic and card star ranks
+- **Ultimate:** `ultimate_charge`, `ultimate_ready` – charge builds with actions to power character ultimates
 
 `damage_type` is a `DamageType` plugin instance (default `Generic`). The helper
 property `element_id` exposes the damage type's string identifier for

--- a/backend/autofighter/rooms/battle.py
+++ b/backend/autofighter/rooms/battle.py
@@ -370,6 +370,13 @@ class BattleRoom(Room):
                                         m.exp_multiplier += 0.025
                             except Exception:
                                 pass
+                member.add_ultimate_charge(member.actions_per_turn)
+                for ally in combat_party.members:
+                    if ally is member:
+                        continue
+                    dt = getattr(ally, "damage_type", None)
+                    if getattr(dt, "id", "").lower() == "ice":
+                        ally.add_ultimate_charge(member.actions_per_turn)
                 # Keep prior enrage bleed: every 10 stacks since activation,
                 # add increasing stacks of a %max HP DoT to both sides.
                 if enrage_active:

--- a/backend/autofighter/stats.py
+++ b/backend/autofighter/stats.py
@@ -84,6 +84,10 @@ class Stats:
     kills: int = 0
     last_damage_taken: int = 0
 
+    # Ultimate system
+    ultimate_charge: int = 0
+    ultimate_ready: bool = False
+
     # Overheal system (for shields from relics/cards)
     overheal_enabled: bool = field(default=False, init=False)
     shields: int = field(default=0, init=False)  # Amount of overheal/shields
@@ -325,6 +329,14 @@ class Stats:
             self.exp -= needed
             self.level += 1
             self._on_level_up()
+
+    def add_ultimate_charge(self, amount: int = 1) -> None:
+        """Increase ultimate charge, capping at 15."""
+        if self.ultimate_ready:
+            return
+        self.ultimate_charge = min(15, self.ultimate_charge + amount)
+        if self.ultimate_charge >= 15:
+            self.ultimate_ready = True
 
 
     async def apply_damage(

--- a/backend/plugins/effects/critical_boost.py
+++ b/backend/plugins/effects/critical_boost.py
@@ -25,8 +25,8 @@ class CriticalBoost:
             self.target = target
             BUS.subscribe("damage_taken", self._on_damage_taken)
         self.stacks += 1
-        target.crit_rate += self.crit_rate_per_stack
-        target.crit_damage += self.crit_damage_per_stack
+        target._base_crit_rate += self.crit_rate_per_stack
+        target._base_crit_damage += self.crit_damage_per_stack
         BUS.emit("critical_boost_change", target, self.stacks)
 
     def _on_damage_taken(self, victim: Stats, *_: object) -> None:

--- a/backend/plugins/players/_base.py
+++ b/backend/plugins/players/_base.py
@@ -7,6 +7,7 @@ from dataclasses import fields
 import logging
 
 from autofighter.character import CharacterType
+from autofighter.stats import BUS
 from autofighter.stats import Stats
 from plugins.damage_types import random_damage_type
 from plugins.damage_types._base import DamageTypeBase
@@ -148,6 +149,15 @@ class PlayerBase(Stats):
             val = getattr(self, name)
             setattr(result, name, copy.deepcopy(val, memo))
         return result
+
+    def use_ultimate(self) -> bool:
+        """Consume charge and emit an event when firing the ultimate."""
+        if not getattr(self, "ultimate_ready", False):
+            return False
+        self.ultimate_charge = 0
+        self.ultimate_ready = False
+        BUS.emit("ultimate_used", self)
+        return True
 
 
     async def send_lrm_message(self, message: str) -> str:

--- a/backend/tests/test_card_rewards.py
+++ b/backend/tests/test_card_rewards.py
@@ -16,6 +16,7 @@ import autofighter.rooms.battle as rooms_module
 from autofighter.stats import BUS
 from autofighter.stats import Stats
 from plugins.effects.critical_boost import CriticalBoost
+from plugins.players._base import PlayerBase
 
 NEW_CARDS: list[tuple[str, dict[str, float]]] = [
     ("lightweight_boots", {"dodge_odds": 0.03}),
@@ -162,8 +163,8 @@ async def test_critical_focus_grants_boost():
 
 @pytest.mark.asyncio
 async def test_critical_transfer_moves_stacks():
-    a = Stats()
-    b = Stats()
+    a = PlayerBase()
+    b = PlayerBase()
     party = Party(members=[a, b])
     award_card(party, "critical_transfer")
     await cards_module.apply_cards(party)
@@ -176,7 +177,9 @@ async def test_critical_transfer_moves_stacks():
     cb_b.apply(b)
     setattr(b, "_critical_boost", cb_b)
     base_atk = a.atk
-    BUS.emit("ultimate_used", a)
+    a.add_ultimate_charge(15)
+    a.use_ultimate()
+    await asyncio.sleep(0)
     assert getattr(a, "_critical_boost").stacks == 3
     assert a.atk == int(base_atk * 1.12)
 

--- a/backend/tests/test_ultimate_charge.py
+++ b/backend/tests/test_ultimate_charge.py
@@ -1,0 +1,52 @@
+import pytest
+
+from autofighter.party import Party
+from autofighter.rooms.battle import BattleRoom
+from autofighter.stats import BUS
+from autofighter.stats import Stats
+from plugins.damage_types.generic import Generic
+from plugins.damage_types.ice import Ice
+from plugins.players._base import PlayerBase
+
+
+def test_charge_accumulates_and_caps():
+    player = PlayerBase(damage_type=Generic())
+    for _ in range(20):
+        player.add_ultimate_charge()
+    assert player.ultimate_charge == 15
+    assert player.ultimate_ready is True
+
+
+@pytest.mark.asyncio
+async def test_ice_allies_gain_charge():
+    actor = PlayerBase(damage_type=Generic())
+    actor.id = "actor"
+    ice = PlayerBase(damage_type=Ice())
+    ice.id = "ice"
+    foe = Stats()
+    foe.id = "foe"
+    foe.hp = 50
+    room = BattleRoom()
+    party = Party(members=[actor, ice])
+    await room.resolve(party, {}, foe=foe)
+    assert ice.ultimate_charge == actor.actions_per_turn
+
+
+def test_use_ultimate_emits_event():
+    player = PlayerBase(damage_type=Generic())
+    player.ultimate_charge = 15
+    player.ultimate_ready = True
+    seen: list[Stats] = []
+
+    def _handler(user):
+        seen.append(user)
+
+    BUS.subscribe("ultimate_used", _handler)
+    try:
+        assert player.use_ultimate() is True
+        assert player.ultimate_charge == 0
+        assert player.ultimate_ready is False
+        assert seen == [player]
+    finally:
+        BUS.unsubscribe("ultimate_used", _handler)
+


### PR DESCRIPTION
## Summary
- Track ultimate readiness with new charge fields on combat stats
- Fire ultimates through PlayerBase API and emit `ultimate_used` events
- Build charge from every action, granting Ice allies bonus charge
- Cover Arcane Flask and Killer Instinct relics with ultimate trigger tests
- Use `use_ultimate` bus event for Critical Transfer card and adjust CriticalBoost stacks to modify base crit stats

## Testing
- `uv run ruff check tests/test_card_rewards.py plugins/cards/critical_transfer.py plugins/effects/critical_boost.py --fix`
- `uv run pytest tests/test_card_rewards.py::test_critical_transfer_moves_stacks tests/test_relic_effects.py::test_arcane_flask_shields tests/test_relic_effects_advanced.py::test_killer_instinct_grants_extra_turn tests/test_ultimate_charge.py::test_use_ultimate_emits_event -q`
- `./run-tests.sh` *(fails: test_800_dots_performance, test_accelerate_dependency, etc.)*

------
https://chatgpt.com/codex/tasks/task_b_68b16b2d3028832c9e4a9adccbf1a47b