### PR TITLE
[FIX] Default unnamed attack action

### DIFF
--- a/backend/battle_logging.py
+++ b/backend/battle_logging.py
@@ -256,6 +256,9 @@ class BattleLogger:
         attacker_id = getattr(attacker, 'id', str(attacker))
         target_id = getattr(target, 'id', str(target))
 
+        if source_type == "attack" and not action_name:
+            action_name = "Normal Attack"
+
         # Get damage type if not provided
         if damage_type is None and hasattr(attacker, 'damage_type'):
             damage_type = getattr(attacker.damage_type, 'id', str(attacker.damage_type))

--- a/backend/tests/test_battle_logging.py
+++ b/backend/tests/test_battle_logging.py
@@ -142,3 +142,26 @@ def test_human_readable_summary(temp_logs_dir):
     assert "hero: 1" in content  # hits landed
     assert "hero: 25" in content  # healing done
     assert "Total Events:" in content
+
+
+def test_damage_dealt_defaults_to_normal_attack(temp_logs_dir):
+    run_id = "test_run_normal_attack"
+    battle_index = 1
+    logger = BattleLogger(run_id, battle_index, temp_logs_dir)
+
+    attacker = Stats()
+    attacker.id = "hero"
+    target = Stats()
+    target.id = "monster"
+
+    BUS.emit("battle_start", attacker)
+    BUS.emit("battle_start", target)
+    BUS.emit("damage_dealt", attacker, target, 42)
+
+    logger.finalize_battle("victory")
+
+    summary_path = temp_logs_dir / "runs" / run_id / "battles" / "1" / "summary"
+    with open(summary_path / "battle_summary.json") as f:
+        summary = json.load(f)
+
+    assert summary["damage_by_action"]["hero"]["Normal Attack"] == 42


### PR DESCRIPTION
## Summary
- default missing attack actions to "Normal Attack" in battle logging
- test battle logging unnamed attack actions

## Testing
- `uv tool run ruff check backend --fix`
- `./run-tests.sh` *(fails: frontend tests missing modules; timed out: backend tests/test_app.py, backend tests/test_damage_type_persistence.py, backend tests/test_gacha.py)*
- `PYTHONPATH=. uv run pytest tests/test_battle_logging.py -k test_damage_dealt_defaults_to_normal_attack -q`

------
https://chatgpt.com/codex/tasks/task_b_68b4a9747a40832ca85110cdd06d0941