### PR TITLE
[FIX] flatten room action payloads

### DIFF
--- a/frontend/src/lib/systems/uiApi.js
+++ b/frontend/src/lib/systems/uiApi.js
@@ -131,13 +131,16 @@ export async function startRun(party, damageType = '', pressure = 0) {
 /**
  * Perform a room action.
  * @param {string} roomId - The room ID (typically "0" for current room)
- * @param {string} actionData - Action-specific data
+ * @param {object|string} actionData - Action-specific data
  */
-export async function roomAction(roomId = "0", actionData = "") {
-  return await sendAction('room_action', { 
-    room_id: roomId, 
-    action: actionData 
-  });
+export async function roomAction(roomId = '0', actionData = {}) {
+  const params = { room_id: roomId };
+  if (actionData && typeof actionData === 'object') {
+    Object.assign(params, actionData);
+  } else if (actionData) {
+    params.action = actionData;
+  }
+  return await sendAction('room_action', params);
 }
 
 /**

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -793,15 +793,15 @@
   }
   async function handleShopBuy(item) {
     if (!runId) return;
-    roomData = await roomAction("0", item);
+    roomData = await roomAction('0', { id: item.id, cost: item.cost });
   }
   async function handleShopReroll() {
     if (!runId) return;
-    roomData = await roomAction("0", {"action": "reroll"});
+    roomData = await roomAction('0', { action: 'reroll' });
   }
   async function handleShopLeave() {
     if (!runId) return;
-    await roomAction("0", {"action": "leave"});
+    await roomAction('0', { action: 'leave' });
     const res = await advanceRoom();
     if (res && typeof res.current_index === 'number') {
       currentIndex = res.current_index;

--- a/frontend/tests/api.test.js
+++ b/frontend/tests/api.test.js
@@ -51,6 +51,20 @@ describe('api calls', () => {
     expect(result).toEqual({ result: 'battle', party: [], foes: [] });
   });
 
+  test('roomAction buy reduces gold and removes item', async () => {
+    const fetchMock = mock(async (url, options) => {
+      const body = JSON.parse(options.body);
+      expect(body).toEqual({
+        action: 'room_action',
+        params: { room_id: '0', id: 'r1', cost: 10 }
+      });
+      return { ok: true, status: 200, json: async () => ({ result: 'shop', gold: 90, stock: [] }) };
+    });
+    global.fetch = fetchMock;
+    const result = await roomAction('0', { id: 'r1', cost: 10 });
+    expect(result).toEqual({ result: 'shop', gold: 90, stock: [] });
+  });
+
   test('roomAction throws on HTTP error', async () => {
     global.fetch = createFetch({}, false, 500);
     await expect(roomAction('0', 'attack')).rejects.toThrow('HTTP error 500');


### PR DESCRIPTION
## Summary
- flatten `roomAction` payload so shop actions send top-level fields
- ensure shop handlers send expected params for buy, reroll, and leave
- add API test covering shop purchase behavior

## Testing
- `bun run lint:fix`
- `bun test tests/api.test.js` *(fails: Cannot find module '../src/lib/api.js')*
- `UV_VENV_CLEAR=1 ./run-tests.sh` *(fails: multiple backend tests)*

------
https://chatgpt.com/codex/tasks/task_b_68b91b17b010832c9c5af963dfcd0c78