### PR TITLE
[FEAT] include max_stacks in passive serialization

### DIFF
--- a/backend/autofighter/rooms/utils.py
+++ b/backend/autofighter/rooms/utils.py
@@ -12,6 +12,7 @@ from plugins.foes._base import FoeBase
 
 from ..mapgen import MapNode
 from ..party import Party
+from ..passives import discover
 from ..stats import Stats
 
 # Balance caps for foe stats to prevent runaway scaling
@@ -314,7 +315,15 @@ def _serialize(obj: Stats) -> dict[str, Any]:
     data.pop("dots", None)
     data.pop("hots", None)
     counts = Counter(data.pop("passives", []))
-    data["passives"] = [{"id": pid, "stacks": count} for pid, count in counts.items()]
+    registry = discover()
+    data["passives"] = [
+        {
+            "id": pid,
+            "stacks": count,
+            "max_stacks": getattr(registry.get(pid), "max_stacks", None),
+        }
+        for pid, count in counts.items()
+    ]
 
     mgr = getattr(obj, "effect_manager", None)
     dots = []

--- a/backend/tests/test_effect_serialization.py
+++ b/backend/tests/test_effect_serialization.py
@@ -17,7 +17,7 @@ def test_serialize_effect_details():
     mgr.add_dot(DamageOverTime("burn", 5, 1, "burn", source))
     mgr.add_hot(HealingOverTime("regen", 3, 1, "regen", source))
 
-    target.passives = ["p1", "p1", "p2"]
+    target.passives = ["attack_up", "luna_lunar_reservoir", "luna_lunar_reservoir"]
 
     data = _serialize(target)
 
@@ -41,5 +41,11 @@ def test_serialize_effect_details():
             "stacks": 1,
         }
     ]
-    assert any(p["id"] == "p1" and p["stacks"] == 2 for p in data["passives"])
-    assert any(p["id"] == "p2" and p["stacks"] == 1 for p in data["passives"])
+    assert any(
+        p["id"] == "attack_up" and p["stacks"] == 1 and p["max_stacks"] is None
+        for p in data["passives"]
+    )
+    assert any(
+        p["id"] == "luna_lunar_reservoir" and p["stacks"] == 2 and p["max_stacks"] == 1
+        for p in data["passives"]
+    )


### PR DESCRIPTION
## Summary
- expose each passive's `max_stacks` when serializing characters
- test passive serialization with new `max_stacks` field

## Testing
- `./run-tests.sh` *(fails: RuntimeError: no running event loop, ModuleNotFoundError: No module named 'llms', ImportError: Failed to import plugin(s) ...)*

------
https://chatgpt.com/codex/tasks/task_b_68b51208aaf4832cab6151ad4426d433