### PR TITLE
feat: crossfade battle music and weighted playlists

### DIFF
--- a/.codex/implementation/game-music.md
+++ b/.codex/implementation/game-music.md
@@ -25,15 +25,23 @@ category is omitted the file falls under `other`.
 first foe's `boss` playlist overrides and plays if present, otherwise the global
 library is used. For regular battles the party and foes contribute their playlists
 and a weighted roll chooses one. Foes named `Luna` receive a weight of 3 while all
-others use 1, giving Luna's themes a higher chance to play.
+others use 1, giving Luna's themes a higher chance to play. Battle music only
+switches after the backend has reported combatants several times so transitions
+occur after full data is available.
 
 ## Shuffling and playback
 
 `startGameMusic()` shuffles the selected playlist with a Fisher–Yates algorithm and
-loops it. When the playlist ends it reshuffles before replaying; if no playlist is
-active a random track is chosen from the full library. Because assets are discovered
-recursively, any additional files dropped into `assets/music` are picked up and
-participate in this shuffle automatically.
+crossfades between the previous and next track using two `Audio` instances. When the
+playlist ends it reshuffles before replaying; if no playlist is active a random
+track is chosen from the full library. Because assets are discovered recursively,
+any additional files dropped into `assets/music` are picked up and participate in
+this shuffle automatically.
+
+To prevent abrupt stops during room transitions, `startGameMusic` caches the
+unshuffled playlist. Repeated calls with the same list simply reapply volume,
+allowing the current track to continue until it ends or a new playlist is
+requested.
 
 Headless environments may not support audio playback; tests rely on Bun's no-op
 `Audio` implementation so CI runs without sound hardware.

--- a/frontend/.codex/implementation/battle-music.md
+++ b/frontend/.codex/implementation/battle-music.md
@@ -4,19 +4,25 @@ Describes how the frontend selects playlists for combat.
 
 ## selectBattleMusic
 `selectBattleMusic({ roomType, party, foes })` returns a playlist of music
-tracks for the next room transition.
+tracks for the next room transition. Battle playlists are only evaluated after
+the backend has reported fighters for the room a few times, keeping the
+fallback music active until complete data is available.
 
 - **Boss rooms** (`roomType === 'battle-boss-floor'`)
   - Always returns the boss's `boss` playlist.
   - Playlist loops continuously.
 - **Non-boss battles**
   - Collects playlists for every combatant present.
-  - Each playlist is weighted equally, but Luna receives an extra weight when
-    appearing as a foe.
-  - A weighted roll decides which playlist to use.
+  - Luna's playlist receives weight 3; all others use weight 1.
+  - A weighted roll chooses the resulting playlist, favouring Luna when
+    present.
 - **Fallback**
   - When no character has music, generic library tracks are returned.
 
 The chosen playlist is passed to `startGameMusic` which accepts a track list,
-shuffles it, and plays tracks sequentially. When looping, the playlist is
+shuffles it, and crossfades from the previous selection. When fighters appear,
+the player transitions from fallback tracks to character themes via crossfade.
+If `startGameMusic` receives the same playlist again during scene changes, it
+simply reapplies volume, allowing the current music to keep playing until it
+naturally ends or a new playlist is requested. When looping, the playlist is
 reshuffled after each cycle to avoid repetition.


### PR DESCRIPTION
## Summary
- crossfade between battle tracks and respect character-specific playlists
- weight battle music selection toward Luna with fallback support
- cache playlists so battle music continues across scene changes

## Testing
- `bun run lint:fix`
- `uv tool run ruff check backend --fix`
- `./run-tests.sh` *(fails: ModuleNotFoundError: No module named 'battle_logging', etc.)*

------
https://chatgpt.com/codex/tasks/task_b_68b6e1394c30832c82a6750cb066a861