### PR TITLE
[FEAT] show passive stacks on fighter portraits

### DIFF
--- a/frontend/.codex/implementation/battle-effects.md
+++ b/frontend/.codex/implementation/battle-effects.md
@@ -5,7 +5,12 @@
 includes an `id`, optional `name`, `stacks`, `turns`, and `source` along
 with `damage` or `healing` values. `StatusIcons.svelte` and
 `FighterPortrait.svelte` consume these arrays to render icons with stack
-counts and tooltips showing effect details.
+counts and tooltips showing effect details. Fighter portraits now also
+display passive stack indicators beside the element chip: passives with
+five or fewer maximum stacks render pips that fill as stacks accrue,
+larger finite stacks show `current/max`, and unlimited stacks display the
+raw count. These indicators respect Reduced Motion settings and expose
+tooltips for screen readers and mouse users.
 
 ## Stained-Glass Palette
 

--- a/frontend/src/lib/battle/FighterPortrait.svelte
+++ b/frontend/src/lib/battle/FighterPortrait.svelte
@@ -4,6 +4,7 @@
   import StatusIcons from './StatusIcons.svelte';
 
   export let fighter = {};
+  export let reducedMotion = false;
   $: passiveTip = (fighter.passives || [])
     .map((p) => `${p.id}${p.stacks > 1 ? ` x${p.stacks}` : ''}`)
     .join(', ');
@@ -64,6 +65,26 @@
         aria-hidden="true"
       />
     </div>
+    {#if (fighter.passives || []).length}
+      <div class="passive-indicators" class:reduced={reducedMotion}>
+        {#each fighter.passives as p (p.id)}
+          {@const tip = `${p.id} ${p.stacks}${p.max_stacks ? `/${p.max_stacks}` : ''}`}
+          <div class="passive" aria-label={tip} title={tip}>
+            {#if p.max_stacks && p.max_stacks <= 5}
+              <div class="pips">
+                {#each Array(p.max_stacks) as _, i (i)}
+                  <span class="pip" class:filled={i < p.stacks} aria-hidden="true"></span>
+                {/each}
+              </div>
+            {:else if p.max_stacks}
+              <span class="count">{p.stacks}/{p.max_stacks}</span>
+            {:else}
+              <span class="count">{p.stacks}</span>
+            {/if}
+          </div>
+        {/each}
+      </div>
+    {/if}
   </div>
   {#if ((Array.isArray(fighter.hots) ? fighter.hots.length : 0) + (Array.isArray(fighter.dots) ? fighter.dots.length : 0) + (Array.isArray(fighter.active_effects) ? fighter.active_effects.length : 0)) > 0}
     <!-- Buff Bar: shows current HoT/DoT effects under the portrait. -->
@@ -132,6 +153,47 @@
     transition: stroke-dasharray 0.2s linear;
   }
   .element-icon { width: 16px; height: 16px; display: block; }
+
+  .passive-indicators {
+    position: absolute;
+    bottom: 2px;
+    right: 24px;
+    display: flex;
+    gap: 2px;
+    pointer-events: none;
+  }
+  .passive {
+    background: var(--glass-bg);
+    box-shadow: var(--glass-shadow);
+    border: var(--glass-border);
+    backdrop-filter: var(--glass-filter);
+    padding: 0 2px;
+    min-width: 12px;
+    height: 12px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.6rem;
+    line-height: 1;
+  }
+  .pips { display: flex; gap: 1px; }
+  .pip {
+    width: 3px;
+    height: 3px;
+    border-radius: 50%;
+    background: rgba(0, 0, 0, 0.4);
+    transition: transform 0.2s, background 0.2s;
+  }
+  .pip.filled {
+    background: var(--el-color);
+    transform: scale(1.2);
+  }
+  .passive-indicators.reduced .pip {
+    transition: none;
+  }
+  .passive-indicators.reduced .pip.filled {
+    transform: none;
+  }
 
   /* Buff Bar (stained-glass style) */
   .buff-bar {

--- a/frontend/src/lib/components/BattleReview.svelte
+++ b/frontend/src/lib/components/BattleReview.svelte
@@ -15,6 +15,7 @@
   export let foes = [];
   export let partyData = [];
   export let foeData = [];
+  export let reducedMotion = false;
 
   const dispatch = createEventDispatcher();
   let summary = { damage_by_type: {} };
@@ -855,7 +856,7 @@
             {:else if tab.entity}
               {@const _tabFighter = toDisplayFighter(tab.entity)}
               <div style="--portrait-size: 3rem;">
-                <FighterPortrait fighter={_tabFighter} />
+                <FighterPortrait fighter={_tabFighter} {reducedMotion} />
               </div>
             {:else}
               <User size={20} />
@@ -1266,7 +1267,7 @@
               {#if currentTab.entity}
                 {@const _fighter = toDisplayFighter(currentTab.entity)}
                 <div style="--portrait-size: 4.5rem;">
-                  <FighterPortrait fighter={_fighter} />
+                  <FighterPortrait fighter={_fighter} {reducedMotion} />
                 </div>
               {/if}
               <h3>{currentTab.label} Breakdown</h3>

--- a/frontend/src/lib/components/BattleView.svelte
+++ b/frontend/src/lib/components/BattleView.svelte
@@ -211,7 +211,7 @@
   <div class="party-column" style={`--portrait-size: ${partyPortraitSize}` }>
     {#each party as member (member.id)}
       <div class="combatant">
-        <FighterPortrait fighter={member} />
+        <FighterPortrait fighter={member} {reducedMotion} />
         {#if showHud}
           <div class="stats right stained-glass-panel">
             <div class="name">{(member.name ?? member.id)} ({member.level ?? 1})</div>
@@ -261,7 +261,7 @@
               </details>
             </div>
           {/if}
-          <FighterPortrait fighter={foe} />
+          <FighterPortrait fighter={foe} {reducedMotion} />
         </div>
       {/each}
     </div>

--- a/frontend/src/lib/components/OverlayHost.svelte
+++ b/frontend/src/lib/components/OverlayHost.svelte
@@ -250,6 +250,7 @@
         foeData={(battleSnapshot?.foes && battleSnapshot?.foes.length) ? battleSnapshot.foes : (roomData?.foes || [])}
         cards={[]}
         relics={[]}
+        {reducedMotion}
       />
       <div class="stained-glass-row" style="justify-content: flex-end; margin-top: 0.75rem;">
         <button class="icon-btn" on:click={() => dispatch('nextRoom')}>Next Room</button>

--- a/frontend/tests/battleview.test.js
+++ b/frontend/tests/battleview.test.js
@@ -58,6 +58,11 @@ describe('BattleView layout and polling', () => {
     expect(statusIcons).toContain('stack inside');
   });
 
+  test('displays passive stack indicators', () => {
+    expect(fighterPortrait).toContain('fighter.passives');
+    expect(fighterPortrait).toContain('passive-indicators');
+  });
+
   test('uses normalized element for portraits', () => {
     expect(fighterPortrait).toContain('getElementIcon(fighter.element)');
     expect(fighterPortrait).toContain('getElementColor(fighter.element)');


### PR DESCRIPTION
## Summary
- render passive stack indicators beside element chips
- propagate reduced motion flag through battle components
- document passive indicators

## Testing
- `cd backend && ruff check . --fix`
- `cd frontend && bun run lint:fix`
- `./run-tests.sh` *(fails: multiple backend and frontend tests, see log)*

------
https://chatgpt.com/codex/tasks/task_b_68b513fd32d0832cbccc6ff1c9cd43e7