### PR TITLE
Display summon portraits in battle view

### DIFF
--- a/frontend/.codex/implementation/summon-portraits.md
+++ b/frontend/.codex/implementation/summon-portraits.md
@@ -1,0 +1,10 @@
+# Summon Portrait Display
+
+Battle snapshots may include `party_summons` and `foe_summons` arrays keyed by `owner_id`.
+`BattleView.svelte` now maps these entries to a `summons` property on each fighter.
+During combat, each fighter renders any summons beside its portrait:
+
+- Party summons appear to the right of their owner.
+- Foe summons appear to the left of their owner.
+
+Summon portraits reuse `FighterPortrait` at 60% of the base `--portrait-size` and respect Reduced Motion settings.

--- a/frontend/src/lib/systems/viewportState.js
+++ b/frontend/src/lib/systems/viewportState.js
@@ -6,7 +6,6 @@ import { getPlayers } from './api.js';
 import {
   getCharacterPlaylist,
   getMusicTracks,
-  getRandomMusicTrack,
   getFallbackPlaylist,
   shuffle,
 } from './music.js';


### PR DESCRIPTION
## Summary
- map snapshot party and foe summons onto their respective fighters
- render summon portraits around combatants and remove deprecated stat panels
- document summon portrait behaviour

## Testing
- `uv tool run ruff check backend --fix`
- `bun run lint:fix`
- `./run-tests.sh` *(fails: ModuleNotFoundError: No module named 'battle_logging')*

------
https://chatgpt.com/codex/tasks/task_b_68b6df7ebba8832c9dde07ae7ef0c6c4