### PR TITLE
[FEAT] add action events and ultimate handling

### DIFF
--- a/backend/.codex/implementation/battle-action-events.md
+++ b/backend/.codex/implementation/battle-action-events.md
@@ -1,0 +1,16 @@
+# Battle action events
+
+The battle system emits additional events to coordinate turn-based effects and
+passive abilities:
+
+- `action_used` – emitted from `rooms/battle.py` whenever a combatant completes
+  an action.  Subscribers receive the acting entity, the target, and the amount
+  of damage or healing dealt.
+- `extra_turn` – grants an immediate extra action to the recipient.  The battle
+  loop tracks pending turns so effects like **SwiftFootwork** or **EchoBell** can
+  schedule additional moves without creating infinite loops.
+
+Damage type ultimates now consume charge via `use_ultimate()` and are invoked by
+`rooms/battle.py` when `ultimate_ready` is set.  Damage type plugins may add
+additional effects in their `ultimate` methods or respond to the
+`ultimate_used` event.

--- a/backend/plugins/damage_types/_base.py
+++ b/backend/plugins/damage_types/_base.py
@@ -176,6 +176,21 @@ class DamageTypeBase:
             pass
         return heal
 
+    async def ultimate(
+        self,
+        actor: Stats,
+        allies: list[Stats],
+        enemies: list[Stats],
+    ) -> bool:
+        """Default ultimate implementation.
+
+        Consumes the actor's ultimate charge via ``use_ultimate``.  Subclasses
+        should override this method to provide their own effects but may call
+        it with ``super().ultimate(...)`` to handle charge consumption.
+        """
+
+        return getattr(actor, "use_ultimate", lambda: False)()
+
     def create_dot(self, damage: float, source: Stats) -> DamageOverTime | None:
         """Return a DoT effect based on ``damage`` or ``None`` to skip."""
 

--- a/backend/plugins/damage_types/ice.py
+++ b/backend/plugins/damage_types/ice.py
@@ -15,8 +15,10 @@ class Ice(DamageTypeBase):
     def create_dot(self, damage: float, source) -> DamageOverTime | None:
         return damage_effects.create_dot(self.id, damage, source)
 
-    async def ultimate(self, user: Stats, foes: list[Stats]) -> None:
+    async def ultimate(self, user: Stats, foes: list[Stats]) -> bool:
         """Strike all foes six times, ramping damage by 30% per target."""
+        if not getattr(user, "use_ultimate", lambda: False)():
+            return False
         base = user.atk
         for _ in range(6):
             bonus = 1.0
@@ -24,3 +26,4 @@ class Ice(DamageTypeBase):
                 dmg = int(base * bonus)
                 await foe.apply_damage(dmg, attacker=user)
                 bonus += 0.3
+        return True

--- a/backend/plugins/damage_types/lightning.py
+++ b/backend/plugins/damage_types/lightning.py
@@ -30,7 +30,9 @@ class Lightning(DamageTypeBase):
                     target.apply_damage(dmg, attacker=attacker, trigger_on_hit=False)
                 )
 
-    def ultimate(self, attacker, target) -> None:
+    def ultimate(self, attacker, target) -> bool:
+        if not getattr(attacker, "use_ultimate", lambda: False)():
+            return False
         mgr = getattr(target, "effect_manager", None)
         if mgr is not None:
             types = ["Fire", "Ice", "Wind", "Lightning", "Light", "Dark"]
@@ -65,3 +67,4 @@ class Lightning(DamageTypeBase):
             BUS.subscribe("hit_landed", _hit)
             BUS.subscribe("battle_end", _clear)
             attacker._lightning_aftertaste_handler = _hit
+        return True


### PR DESCRIPTION
## Summary
- unify damage type ultimate handling and add default ultimate implementation
- emit `action_used` events and support extra turns in battle loop
- document battle action events and update dark ultimate tests

## Testing
- `uv run ruff check . --fix`
- `./run-tests.sh` *(fails: async plugin missing, missing tables, missing llms modules, asset placeholder missing, etc.)*


------
https://chatgpt.com/codex/tasks/task_b_68b17b5a80ac832c80d37b72d0bd09c6