### PR TITLE
[FIX] Spawn single foe in boss rooms

### DIFF
--- a/.codex/implementation/battle-room.md
+++ b/.codex/implementation/battle-room.md
@@ -11,6 +11,7 @@ Each strike rolls the attacker's `effect_hit_rate` against the target's `effect_
 During the foe's turn, a target is chosen from living party members with a probability weight of `defense × mitigation`, making sturdier allies more likely to draw aggro.
 
 `BossRoom` subclasses `BattleRoom` but multiplies foe stats by 100× to create floor bosses.
+Boss encounters always spawn exactly one foe regardless of party size or pressure.
 
 Experience is awarded as soon as a foe falls, allowing multiple enemies to grant cumulative rewards. When the fight ends, the backend returns updated party stats, card choices, and foe data so the run map can advance.
 

--- a/README.md
+++ b/README.md
@@ -272,6 +272,7 @@ Base battles spawn one foe plus one more for every five Pressure, up to ten.
 Party size can add bonus enemies: parties of two have a 35% chance to face one
 extra foe; parties of three roll 35% for two extras else 75% for one. Larger
 groups follow the same pattern, always capped at ten foes.
+Boss encounters ignore these rules and always spawn exactly one foe.
 
 5★ cards such as Phantom Ally, Temporal Shield, and Reality Split introduce
 summoned allies, turn-based damage reduction, and afterimage attacks that echo

--- a/backend/autofighter/rooms/utils.py
+++ b/backend/autofighter/rooms/utils.py
@@ -438,6 +438,9 @@ def _build_foes(node: MapNode, party: Party) -> list[FoeBase]:
     unique foe pool is smaller than the desired count, the final list is
     capped to the number of unique candidates.
     """
+    if "boss" in node.room_type:
+        return [_choose_foe(party)]
+
     base = min(10, 1 + node.pressure // 5)
     extras = 0
     size = len(party.members)

--- a/backend/routes/rooms.py
+++ b/backend/routes/rooms.py
@@ -24,6 +24,7 @@ from autofighter.rooms import ChatRoom
 from autofighter.rooms import RestRoom
 from autofighter.rooms import ShopRoom
 from autofighter.rooms import _build_foes
+from autofighter.rooms import _choose_foe
 from autofighter.rooms import _scale_stats
 from autofighter.rooms import _serialize
 from plugins.damage_types import load_damage_type
@@ -267,9 +268,9 @@ async def boss_room(run_id: str) -> tuple[str, int, dict[str, str]]:
     await asyncio.to_thread(save_map, run_id, state)
     room = BossRoom(node)
     party = await asyncio.to_thread(load_party, run_id)
-    foes = _build_foes(node, party)
-    for f in foes:
-        _scale_stats(f, node, room.strength)
+    foe = _choose_foe(party)
+    _scale_stats(foe, node, room.strength)
+    foes = [foe]
     combat_party = Party(
         members=[copy.deepcopy(m) for m in party.members],
         gold=party.gold,

--- a/backend/tests/test_boss_room_single_foe.py
+++ b/backend/tests/test_boss_room_single_foe.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))  # noqa: E402
+
+import pytest
+
+from autofighter.mapgen import MapNode
+from autofighter.party import Party
+from autofighter.rooms import utils
+from plugins.players import Player
+
+
+def _make_party(size: int) -> Party:
+    return Party(members=[Player() for _ in range(size)])
+
+
+def _make_node(pressure: int) -> MapNode:
+    return MapNode(
+        room_id=0,
+        room_type="battle-boss-floor",
+        floor=1,
+        index=1,
+        loop=1,
+        pressure=pressure,
+    )
+
+
+@pytest.mark.parametrize("size,pressure", [(1, 0), (3, 10), (5, 50)])
+def test_boss_rooms_spawn_one_foe(size: int, pressure: int) -> None:
+    party = _make_party(size)
+    node = _make_node(pressure)
+    foes = utils._build_foes(node, party)
+    assert len(foes) == 1
+


### PR DESCRIPTION
## Summary
- Return a single foe from `_build_foes` when room type is a boss
- Update boss room handler to scale a single chosen foe
- Document boss room single-foe encounters and add regression test

## Testing
- `uvx ruff check . --fix`
- `./run-tests.sh` *(fails: frontend tests assets.test.js, floor-transition.test.js, gameviewport.test.js)*

------
https://chatgpt.com/codex/tasks/task_b_68b36879116c832ca4f9054e27cf1218