### PR TITLE
Wind ultimate detonates transferred DoTs

### DIFF
--- a/backend/.codex/implementation/vitality-effects.md
+++ b/backend/.codex/implementation/vitality-effects.md
@@ -12,5 +12,7 @@
   defense. All Shadow Siphon stacks are cleared when the battle ends.
 - Wind damage type users strike all remaining foes after their first hit,
   repeating the damage and rolling their Gale Erosion DoT on each target.
+- When a Wind user fires their ultimate, all existing enemy DoTs are pulled
+  onto the chosen target and detonate immediately.
 - Frozen Wound stacks reduce actions per turn and give the afflicted unit a
   `1% × stacks` chance to miss their next action.

--- a/backend/plugins/damage_types/wind.py
+++ b/backend/plugins/damage_types/wind.py
@@ -1,6 +1,9 @@
+import asyncio
 from dataclasses import dataclass
+from typing import ClassVar
 
 from autofighter.effects import DamageOverTime
+from autofighter.stats import BUS
 from plugins import damage_effects
 from plugins.damage_types._base import DamageTypeBase
 
@@ -10,6 +13,60 @@ class Wind(DamageTypeBase):
     id: str = "Wind"
     weakness: str = "Lightning"
     color: tuple[int, int, int] = (0, 255, 0)
+
+    _players: ClassVar[list] = []
+    _foes: ClassVar[list] = []
+    _pending: ClassVar[dict[int, list]] = {}
+    _subs_registered: ClassVar[bool] = False
+
+    def __post_init__(self) -> None:
+        cls = type(self)
+        if not cls._subs_registered:
+            BUS.subscribe("battle_start", cls._battle_start)
+            BUS.subscribe("battle_end", cls._battle_end)
+            BUS.subscribe("ultimate_used", cls._ultimate_used)
+            BUS.subscribe("hit_landed", cls._hit_landed)
+            cls._subs_registered = True
+
+    @classmethod
+    def _battle_start(cls, entity) -> None:
+        kind = getattr(entity, "plugin_type", "")
+        if kind == "player":
+            cls._players.append(entity)
+        elif kind == "foe":
+            cls._foes.append(entity)
+
+    @classmethod
+    def _battle_end(cls, entity) -> None:
+        if entity in cls._players:
+            cls._players.remove(entity)
+        if entity in cls._foes:
+            cls._foes.remove(entity)
+        cls._pending.pop(entity, None)
+
+    @classmethod
+    def _ultimate_used(cls, user) -> None:
+        if not isinstance(getattr(user, "damage_type", None), cls):
+            return
+        enemies = cls._foes if getattr(user, "plugin_type", "") == "player" else cls._players
+        cls._pending[id(user)] = [e for e in enemies if e.hp > 0 and e is not user]
+
+    @classmethod
+    def _hit_landed(cls, attacker, target, *_args) -> None:
+        enemies = cls._pending.pop(id(attacker), None)
+        if not enemies:
+            return
+        for enemy in enemies:
+            mgr = getattr(enemy, "effect_manager", None)
+            if mgr is None:
+                continue
+            for dot in list(mgr.dots):
+                mgr.dots.remove(dot)
+                try:
+                    enemy.dots.remove(dot.id)
+                except ValueError:
+                    pass
+                asyncio.create_task(dot.tick(target))
 
     def create_dot(self, damage: float, source) -> DamageOverTime | None:
         return damage_effects.create_dot(self.id, damage, source)

--- a/backend/tests/test_wind_ultimate_dot_transfer.py
+++ b/backend/tests/test_wind_ultimate_dot_transfer.py
@@ -1,0 +1,116 @@
+import asyncio
+
+import pytest
+
+from autofighter.effects import EffectManager
+from autofighter.stats import BUS
+from autofighter.stats import Stats
+from plugins.damage_types.wind import Wind
+from plugins.dots.blazing_torment import BlazingTorment
+
+
+def _use_ultimate(self):
+    if not getattr(self, "ultimate_ready", False):
+        return False
+    self.ultimate_charge = 0
+    self.ultimate_ready = False
+    BUS.emit("ultimate_used", self)
+    return True
+
+
+@pytest.mark.asyncio
+async def test_wind_ultimate_transfers_from_foes():
+    Wind._players.clear()
+    Wind._foes.clear()
+    Wind._pending.clear()
+
+    player = Stats(damage_type=Wind())
+    player.plugin_type = "player"
+    player.id = "p"
+    foe1 = Stats()
+    foe1.plugin_type = "foe"
+    foe1._base_max_hp = 100
+    foe1.hp = 100
+    foe1._base_defense = 0
+    foe1.id = "f1"
+    foe2 = Stats()
+    foe2.plugin_type = "foe"
+    foe2._base_max_hp = 100
+    foe2.hp = 100
+    foe2._base_defense = 0
+    foe2.id = "f2"
+    foe1.effect_manager = EffectManager(foe1)
+    foe2.effect_manager = EffectManager(foe2)
+
+    dot = BlazingTorment(1, 3)
+    dot.source = player
+    foe2.effect_manager.add_dot(dot)
+
+    player.use_ultimate = _use_ultimate.__get__(player, Stats)
+
+    BUS.emit("battle_start", player)
+    BUS.emit("battle_start", foe1)
+    BUS.emit("battle_start", foe2)
+
+    player.add_ultimate_charge(15)
+    assert player.use_ultimate()
+
+    BUS.emit("hit_landed", player, foe1, 0, "attack")
+    await asyncio.sleep(0.01)
+
+    assert foe2.effect_manager.dots == []
+    assert foe2.dots == []
+    assert foe1.hp == 99
+
+    BUS.emit("battle_end", player)
+    BUS.emit("battle_end", foe1)
+    BUS.emit("battle_end", foe2)
+
+
+@pytest.mark.asyncio
+async def test_wind_foe_ultimate_transfers_from_allies():
+    Wind._players.clear()
+    Wind._foes.clear()
+    Wind._pending.clear()
+
+    foe = Stats(damage_type=Wind())
+    foe.plugin_type = "foe"
+    foe.id = "f"
+    p1 = Stats()
+    p1.plugin_type = "player"
+    p1._base_max_hp = 100
+    p1.hp = 100
+    p1._base_defense = 0
+    p1.id = "p1"
+    p2 = Stats()
+    p2.plugin_type = "player"
+    p2._base_max_hp = 100
+    p2.hp = 100
+    p2._base_defense = 0
+    p2.id = "p2"
+    p1.effect_manager = EffectManager(p1)
+    p2.effect_manager = EffectManager(p2)
+
+    dot = BlazingTorment(1, 3)
+    dot.source = foe
+    p2.effect_manager.add_dot(dot)
+
+    foe.use_ultimate = _use_ultimate.__get__(foe, Stats)
+
+    BUS.emit("battle_start", foe)
+    BUS.emit("battle_start", p1)
+    BUS.emit("battle_start", p2)
+
+    foe.add_ultimate_charge(15)
+    assert foe.use_ultimate()
+
+    BUS.emit("hit_landed", foe, p1, 0, "attack")
+    await asyncio.sleep(0.01)
+
+    assert p2.effect_manager.dots == []
+    assert p2.dots == []
+    assert p1.hp == 99
+
+    BUS.emit("battle_end", foe)
+    BUS.emit("battle_end", p1)
+    BUS.emit("battle_end", p2)


### PR DESCRIPTION
## Summary
- Move all existing enemy DoTs to the chosen target when a Wind user fires their ultimate and detonate them instantly
- Clarify documentation for Wind ultimate DoT transfer
- Test Wind ultimate DoT transfer for both player and foe scenarios

## Testing
- `uv run ruff check plugins/damage_types/wind.py --fix`
- `uv run ruff check tests/test_wind_ultimate_dot_transfer.py --fix`
- `uv run pytest tests/test_wind_ultimate_dot_transfer.py`


------
https://chatgpt.com/codex/tasks/task_b_68b175f2560c832ca1840ae73cfbbd56