### PR TITLE
Fix run restoration 404 handling

### DIFF
--- a/frontend/.codex/implementation/run-helpers.md
+++ b/frontend/.codex/implementation/run-helpers.md
@@ -9,5 +9,5 @@
 - `src/lib/RunButtons.svelte`: module script exporting `buildRunMenu` for constructing the menu item list. Inventory was removed from this menu and moved to the in‑run NavBar.
 - `src/lib/api.js`: `getBackendFlavor()` reports which backend flavor is active.
 - `src/routes/+page.svelte` now coordinates these helpers and avoids direct `localStorage` or fetch logic, also checking the backend flavor on mount.
-- `enterRoom` wraps `roomAction` calls with error handling. If the request fails, it attempts to load the latest battle snapshot and alerts the user when recovery is not possible.
+- `enterRoom` wraps `roomAction` calls with error handling. If the request fails, it attempts to load the latest battle snapshot and alerts the user when recovery is not possible. A `404` response clears the stored run state and returns the player to the main menu so restarting is possible.
 - `NavBar.svelte` now exposes an in‑run Inventory button (disabled during battles) alongside Home/Battle, Editor, Settings, and Back.

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -54,7 +54,7 @@ export async function getBackendHealth() {
       status = 'error';
     }
     return { status, ping_ms };
-  } catch (e) {
+  } catch {
     return { status: 'error', ping_ms: null };
   }
 }

--- a/frontend/src/lib/runApi.js
+++ b/frontend/src/lib/runApi.js
@@ -109,27 +109,23 @@ export async function chooseRelic(runId, relicId) {
 export async function getBattleSummary(runId, index) {
   // Use the backend API base; 404 is expected if summary not yet written
   const url = `${API_BASE}/run/${runId}/battles/${index}/summary`;
-  try {
-    const res = await fetch(url, { cache: 'no-store' });
-    if (res.status === 404) {
-      const err = new Error('summary not found');
-      err.status = 404;
-      err.overlayShown = true; // prevent global error overlay
-      throw err;
-    }
-    if (!res.ok) {
-      let data;
-      try { data = await res.json(); } catch {}
-      const message = data?.message || `HTTP error ${res.status}`;
-      const err = new Error(message);
-      err.status = res.status;
-      err.overlayShown = true;
-      throw err;
-    }
-    return res.json();
-  } catch (e) {
-    throw e;
+  const res = await fetch(url, { cache: 'no-store' });
+  if (res.status === 404) {
+    const err = new Error('summary not found');
+    err.status = 404;
+    err.overlayShown = true; // prevent global error overlay
+    throw err;
   }
+  if (!res.ok) {
+    let data;
+    try { data = await res.json(); } catch {}
+    const message = data?.message || `HTTP error ${res.status}`;
+    const err = new Error(message);
+    err.status = res.status;
+    err.overlayShown = true;
+    throw err;
+  }
+  return res.json();
 }
 
 export async function getBattleEvents(runId, index) {

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -409,7 +409,12 @@
           }
         } catch {}
       }
-  } catch (e) {
+    } catch (e) {
+      if (e?.status === 404) {
+        handleRunEnd();
+        openOverlay('error', { message: 'Run not found. Please start a new run.', traceback: '' });
+        return;
+      }
       try {
         if (haltSync || !runId) return;
         const snap = mapStatuses(await roomAction(runId, 'battle', 'snapshot'));


### PR DESCRIPTION
## Summary
- reset run state and show error when room endpoint returns 404
- document run helper behavior for missing runs
- clean up API helpers to satisfy lint rules

## Testing
- `uv tool run ruff check backend --fix`
- `bun run lint:fix`
- `./run-tests.sh` *(fails: ModuleNotFoundError: No module named 'llms'; TypeError: Stats.__init__() unexpected keyword 'atk')*

------
https://chatgpt.com/codex/tasks/task_b_68b336443f4c832c82d87a9bf2339750