### PR TITLE
[FIX] ensure damage-type ultimates consume charge

### DIFF
--- a/backend/plugins/damage_types/dark.py
+++ b/backend/plugins/damage_types/dark.py
@@ -14,6 +14,7 @@ class Dark(DamageTypeBase):
     id: str = "Dark"
     weakness: str = "Light"
     color: tuple[int, int, int] = (145, 0, 145)
+    ultimate_via_bus: bool = True
 
     _cleanup_registered: bool = False
 

--- a/backend/plugins/damage_types/ice.py
+++ b/backend/plugins/damage_types/ice.py
@@ -17,6 +17,8 @@ class Ice(DamageTypeBase):
 
     async def ultimate(self, user: Stats, foes: list[Stats]) -> None:
         """Strike all foes six times, ramping damage by 30% per target."""
+        if not user.use_ultimate():
+            return
         base = user.atk
         for _ in range(6):
             bonus = 1.0

--- a/backend/plugins/damage_types/lightning.py
+++ b/backend/plugins/damage_types/lightning.py
@@ -31,6 +31,8 @@ class Lightning(DamageTypeBase):
                 )
 
     def ultimate(self, attacker, target) -> None:
+        if not getattr(attacker, "use_ultimate", lambda: False)():
+            return
         mgr = getattr(target, "effect_manager", None)
         if mgr is not None:
             types = ["Fire", "Ice", "Wind", "Lightning", "Light", "Dark"]


### PR DESCRIPTION
## Summary
- call `use_ultimate` within Lightning and Ice damage-type ultimates
- mark Dark damage type as bus-triggered for ultimates

## Testing
- `ruff check . --fix`
- `./run-tests.sh` *(fails: missing card placeholder asset, BattleReview expectation, backend tests/test_app.py timeout)*

------
https://chatgpt.com/codex/tasks/task_b_68b17b5a80ac832c80d37b72d0bd09c6