### PR TITLE
Trigger battle music on fighter data

### DIFF
--- a/frontend/.codex/implementation/battle-music.md
+++ b/frontend/.codex/implementation/battle-music.md
@@ -4,9 +4,9 @@ Describes how the frontend selects playlists for combat.
 
 ## selectBattleMusic
 `selectBattleMusic({ roomType, party, foes })` returns a playlist of music
-tracks for the next room transition. Battle playlists are only evaluated after
-the backend has reported fighters for the room a few times, keeping the
-fallback music active until complete data is available.
+tracks for the next room transition. When both party and foe data are present,
+character-specific playlists are evaluated immediately. Until battler
+information arrives, generic fallback tracks continue playing.
 
 - **Boss rooms** (`roomType === 'battle-boss-floor'`)
   - Always returns the boss's `boss` playlist.
@@ -20,9 +20,9 @@ fallback music active until complete data is available.
   - When no character has music, generic library tracks are returned.
 
 The chosen playlist is passed to `startGameMusic` which accepts a track list,
-shuffles it, and crossfades from the previous selection. When fighters appear,
-the player transitions from fallback tracks to character themes via crossfade.
-If `startGameMusic` receives the same playlist again during scene changes, it
-simply reapplies volume, allowing the current music to keep playing until it
-naturally ends or a new playlist is requested. When looping, the playlist is
-reshuffled after each cycle to avoid repetition.
+shuffles it, and crossfades from the previous selection. GameViewport tracks
+party and foe identifiers so that when fighter data appears or changes, a new
+playlist is requested. If `startGameMusic` receives the same playlist again
+during scene changes, it simply reapplies volume, allowing the current music to
+keep playing until it naturally ends or a new playlist is requested. When
+looping, the playlist is reshuffled after each cycle to avoid repetition.

--- a/frontend/src/lib/components/GameViewport.svelte
+++ b/frontend/src/lib/components/GameViewport.svelte
@@ -90,11 +90,19 @@
 
   let lastMusicKey = '';
   $: {
-    // Change music per room type and battle index (new fights),
-    // avoiding restarts on reward overlays or UI toggles.
+    // Change music per room type and battle index (new fights) and
+    // rerun when party/foe combatants change to trigger character themes.
     const typeKey = String(currentRoomType || roomData?.current_room || '');
     const battleKey = String(roomData?.battle_index || 0);
-    const key = `${typeKey}|${battleKey}`;
+    const partyKey = (roomData?.party || [])
+      .map((p) => (typeof p === 'string' ? p : p.id || p.name))
+      .sort()
+      .join(',');
+    const foeKey = (roomData?.foes || [])
+      .map((f) => (typeof f === 'string' ? f : f.id || f.name))
+      .sort()
+      .join(',');
+    const key = `${typeKey}|${battleKey}|${partyKey}|${foeKey}`;
     if (key !== lastMusicKey) {
       lastMusicKey = key;
       const playlist = selectBattleMusic({

--- a/frontend/src/lib/systems/music.js
+++ b/frontend/src/lib/systems/music.js
@@ -1,7 +1,11 @@
 // Music loader for background tracks
 // Tracks are provided by the lead developer in ./assets/music
 
-const musicModules = import.meta.glob('../assets/music/**/*.{mp3,ogg,wav}', {
+const glob = typeof import.meta.glob === 'function'
+  ? import.meta.glob
+  : () => ({})
+;
+const musicModules = glob('../assets/music/**/*.{mp3,ogg,wav}', {
   eager: true,
   import: 'default',
   query: '?url'
@@ -64,4 +68,4 @@ export function getFallbackPlaylist(category = 'normal') {
   return [...tracks];
 }
 
-export { characterLibrary };
+export { characterLibrary, fallbackLibrary };

--- a/frontend/src/lib/systems/viewportState.js
+++ b/frontend/src/lib/systems/viewportState.js
@@ -83,8 +83,6 @@ export function rewardOpen(roomData, _battleActive) {
   return Boolean(hasCards || hasRelics);
 }
 
-const battlePollCounts = new Map();
-
 export function selectBattleMusic({ roomType, party = [], foes = [] }) {
   const type = String(roomType || '');
   const category =
@@ -105,16 +103,12 @@ export function selectBattleMusic({ roomType, party = [], foes = [] }) {
     return getFallbackPlaylist('normal');
   }
 
-  const key = `${type}`;
   if (type.startsWith('battle')) {
     const ready = (party?.length || 0) > 0 && (foes?.length || 0) > 0;
-    const count = battlePollCounts.get(key) || 0;
-    if (!ready || count < 2) {
-      battlePollCounts.set(key, count + 1);
+    if (!ready) {
       const fb = getFallbackPlaylist(category);
       return fb.length ? fb : [];
     }
-    battlePollCounts.delete(key);
   }
 
   const candidates = [];

--- a/frontend/tests/battlemusic.test.js
+++ b/frontend/tests/battlemusic.test.js
@@ -1,0 +1,24 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  characterLibrary,
+  fallbackLibrary,
+} from '../src/lib/systems/music.js';
+import { selectBattleMusic } from '../src/lib/systems/viewportState.js';
+
+characterLibrary.luna = { normal: ['/luna/theme.mp3'] };
+fallbackLibrary.normal = ['/fallback/track.mp3'];
+
+describe('battle music selection', () => {
+  test("Luna's theme plays once combatants are known", () => {
+    const roomType = 'battle-normal';
+    const early = selectBattleMusic({ roomType, party: [], foes: [] });
+    expect(early.some((t) => t.includes('/luna/'))).toBe(false);
+
+    const playlist = selectBattleMusic({
+      roomType,
+      party: [{ id: 'luna' }],
+      foes: [{ id: 'slime' }]
+    });
+    expect(playlist.some((t) => t.includes('/luna/'))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- rerun viewport music when party or foe roster changes
- simplify battle music selection to evaluate fighter playlists immediately
- document battler-driven music logic and test Luna's theme activation

## Testing
- `ruff check . --fix` (frontend)
- `bun test tests/battlemusic.test.js`
- `./run-tests.sh` *(fails: missing modules and other backend issues)*

------
https://chatgpt.com/codex/tasks/task_b_68b6ef3ff81c832c8a062ee83114560c