### PR TITLE
[FEAT] add upgrade system

### DIFF
--- a/backend/.codex/implementation/player-upgrade-endpoint.md
+++ b/backend/.codex/implementation/player-upgrade-endpoint.md
@@ -1,0 +1,12 @@
+# Player Upgrade Endpoint
+
+`GET /players/<id>/upgrade` returns the current upgrade level for the
+specified character and the full inventory of element-based upgrade items.
+
+`POST /players/<id>/upgrade` consumes 20×4★ (or 100×3★/500×2★/1000×1★) items
+matching the character's damage type and increments their stored level. Each
+rank boosts HP, ATK, and DEF by 5% and persists in the `player_upgrades`
+table. Item counts live in `upgrade_items`.
+
+## Testing
+- `uv run pytest backend/tests/test_player_upgrade.py`

--- a/backend/README.md
+++ b/backend/README.md
@@ -87,6 +87,12 @@ disabled by default but can be toggled with `POST /gacha/auto-craft`, which
 converts 125 lower-star items into one higher star and ten 4★ items into a
 ticket.
 
+`GET /players/<id>/upgrade` returns a character's current upgrade level and the
+inventory of element-based items. `POST /players/<id>/upgrade` consumes
+20×4★ (or 100×3★/500×2★/1000×1★) items matching the character's damage type to
+raise their level, boosting core stats by 5% per rank. Upgrade levels are stored
+in the `player_upgrades` table and item counts in `upgrade_items`.
+
 `GET /player/editor` returns saved pronouns, element, and stat allocations for
 the player. `PUT /player/editor` validates pronouns up to 15 characters,
 ensures the chosen damage type is Light, Dark, Wind, Lightning, Fire, or Ice,

--- a/backend/migrations/003_upgrades.sql
+++ b/backend/migrations/003_upgrades.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS player_upgrades (
+    id TEXT PRIMARY KEY,
+    level INTEGER NOT NULL DEFAULT 0
+);
+CREATE TABLE IF NOT EXISTS upgrade_items (
+    id TEXT PRIMARY KEY,
+    count INTEGER NOT NULL DEFAULT 0
+);

--- a/backend/tests/test_gacha.py
+++ b/backend/tests/test_gacha.py
@@ -46,8 +46,8 @@ async def test_pull_requires_ticket(app_with_db):
     conn = sqlcipher3.connect(db_path)
     conn.execute("PRAGMA key = 'testkey'")
     conn.execute(
-        "INSERT OR REPLACE INTO options (key, value) VALUES (?, ?)",
-        ("upgrade_items", '{}')
+        "INSERT OR REPLACE INTO upgrade_items (id, count) VALUES (?, ?)",
+        ("ticket", 0)
     )
     conn.commit()
     client = app.test_client()
@@ -77,8 +77,8 @@ async def test_pull_five_star_duplicate(app_with_db):
     for cid in others:
         conn.execute("INSERT OR IGNORE INTO owned_players (id) VALUES (?)", (cid,))
     conn.execute(
-        "INSERT OR REPLACE INTO options (key, value) VALUES (?, ?)",
-        ("upgrade_items", '{"ticket":1}')
+        "INSERT OR REPLACE INTO upgrade_items (id, count) VALUES (?, ?)",
+        ("ticket", 1)
     )
     conn.commit()
 
@@ -124,11 +124,12 @@ async def test_auto_craft_setting(app_with_db):
     conn = sqlcipher3.connect(db_path)
     conn.execute("PRAGMA key = 'testkey'")
     conn.execute(
-        "CREATE TABLE IF NOT EXISTS options (key TEXT PRIMARY KEY, value TEXT)"
+        "INSERT OR REPLACE INTO upgrade_items (id, count) VALUES (?, ?)",
+        ("ticket", 1)
     )
     conn.execute(
-        "INSERT OR REPLACE INTO options (key, value) VALUES (?, ?)",
-        ("upgrade_items", '{"ticket":1,"fire_1":125}')
+        "INSERT OR REPLACE INTO upgrade_items (id, count) VALUES (?, ?)",
+        ("fire_1", 125)
     )
     conn.commit()
     with patch(
@@ -142,8 +143,12 @@ async def test_auto_craft_setting(app_with_db):
     resp = await client.post("/gacha/auto-craft", json={"enabled": True})
     assert (await resp.get_json())["auto_craft"] is True
     conn.execute(
-        "INSERT OR REPLACE INTO options (key, value) VALUES (?, ?)",
-        ("upgrade_items", '{"ticket":1,"fire_1":125}')
+        "INSERT OR REPLACE INTO upgrade_items (id, count) VALUES (?, ?)",
+        ("ticket", 1)
+    )
+    conn.execute(
+        "INSERT OR REPLACE INTO upgrade_items (id, count) VALUES (?, ?)",
+        ("fire_1", 125)
     )
     conn.commit()
     with patch(
@@ -162,11 +167,8 @@ async def test_manual_craft_endpoint(app_with_db):
     conn = sqlcipher3.connect(db_path)
     conn.execute("PRAGMA key = 'testkey'")
     conn.execute(
-        "CREATE TABLE IF NOT EXISTS options (key TEXT PRIMARY KEY, value TEXT)",
-    )
-    conn.execute(
-        "INSERT OR REPLACE INTO options (key, value) VALUES (?, ?)",
-        ("upgrade_items", '{"fire_1":125}')
+        "INSERT OR REPLACE INTO upgrade_items (id, count) VALUES (?, ?)",
+        ("fire_1", 125)
     )
     conn.commit()
     resp = await client.post("/gacha/craft")

--- a/backend/tests/test_player_upgrade.py
+++ b/backend/tests/test_player_upgrade.py
@@ -1,0 +1,60 @@
+import importlib.util
+from pathlib import Path
+
+import pytest
+import sqlcipher3
+
+
+@pytest.fixture()
+def app_with_db(tmp_path, monkeypatch):
+    db_path = tmp_path / "save.db"
+    monkeypatch.setenv("AF_DB_PATH", str(db_path))
+    monkeypatch.setenv("AF_DB_KEY", "testkey")
+    monkeypatch.syspath_prepend(Path(__file__).resolve().parents[1])
+    spec = importlib.util.spec_from_file_location(
+        "app", Path(__file__).resolve().parents[1] / "app.py",
+    )
+    app_module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(app_module)
+    app_module.app.testing = True
+    conn = sqlcipher3.connect(db_path)
+    conn.execute("PRAGMA key = 'testkey'")
+    conn.execute(
+        "INSERT OR REPLACE INTO damage_types (id, type) VALUES (?, ?)",
+        ("player", "fire"),
+    )
+    conn.execute(
+        "INSERT OR REPLACE INTO upgrade_items (id, count) VALUES (?, ?)",
+        ("fire_4", 20),
+    )
+    conn.commit()
+    conn.close()
+    return app_module.app, db_path
+
+
+@pytest.mark.asyncio
+async def test_upgrade_increases_stats(app_with_db):
+    app, db_path = app_with_db
+    client = app.test_client()
+
+    resp = await client.post("/players/player/upgrade")
+    data = await resp.get_json()
+    assert data["level"] == 1
+    assert data["items"].get("fire_4", 0) == 0
+
+    resp = await client.get("/players/player/upgrade")
+    data = await resp.get_json()
+    assert data["level"] == 1
+
+    resp = await client.get("/players")
+    roster = await resp.get_json()
+    player_entry = next(p for p in roster["players"] if p["id"] == "player")
+    assert player_entry["stats"]["max_hp"] > 1000
+
+    conn = sqlcipher3.connect(db_path)
+    conn.execute("PRAGMA key = 'testkey'")
+    cur = conn.execute("SELECT level FROM player_upgrades WHERE id = ?", ("player",))
+    assert cur.fetchone()[0] == 1
+    conn.close()
+

--- a/frontend/.codex/implementation/party-ui.md
+++ b/frontend/.codex/implementation/party-ui.md
@@ -19,4 +19,7 @@ Implementation details:
 - `PartyPicker.svelte` propagates `reducedMotion` to the roster so the effect
   can be disabled via Settings.
 - `StatTabs.svelte` uses flexible sizing so the panel fills its side.
+- `StatTabs.svelte` now embeds an `UpgradePanel` beneath the stats list,
+  showing upgrade level and per-star item counts with a button disabled until
+  enough materials are available (20×4★ or 100×3★ or 500×2★ or 1000×1★).
 

--- a/frontend/src/lib/StatTabs.svelte
+++ b/frontend/src/lib/StatTabs.svelte
@@ -24,6 +24,7 @@
   import { createEventDispatcher } from 'svelte';
   import PlayerEditor from './PlayerEditor.svelte';
   import { getPlayerConfig } from './api.js';
+  import UpgradePanel from './UpgradePanel.svelte';
 
   /**
    * Renders the stats panel with category tabs and a toggle control.
@@ -264,7 +265,7 @@
             />
           </div>
         {/if}
-        <div class="upgrade-placeholder">Upgrade Character: Placeholder</div>
+        <UpgradePanel id={sel.id} element={sel.element} />
       </div>
     {/each}
   {/if}
@@ -358,11 +359,6 @@ button.confirm {
 
 /* Inline container occupying 50% of the stats panel width */
 .editor-wrap { width: 100%; }
-.upgrade-placeholder {
-  margin-top: 0.5rem;
-  font-size: 0.9rem;
-  color: #ddd;
-}
 
 /* Effects tab styles */
 .effects-header {

--- a/frontend/src/lib/UpgradePanel.svelte
+++ b/frontend/src/lib/UpgradePanel.svelte
@@ -1,0 +1,68 @@
+<script>
+  import { onMount } from 'svelte';
+  import { getUpgrade, upgradeCharacter } from './api.js';
+
+  export let id;
+  export let element;
+
+  let level = 0;
+  let items = {};
+  let loading = true;
+
+  async function load() {
+    loading = true;
+    try {
+      const data = await getUpgrade(id);
+      level = data.level || 0;
+      items = data.items || {};
+    } finally {
+      loading = false;
+    }
+  }
+
+  onMount(load);
+
+  $: key1 = `${element}_1`;
+  $: key2 = `${element}_2`;
+  $: key3 = `${element}_3`;
+  $: key4 = `${element}_4`;
+  $: have1 = items[key1] || 0;
+  $: have2 = items[key2] || 0;
+  $: have3 = items[key3] || 0;
+  $: have4 = items[key4] || 0;
+  $: canUpgrade =
+    have4 >= 20 || have3 >= 100 || have2 >= 500 || have1 >= 1000;
+
+  async function doUpgrade() {
+    await upgradeCharacter(id);
+    await load();
+  }
+</script>
+
+<div class="upgrade-panel" data-testid="upgrade-panel">
+  {#if loading}
+    <div>Loading upgrades...</div>
+  {:else}
+    <div>Upgrade Level: {level}</div>
+    <div>
+      Items: 1★ {have1}, 2★ {have2}, 3★ {have3}, 4★ {have4}
+    </div>
+    <div class="cost">Cost: 20×4★ or 100×3★ or 500×2★ or 1000×1★</div>
+    <button on:click={doUpgrade} disabled={!canUpgrade}>Upgrade</button>
+  {/if}
+</div>
+
+<style>
+.upgrade-panel {
+  margin-top: 0.5rem;
+  font-size: 0.9rem;
+  color: #ddd;
+}
+.upgrade-panel button {
+  margin-top: 0.25rem;
+}
+.upgrade-panel .cost {
+  margin-top: 0.25rem;
+  font-size: 0.8rem;
+}
+</style>

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -140,3 +140,15 @@ export async function getRelicCatalog() {
   const data = await handleFetch(`${API_BASE}/catalog/relics`, { cache: 'no-store', noOverlay: true });
   return data.relics || [];
 }
+
+export async function getUpgrade(id) {
+  return handleFetch(`${API_BASE}/players/${id}/upgrade`, { cache: 'no-store' });
+}
+
+export async function upgradeCharacter(id) {
+  return handleFetch(`${API_BASE}/players/${id}/upgrade`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({})
+  });
+}

--- a/frontend/tests/api.test.js
+++ b/frontend/tests/api.test.js
@@ -6,6 +6,8 @@ import {
   getGacha,
   pullGacha,
   setAutoCraft,
+  getUpgrade,
+  upgradeCharacter,
   wipeData,
   getLrmConfig,
   setLrmModel,
@@ -127,5 +129,17 @@ describe('api calls', () => {
     global.fetch = createFetch({ response: 'ok' });
     const result = await testLrmModel('hi');
     expect(result).toEqual({ response: 'ok' });
+  });
+
+  test('getUpgrade retrieves data', async () => {
+    global.fetch = createFetch({ level: 2, items: { fire_1: 3 } });
+    const result = await getUpgrade('player');
+    expect(result).toEqual({ level: 2, items: { fire_1: 3 } });
+  });
+
+  test('upgradeCharacter posts upgrade', async () => {
+    global.fetch = createFetch({ level: 1, items: {} });
+    const result = await upgradeCharacter('player');
+    expect(result).toEqual({ level: 1, items: {} });
   });
 });

--- a/frontend/tests/upgradepanel.test.js
+++ b/frontend/tests/upgradepanel.test.js
@@ -1,0 +1,13 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+describe('UpgradePanel component', () => {
+  test('contains upgrade UI', () => {
+    const content = readFileSync(join(import.meta.dir, '../src/lib/UpgradePanel.svelte'), 'utf8');
+    expect(content).toContain('data-testid="upgrade-panel"');
+    expect(content).toContain('Upgrade Level');
+    expect(content).toContain('Cost: 20×4★ or 100×3★ or 500×2★ or 1000×1★');
+    expect(content).toContain('button');
+  });
+});


### PR DESCRIPTION
## Summary
- align upgrade endpoints and docs with gacha plan costs
- show per-star upgrade items in StatTabs with cost-aware UI
- exercise upgrade flow with updated test cases

## Testing
- `ruff check backend/routes/players.py backend/tests/test_player_upgrade.py --fix`
- `./run-tests.sh` *(failed: numerous backend tests, run terminated early)*

------
https://chatgpt.com/codex/tasks/task_b_68b1ee223eec832c96e636eee9912193