### PR TITLE
[FEATURE] Add Fire ultimate drain and damage boost

### DIFF
--- a/backend/plugins/damage_types/fire.py
+++ b/backend/plugins/damage_types/fire.py
@@ -1,6 +1,9 @@
+import asyncio
 from dataclasses import dataclass
+import math
 
 from autofighter.effects import DamageOverTime
+from autofighter.stats import BUS
 from autofighter.stats import Stats
 from plugins import damage_effects
 from plugins.damage_types._base import DamageTypeBase
@@ -12,6 +15,13 @@ class Fire(DamageTypeBase):
     weakness: str = "Ice"
     color: tuple[int, int, int] = (255, 0, 0)
 
+    _drain_stacks: int = 0
+
+    def __post_init__(self) -> None:
+        BUS.subscribe("ultimate_used", self._on_ultimate_used)
+        BUS.subscribe("turn_start", self._on_turn_start)
+        BUS.subscribe("battle_end", self._on_battle_end)
+
     def create_dot(self, damage: float, source) -> DamageOverTime | None:
         return damage_effects.create_dot(self.id, damage, source)
 
@@ -19,4 +29,25 @@ class Fire(DamageTypeBase):
         if attacker.max_hp <= 0:
             return damage
         missing_ratio = 1 - (attacker.hp / attacker.max_hp)
-        return damage * (1 + missing_ratio)
+        dmg = damage * (1 + missing_ratio)
+        if self._drain_stacks > 0:
+            dmg *= math.sqrt(5)
+        return dmg
+
+    def _on_ultimate_used(self, user: Stats) -> None:
+        if getattr(user, "damage_type", None) is not self:
+            return
+        self._drain_stacks += 1
+
+    def _on_turn_start(self, actor: Stats) -> None:
+        if self._drain_stacks <= 0:
+            return
+        if getattr(actor, "damage_type", None) is not self:
+            return
+        dmg = actor.max_hp * 0.05 * self._drain_stacks
+        if dmg > 0:
+            pre = math.sqrt(dmg)
+            asyncio.create_task(actor.apply_damage(pre))
+
+    def _on_battle_end(self, *_: object) -> None:
+        self._drain_stacks = 0

--- a/backend/tests/test_fire_ultimate.py
+++ b/backend/tests/test_fire_ultimate.py
@@ -1,0 +1,88 @@
+import asyncio
+
+import pytest
+
+from autofighter.stats import BUS
+from autofighter.stats import Stats
+from plugins.damage_types.fire import Fire
+
+
+class Actor(Stats):
+    def use_ultimate(self) -> bool:
+        if not self.ultimate_ready:
+            return False
+        self.ultimate_charge = 0
+        self.ultimate_ready = False
+        BUS.emit("ultimate_used", self)
+        return True
+
+
+@pytest.mark.asyncio
+async def test_fire_ultimate_stack_accumulation_and_drain():
+    actor = Actor(damage_type=Fire())
+    actor._base_defense = 0
+    actor.id = "actor"
+    actor.hp = actor.max_hp
+    actor.ultimate_charge = 15
+    actor.ultimate_ready = True
+    actor.use_ultimate()
+    assert actor.damage_type._drain_stacks == 1
+
+    BUS.emit("turn_start", actor)
+    await asyncio.sleep(0)
+    expected = actor.max_hp - int(actor.max_hp * 0.05)
+    assert actor.hp == expected
+
+    actor.ultimate_charge = 15
+    actor.ultimate_ready = True
+    actor.use_ultimate()
+    assert actor.damage_type._drain_stacks == 2
+
+    BUS.emit("turn_start", actor)
+    await asyncio.sleep(0)
+    expected -= int(actor.max_hp * 0.10)
+    assert actor.hp == expected
+
+    BUS.emit("battle_end", actor)
+
+
+@pytest.mark.asyncio
+async def test_fire_ultimate_resets_on_battle_end():
+    actor = Actor(damage_type=Fire())
+    actor._base_defense = 0
+    actor.id = "actor"
+    actor.ultimate_charge = 15
+    actor.ultimate_ready = True
+    actor.use_ultimate()
+    assert actor.damage_type._drain_stacks == 1
+
+    BUS.emit("battle_end", actor)
+    assert actor.damage_type._drain_stacks == 0
+
+    actor.hp = actor.max_hp
+    BUS.emit("turn_start", actor)
+    await asyncio.sleep(0)
+    assert actor.hp == actor.max_hp
+
+
+@pytest.mark.asyncio
+async def test_fire_ultimate_damage_multiplier():
+    attacker = Actor(damage_type=Fire())
+    attacker._base_defense = 0
+    attacker.id = "attacker"
+    target = Stats()
+    target._base_defense = 0
+    target.id = "target"
+    base = await target.apply_damage(100, attacker)
+
+    attacker.ultimate_charge = 15
+    attacker.ultimate_ready = True
+    attacker.use_ultimate()
+
+    target2 = Stats()
+    target2._base_defense = 0
+    target2.id = "target2"
+    boosted = await target2.apply_damage(100, attacker)
+    assert boosted == base * 5
+
+    BUS.emit("battle_end", attacker)


### PR DESCRIPTION
## Summary
- add Fire damage type ultimate that stacks a 5% max HP self drain and multiplies damage by 5
- persist and clear drain stacks across battles
- cover fire ultimate behavior with unit tests

## Testing
- `ruff check . --fix`
- `uv run pytest tests/test_fire_ultimate.py`
- `./run-tests.sh` *(failed: backend tests/test_app.py timed out; backend tests/test_gacha.py timed out; frontend tests/assets.test.js missing asset; frontend tests/battlereview.test.js expectation mismatch)*

------
https://chatgpt.com/codex/tasks/task_b_68b175e88b94832c899089caab46ca0d