### PR TITLE
[FEAT] Shuffle battle playlists

### DIFF
--- a/frontend/.codex/implementation/battle-music.md
+++ b/frontend/.codex/implementation/battle-music.md
@@ -17,5 +17,6 @@ tracks for the next room transition.
 - **Fallback**
   - When no character has music, generic library tracks are returned.
 
-The chosen playlist is passed to `startGameMusic` which handles sequential
-playback and looping.
+The chosen playlist is passed to `startGameMusic` which accepts a track list,
+shuffles it, and plays tracks sequentially. When looping, the playlist is
+reshuffled after each cycle to avoid repetition.

--- a/frontend/src/lib/systems/music.js
+++ b/frontend/src/lib/systems/music.js
@@ -21,7 +21,7 @@ for (const [path, url] of Object.entries(musicModules)) {
   musicLibrary[character][category].push(url);
 }
 
-function shuffle(array) {
+export function shuffle(array) {
   const result = [...array];
   for (let i = result.length - 1; i > 0; i--) {
     const j = Math.floor(Math.random() * (i + 1));

--- a/frontend/src/lib/systems/viewportState.js
+++ b/frontend/src/lib/systems/viewportState.js
@@ -7,6 +7,7 @@ import {
   getCharacterPlaylist,
   getMusicTracks,
   getRandomMusicTrack,
+  shuffle,
 } from './music.js';
 
 export async function loadInitialState() {
@@ -151,6 +152,7 @@ function playNextTrack() {
       playlistIndex += 1;
       if (playlistIndex >= currentPlaylist.length) {
         if (playlistLoop) {
+          currentPlaylist = shuffle(currentPlaylist);
           playlistIndex = 0;
         } else {
           currentPlaylist = [];
@@ -166,7 +168,7 @@ export function startGameMusic(volume, playlist = [], loop = true) {
   if (typeof volume === 'number') currentMusicVolume = volume;
   stopGameMusic();
   if (Array.isArray(playlist) && playlist.length > 0) {
-    currentPlaylist = playlist;
+    currentPlaylist = shuffle(playlist);
     playlistIndex = 0;
     playlistLoop = loop;
   } else {


### PR DESCRIPTION
## Summary
- shuffle playlist retrieval for character music
- randomize and reshuffle battle music loops
- document battle music playlist behavior

## Testing
- `bun run lint:fix`
- `./run-tests.sh` *(fails: Timed out (>15s) tests: backend tests/test_app.py, backend tests/test_app_without_llm_deps.py)*

------
https://chatgpt.com/codex/tasks/task_b_68b6c6c96230832c98cae6606d6b1640