### PR TITLE
[FIX] maintain foe level progression across floors

### DIFF
--- a/backend/autofighter/rooms/utils.py
+++ b/backend/autofighter/rooms/utils.py
@@ -64,7 +64,7 @@ def _scale_stats(obj: Stats, node: MapNode, strength: float = 1.0) -> None:
             setattr(obj, field.name, type(value)(total))
 
     try:
-        room_num = max(int(node.index), 1)
+        room_num = max(int(cumulative_rooms), 1)
         desired = max(1, math.ceil(room_num / 2))
         obj.level = int(max(getattr(obj, "level", 1), desired))
     except Exception:

--- a/backend/tests/test_foe_scaling_cumulative.py
+++ b/backend/tests/test_foe_scaling_cumulative.py
@@ -78,6 +78,33 @@ def test_foe_scaling_room_progression_within_floor():
     assert foe2.atk > foe1.atk, f"Room 10 foe should be stronger than Room 5: {foe2.atk} > {foe1.atk}"
 
 
+def test_foe_level_cumulative_progression():
+    """Foe level should never decrease across floor transitions."""
+    foe1 = FoeBase()
+    foe1.atk = 100
+    foe1.defense = 50
+    foe1.max_hp = 1000
+    foe1.hp = 1000
+
+    foe2 = FoeBase()
+    foe2.atk = 100
+    foe2.defense = 50
+    foe2.max_hp = 1000
+    foe2.hp = 1000
+
+    node1 = MapNode(room_id=45, room_type="battle-normal", floor=1, index=45, loop=1, pressure=0)
+    node2 = MapNode(room_id=1, room_type="battle-normal", floor=2, index=1, loop=1, pressure=0)
+
+    random.seed(42)
+    _scale_stats(foe1, node1)
+    random.seed(42)
+    _scale_stats(foe2, node2)
+
+    assert foe2.level >= foe1.level, (
+        f"Floor 2 Room 1 foe level {foe2.level} should be ≥ Floor 1 Room 45 foe level {foe1.level}"
+    )
+
+
 def test_cumulative_room_calculation():
     """Test that cumulative room calculation matches expected values."""
     # Floor 1, Room 1 should be cumulative room 1


### PR DESCRIPTION
## Summary
- prevent foes from dropping levels on new floors by basing level on cumulative room count
- add regression test ensuring floor 2 room 1 foes are never lower level than floor 1 room 45 foes

## Testing
- `ruff check backend/autofighter/rooms/utils.py backend/tests/test_foe_scaling_cumulative.py --fix`
- `uv run pytest tests/test_foe_scaling_cumulative.py -q`

------
https://chatgpt.com/codex/tasks/task_b_68b1ddee0ae8832cb193080ffff1d1b3