### PR TITLE
[FEATURE] track self damage and friendly fire in battle logs

### DIFF
--- a/backend/.codex/implementation/battle-logging.md
+++ b/backend/.codex/implementation/battle-logging.md
@@ -31,6 +31,8 @@ Each battle summary includes:
 - Total damage taken by each participant
 - Total healing done by each participant
 - Total hits landed by each participant
+- Total self-inflicted damage by each participant
+- Total friendly fire damage by each participant
 - Battle duration and result
 - Participant lists (party members and foes)
 - Damage totals by element for each combatant
@@ -73,6 +75,12 @@ The battle logging system subscribes to the global event bus and automatically c
   "total_hits_landed": {
     "player": 8,
     "ally1": 6
+  },
+  "self_damage": {
+    "player": 5
+  },
+  "friendly_fire": {
+    "player": 12
   },
   "event_count": 45,
   "duration_seconds": 27.5


### PR DESCRIPTION
## Summary
- record self-inflicted and friendly fire damage in battle logs
- document new logging metrics

## Testing
- `./run-tests.sh` *(fails: ModuleNotFoundError: No module named 'battle_logging', TypeError: Stats.__init__() got an unexpected keyword argument 'atk', and other failures)*

------
https://chatgpt.com/codex/tasks/task_b_68b4a6148340832cb5b56254365242bb