### PR TITLE
feat: track summons in battle snapshots

### DIFF
--- a/.codex/implementation/asset-loader.md
+++ b/.codex/implementation/asset-loader.md
@@ -6,7 +6,7 @@
 - Backgrounds rotate hourly using a seeded random selector and fall back to the repository logo when none are available.
 - `getElementIcon` and `getElementColor` expose consistent damage type icons and colors for Fire, Ice, Lightning, Light, Dark, Wind, and Generic types.
 
-The loader is shared by the party picker, map display, and battle view so character images and type colors stay in sync across the UI. URL handling is normalized so root-relative or absolute URLs are not re-resolved, preventing malformed `file://` URLs in non-browser contexts.
+The loader lives in `frontend/src/lib/systems/assetLoader.js` and is shared by the party picker, map display, and battle view so character images and type colors stay in sync across the UI. URL handling is normalized so root-relative or absolute URLs are not re-resolved, preventing malformed `file://` URLs in non-browser contexts. IDs beginning with `jellyfish_` are aliased to the base `jellyfish` art folder so summons can reuse bundled portraits.
 
 ## Testing
 - `bun test frontend/tests/assetloader.test.js`

--- a/.codex/implementation/battle-view.md
+++ b/.codex/implementation/battle-view.md
@@ -11,7 +11,8 @@ Visual pieces have been split into small subcomponents under
 - `FighterPortrait.svelte` – portrait, HP bar, element chip (circular dark
   backdrop with a strong background blur; no outer glow) and embedded
   `StatusIcons`. Passive stack pips render as vector icons and tint to the
-  element color when filled.
+  element color when filled. Portrait resolution prefers `fighter.summon_type`
+  when present so summons can reuse shared art folders.
 - `StatusIcons.svelte` – collapses duplicate HoT/DoT names into single icons
   with stack counts.
 - `EnrageIndicator.svelte` – pulsing red/blue overlay when the backend reports
@@ -55,6 +56,10 @@ fixed interval and the polling delay honors 30/60/120 fps settings without a
 `NavBar` shows a stained-glass status panel with a
 spinner while updates are in flight. Incoming party and foe arrays are compared
 to the previous snapshot to avoid unnecessary re-renders.
+
+Summon data is provided through `party_summons` and `foe_summons` objects keyed
+by the summoner's id. The view flattens these maps into arrays grouped by owner
+so that summoned units render alongside their summoners.
 
 ## Testing
 - `bun test frontend/tests/battleview.test.js`

--- a/backend/.codex/implementation/battle-snapshots.md
+++ b/backend/.codex/implementation/battle-snapshots.md
@@ -15,6 +15,10 @@ poll for results:
   crashes. On failure the battle flag is cleared, map and party data are saved,
   and the snapshot records the `error` with `awaiting_next` set to `false` so
   runs do not hang.
+- Snapshots expose active summons through `party_summons` and `foe_summons`.
+  Both maps are keyed by the owning combatant's id and store arrays of
+  serialized summons. Each summon snapshot also includes an `owner_id` for
+  convenience.
 
 These snapshots are stored in `game.battle_snapshots` and polled by the
 frontend during combat.

--- a/backend/plugins/passives/becca_menagerie_bond.py
+++ b/backend/plugins/passives/becca_menagerie_bond.py
@@ -7,6 +7,7 @@ from autofighter.summons import SummonManager
 from plugins.damage_types import load_damage_type
 
 if TYPE_CHECKING:
+    from autofighter.party import Party
     from autofighter.stats import Stats
 
 
@@ -73,8 +74,17 @@ class BeccaMenagerieBond:
         if self._summon_cooldown[entity_id] > 0:
             self._summon_cooldown[entity_id] -= 1
 
-    async def summon_jellyfish(self, target: "Stats", jellyfish_type: str = None) -> bool:
-        """Summon a jellyfish by spending 10% current HP."""
+    async def summon_jellyfish(
+        self,
+        target: "Stats",
+        jellyfish_type: str | None = None,
+        party: "Party | None" = None,
+    ) -> bool:
+        """Summon a jellyfish by spending 10% current HP.
+
+        If a ``party`` is provided, the new summon will be appended so it can
+        participate in combat immediately.
+        """
         entity_id = id(target)
         target_id = getattr(target, 'id', str(id(target)))
 
@@ -125,6 +135,8 @@ class BeccaMenagerieBond:
         )
 
         if summon:
+            if party is not None:
+                SummonManager.add_summons_to_party(party)
             self._last_summon[entity_id] = jellyfish_type
             self._summon_cooldown[entity_id] = 1  # One turn cooldown
             return True

--- a/backend/plugins/passives/becca_menagerie_bond.py
+++ b/backend/plugins/passives/becca_menagerie_bond.py
@@ -102,6 +102,18 @@ class BeccaMenagerieBond:
         if target.hp <= hp_cost:
             return False  # Not enough HP
 
+        # Use the enhanced decision logic from SummonManager
+        # But still allow jellyfish type changes (which is Becca's unique mechanic)
+        decision = SummonManager.should_resummon(target_id, min_health_threshold=0.3)
+        current_summons = SummonManager.get_summons(target_id)
+        jellyfish_summons = [s for s in current_summons if s.summon_source == self.id]
+
+        # If we have viable jellyfish and we're not changing type, skip summoning
+        if (not decision['should_resummon'] and
+            jellyfish_type == self._last_summon.get(entity_id) and
+            jellyfish_summons):
+            return False
+
         # Pay HP cost using proper damage system
         target.hp -= hp_cost
 

--- a/backend/tests/test_summon_decision_logic.py
+++ b/backend/tests/test_summon_decision_logic.py
@@ -1,0 +1,222 @@
+"""Tests for summon decision logic and AI behavior."""
+
+from llms import torch_checker
+import pytest
+
+from autofighter.summons import Summon
+from autofighter.summons import SummonManager
+from plugins.players.ally import Ally
+
+
+@pytest.mark.asyncio
+async def test_summon_viability_evaluation(monkeypatch):
+    """Test the summon viability evaluation logic."""
+    monkeypatch.setattr(torch_checker, "is_torch_available", lambda: False)
+
+    SummonManager.cleanup()
+
+    # Create a test summon
+    summoner = Ally()
+    summoner.id = "test_summoner"
+    summoner._base_atk = 100
+    summoner._base_max_hp = 200
+    summoner._base_defense = 50
+
+    summon = Summon.create_from_summoner(
+        summoner=summoner,
+        summon_type="test",
+        source="test_source",
+        stat_multiplier=0.5,
+        turns_remaining=5
+    )
+
+    # Test healthy summon
+    summon.hp = summon.max_hp  # Full health
+    eval_result = SummonManager.evaluate_summon_viability(summon)
+
+    assert eval_result['viable'] is True
+    assert eval_result['health_good'] is True
+    assert eval_result['expiring_soon'] is False
+    assert eval_result['time_remaining'] == 5
+    assert "keep current summon" in eval_result['recommendation'].lower()
+
+    # Test low health summon
+    summon.hp = int(summon.max_hp * 0.1)  # 10% health
+    eval_result = SummonManager.evaluate_summon_viability(summon)
+
+    assert eval_result['viable'] is False
+    assert eval_result['health_good'] is False
+    assert "low health" in eval_result['recommendation'].lower()
+
+    # Test expiring summon
+    summon.hp = summon.max_hp  # Full health
+    summon.turns_remaining = 1  # Expiring soon
+    eval_result = SummonManager.evaluate_summon_viability(summon)
+
+    assert eval_result['viable'] is False
+    assert eval_result['expiring_soon'] is True
+    assert "expiring" in eval_result['recommendation'].lower()
+
+
+@pytest.mark.asyncio
+async def test_resummon_decision_logic(monkeypatch):
+    """Test the decision logic for when to resummon."""
+    monkeypatch.setattr(torch_checker, "is_torch_available", lambda: False)
+
+    SummonManager.cleanup()
+
+    summoner = Ally()
+    summoner.id = "test_summoner"
+    summoner._base_atk = 100
+    summoner._base_max_hp = 200
+    summoner._base_defense = 50
+
+    # Test no existing summons - should resummon
+    decision = SummonManager.should_resummon("test_summoner")
+    assert decision['should_resummon'] is True
+    assert "no existing summons" in decision['reason'].lower()
+    assert decision['viable_count'] == 0
+
+    # Create a healthy summon
+    summon = SummonManager.create_summon(
+        summoner=summoner,
+        summon_type="test",
+        source="test_source",
+        turns_remaining=10
+    )
+    summon.hp = summon.max_hp  # Ensure full health
+
+    # Test with healthy summon - should NOT resummon
+    decision = SummonManager.should_resummon("test_summoner")
+    assert decision['should_resummon'] is False
+    assert "viable summon" in decision['reason'].lower()
+    assert decision['viable_count'] == 1
+
+    # Damage the summon to low health
+    summon.hp = int(summon.max_hp * 0.1)  # 10% health
+
+    # Test with damaged summon - should resummon
+    decision = SummonManager.should_resummon("test_summoner")
+    assert decision['should_resummon'] is True
+    assert "low health" in decision['reason'].lower()
+    assert decision['viable_count'] == 0
+
+
+@pytest.mark.asyncio
+async def test_smart_summon_creation(monkeypatch):
+    """Test that summon creation respects decision logic."""
+    monkeypatch.setattr(torch_checker, "is_torch_available", lambda: False)
+
+    SummonManager.cleanup()
+
+    summoner = Ally()
+    summoner.id = "test_summoner"
+    summoner._base_atk = 100
+    summoner._base_max_hp = 200
+    summoner._base_defense = 50
+
+    # Create first summon (should succeed)
+    summon1 = SummonManager.create_summon(
+        summoner=summoner,
+        summon_type="test1",
+        source="test_source",
+        max_summons=1
+    )
+    assert summon1 is not None
+    summon1.hp = summon1.max_hp  # Ensure healthy
+
+    # Try to create second summon with healthy first summon (should fail due to smart logic)
+    summon2 = SummonManager.create_summon(
+        summoner=summoner,
+        summon_type="test2",
+        source="test_source",
+        max_summons=1
+    )
+    assert summon2 is None  # Should be blocked by smart logic
+
+    # Damage the first summon
+    summon1.hp = int(summon1.max_hp * 0.1)  # 10% health
+
+    # Try to create second summon with damaged first summon (should succeed and replace)
+    summon3 = SummonManager.create_summon(
+        summoner=summoner,
+        summon_type="test3",
+        source="test_source",
+        max_summons=1
+    )
+    assert summon3 is not None  # Should succeed because first summon is low health
+
+    # Should have replaced the old summon
+    active_summons = SummonManager.get_summons("test_summoner")
+    assert len(active_summons) == 1
+    assert active_summons[0].summon_type == "test3"
+
+
+@pytest.mark.asyncio
+async def test_force_create_bypasses_logic(monkeypatch):
+    """Test that force_create bypasses smart decision logic."""
+    monkeypatch.setattr(torch_checker, "is_torch_available", lambda: False)
+
+    SummonManager.cleanup()
+
+    summoner = Ally()
+    summoner.id = "test_summoner"
+    summoner._base_atk = 100
+    summoner._base_max_hp = 200
+    summoner._base_defense = 50
+
+    # Create first summon
+    summon1 = SummonManager.create_summon(
+        summoner=summoner,
+        summon_type="test1",
+        source="test_source",
+        max_summons=1
+    )
+    assert summon1 is not None
+    summon1.hp = summon1.max_hp  # Ensure healthy
+
+    # Force create second summon even with healthy first summon
+    summon2 = SummonManager.create_summon(
+        summoner=summoner,
+        summon_type="test2",
+        source="test_source",
+        max_summons=1,
+        force_create=True
+    )
+    assert summon2 is not None  # Should succeed due to force_create
+
+    # Should have replaced the old summon
+    active_summons = SummonManager.get_summons("test_summoner")
+    assert len(active_summons) == 1
+    assert active_summons[0].summon_type == "test2"
+
+
+@pytest.mark.asyncio
+async def test_health_threshold_customization(monkeypatch):
+    """Test that health threshold can be customized."""
+    monkeypatch.setattr(torch_checker, "is_torch_available", lambda: False)
+
+    SummonManager.cleanup()
+
+    summoner = Ally()
+    summoner.id = "test_summoner"
+    summoner._base_atk = 100
+    summoner._base_max_hp = 200
+    summoner._base_defense = 50
+
+    # Create summon with 40% health
+    summon = SummonManager.create_summon(
+        summoner=summoner,
+        summon_type="test",
+        source="test_source"
+    )
+    summon.hp = int(summon.max_hp * 0.4)  # 40% health
+
+    # With default threshold (25%), should NOT resummon
+    decision = SummonManager.should_resummon("test_summoner")
+    assert decision['should_resummon'] is False
+
+    # With higher threshold (50%), should resummon
+    decision = SummonManager.should_resummon("test_summoner", min_health_threshold=0.5)
+    assert decision['should_resummon'] is True
+    assert decision['viable_count'] == 0

--- a/frontend/src/lib/battle/FighterPortrait.svelte
+++ b/frontend/src/lib/battle/FighterPortrait.svelte
@@ -77,7 +77,7 @@
     style={`--el-color: ${elColor}`}
   >
     <img
-      src={getCharacterImage(fighter.id)}
+      src={getCharacterImage(fighter.summon_type || fighter.id)}
       alt=""
       class="portrait"
       style={`border-color: ${elColor}`}

--- a/frontend/src/lib/components/BattleView.svelte
+++ b/frontend/src/lib/components/BattleView.svelte
@@ -127,7 +127,9 @@
       if (snap && snap.party_summons) {
         const arr = Array.isArray(snap.party_summons)
           ? snap.party_summons
-          : Object.values(snap.party_summons);
+          : Object.entries(snap.party_summons).flatMap(([owner, list]) =>
+              (Array.isArray(list) ? list : [list]).map(s => ({ owner_id: owner, ...s })),
+            );
         for (const s of arr) {
           const owner = s?.owner_id;
           if (!owner) continue;
@@ -139,7 +141,9 @@
       if (snap && snap.foe_summons) {
         const arr = Array.isArray(snap.foe_summons)
           ? snap.foe_summons
-          : Object.values(snap.foe_summons);
+          : Object.entries(snap.foe_summons).flatMap(([owner, list]) =>
+              (Array.isArray(list) ? list : [list]).map(s => ({ owner_id: owner, ...s })),
+            );
         for (const s of arr) {
           const owner = s?.owner_id;
           if (!owner) continue;

--- a/frontend/src/lib/systems/assetLoader.js
+++ b/frontend/src/lib/systems/assetLoader.js
@@ -143,7 +143,8 @@ export function getCharacterImage(characterId, _isPlayer = false) {
   if (!characterId) return defaultFallback;
 
   // Resolve folder alias when id differs from asset folder
-  const key = CHARACTER_ASSET_ALIASES[characterId] || characterId;
+  let key = CHARACTER_ASSET_ALIASES[characterId] || characterId;
+  if (key.startsWith('jellyfish_')) key = 'jellyfish';
 
   // If this is the Mimic, always mirror the Player's chosen image for this session
   if (characterId === 'mimic') {

--- a/frontend/tests/assetloader.test.js
+++ b/frontend/tests/assetloader.test.js
@@ -4,7 +4,7 @@ import fs from 'fs';
 if (typeof import.meta.glob !== 'function') {
   test('asset loader unsupported', () => {});
 } else {
-  const { getCharacterImage, getElementColor, getElementIcon, getDotImage } = await import('../src/lib/assetLoader.js');
+  const { getCharacterImage, getElementColor, getElementIcon, getDotImage } = await import('../src/lib/systems/assetLoader.js');
 
   describe('asset loader', () => {
     test('returns fallback string for unknown character', () => {
@@ -21,6 +21,13 @@ if (typeof import.meta.glob !== 'function') {
         const filePath = new URL(url);
         expect(fs.existsSync(filePath)).toBe(true);
       }
+    });
+
+    test('aliases jellyfish summons to base art', () => {
+      const url = getCharacterImage('jellyfish_alpha');
+      const jelly = url.includes('jellyfish');
+      const fallback = url.includes('midoriai-logo');
+      expect(jelly || fallback).toBe(true);
     });
 
     test('provides damage type color and icon', () => {


### PR DESCRIPTION
## Summary
- let Becca's jellyfish automatically join the active party
- expose active party and foe summons in battle snapshots
- document summon fields in battle snapshot docs
- alias jellyfish summon IDs to shared art and resolve portraits via `summon_type`
- group party and foe summons by owner in snapshots and flatten them in Battle View

## Testing
- `ruff check backend tests --fix`
- `bun run lint:fix`
- `bun test frontend/tests/assetloader.test.js`
- `bun test frontend/tests/battleview.test.js` (fails: missing BattleView.svelte)
- `uv run pytest backend/tests/test_summons_system.py::test_becca_summon_added_to_party backend/tests/test_summons_system.py::test_collect_summons_grouped_by_owner -q`
- `./run-tests.sh` (fails: multiple missing modules and failing tests)


------
https://chatgpt.com/codex/tasks/task_b_68b7efe36a80832cbfa2c28cb1ff8fae