### PR TITLE
[FIX] support fractional level gains and passive kwargs

### DIFF
--- a/backend/autofighter/passives.py
+++ b/backend/autofighter/passives.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
 from collections import Counter
+import logging
 from pathlib import Path
 from typing import Any
 from typing import Optional
 
 from plugins import PluginLoader
+
+log = logging.getLogger(__name__)
 
 PASSIVE_LOADER: PluginLoader | None = None
 PASSIVE_REGISTRY: dict[str, type] | None = None
@@ -185,7 +188,15 @@ class PassiveRegistry:
             # Regular passive application
             stacks = min(count, getattr(cls, "max_stacks", count))
             for _ in range(stacks):
-                await passive_instance.apply(target, **kwargs)
+                try:
+                    await passive_instance.apply(target, **kwargs)
+                except TypeError:
+                    try:
+                        await passive_instance.apply(target)
+                    except TypeError:
+                        log.warning(
+                            "Passive %s incompatible with level_up kwargs", pid
+                        )
 
     def describe(self, target) -> list[dict[str, Any]]:
         """Return structured information for a target's passives."""

--- a/backend/autofighter/stats.py
+++ b/backend/autofighter/stats.py
@@ -119,8 +119,8 @@ class Stats:
     # Effects system
     _active_effects: list[StatEffect] = field(default_factory=list, init=False)
 
-    level_up_gains: dict[str, int] = field(
-        default_factory=lambda: {"max_hp": 10, "atk": 5, "defense": 3}
+    level_up_gains: dict[str, float] = field(
+        default_factory=lambda: {"max_hp": 10.0, "atk": 5.0, "defense": 3.0}
     )
 
     def __post_init__(self):
@@ -225,7 +225,7 @@ class Stats:
 
     def _calculate_stat_modifier(self, stat_name: str) -> Union[int, float]:
         """Calculate the total modifier for a stat from all active effects."""
-        total = 0
+        total: float = 0.0
         for effect in self._active_effects:
             if stat_name in effect.stat_modifiers:
                 total += effect.stat_modifiers[stat_name]
@@ -329,7 +329,7 @@ class Stats:
             current_base = self.get_base_stat(stat_name)
             if isinstance(current_base, (int, float)) and current_base > 0:
                 new_val = current_base * (1 + inc)
-                self.set_base_stat(stat_name, type(current_base)(new_val))
+                self.set_base_stat(stat_name, new_val)
 
         # Apply fixed gains from level_up_gains to base stats
         for stat, base in self.level_up_gains.items():

--- a/backend/plugins/passives/player_level_up_bonus.py
+++ b/backend/plugins/passives/player_level_up_bonus.py
@@ -16,25 +16,29 @@ class PlayerLevelUpBonus:
     trigger = "level_up"  # Triggers when Player levels up
     max_stacks = 1  # Only one instance per character
 
-    async def apply(self, target: "Stats") -> None:
-        """Apply enhanced level-up gains for Player (1.35x multiplier)."""
-        # Apply 35% bonus to all level-up gains for all base stats
+    async def apply(self, target: "Stats", new_level: int) -> None:
+        """Apply enhanced level-up gains for Player (1.35x multiplier).
+
+        Args:
+            target: Stats object receiving the bonus.
+            new_level: The player's new level after leveling up.
+        """
         level_up_bonus = StatEffect(
             name=f"{self.id}_level_bonus",
             stat_modifiers={
-                "max_hp": int(target.level_up_gains.get("max_hp", 10) * 0.35),
-                "atk": int(target.level_up_gains.get("atk", 5) * 0.35),
-                "defense": int(target.level_up_gains.get("defense", 3) * 0.35),
+                "max_hp": target.level_up_gains.get("max_hp", 10.0) * 0.35,
+                "atk": target.level_up_gains.get("atk", 5.0) * 0.35,
+                "defense": target.level_up_gains.get("defense", 3.0) * 0.35,
                 "crit_rate": target.level_up_gains.get("crit_rate", 0.001) * 0.35,
                 "crit_damage": target.level_up_gains.get("crit_damage", 0.05) * 0.35,
                 "effect_hit_rate": target.level_up_gains.get("effect_hit_rate", 0.001) * 0.35,
                 "mitigation": target.level_up_gains.get("mitigation", 0.01) * 0.35,
-                "regain": int(target.level_up_gains.get("regain", 2) * 0.35),
+                "regain": target.level_up_gains.get("regain", 2.0) * 0.35,
                 "dodge_odds": target.level_up_gains.get("dodge_odds", 0.001) * 0.35,
                 "effect_resistance": target.level_up_gains.get("effect_resistance", 0.001) * 0.35,
                 "vitality": target.level_up_gains.get("vitality", 0.01) * 0.35,
             },
-            duration=-1,  # Permanent level bonus
+            duration=-1,
             source=self.id,
         )
         target.add_effect(level_up_bonus)

--- a/backend/tests/test_stats_passives.py
+++ b/backend/tests/test_stats_passives.py
@@ -1,0 +1,74 @@
+import random
+
+import pytest
+
+from autofighter.passives import PassiveRegistry
+from autofighter.stats import StatEffect
+from autofighter.stats import Stats
+
+
+def test_fractional_level_up_gains(monkeypatch):
+    monkeypatch.setattr(random, "uniform", lambda a, b: 0)
+    stats = Stats(level_up_gains={"atk": 0.5})
+    stats.level += 1
+    stats._on_level_up()
+    assert stats.get_base_stat("atk") == pytest.approx(200 + 0.5 * stats.level)
+
+
+@pytest.mark.asyncio
+async def test_player_level_up_bonus_no_type_error(monkeypatch):
+    monkeypatch.setattr(random, "uniform", lambda a, b: 0)
+    stats = Stats()
+    stats.passives.append("player_level_up_bonus")
+    stats.level += 1
+    stats._on_level_up()
+    registry = PassiveRegistry()
+    await registry.trigger_level_up(stats, new_level=stats.level)
+    assert any(
+        e.name == "player_level_up_bonus_level_bonus" for e in stats.get_active_effects()
+    )
+
+
+class NewPassive:
+    plugin_type = "passive"
+    id = "new_dummy"
+    name = "New Dummy"
+    trigger = "level_up"
+
+    async def apply(self, target: Stats, new_level: int) -> None:
+        effect = StatEffect(
+            name="new_dummy_effect",
+            stat_modifiers={"atk": 1.0},
+            source=self.id,
+        )
+        target.add_effect(effect)
+
+
+class LegacyPassive:
+    plugin_type = "passive"
+    id = "legacy_dummy"
+    name = "Legacy Dummy"
+    trigger = "level_up"
+
+    async def apply(self, target: Stats) -> None:
+        effect = StatEffect(
+            name="legacy_dummy_effect",
+            stat_modifiers={"atk": 1.0},
+            source=self.id,
+        )
+        target.add_effect(effect)
+
+
+@pytest.mark.asyncio
+async def test_trigger_level_up_handles_new_and_legacy_passives():
+    stats = Stats()
+    stats.passives = ["new_dummy", "legacy_dummy"]
+    registry = PassiveRegistry()
+    registry._registry = {
+        "new_dummy": NewPassive,
+        "legacy_dummy": LegacyPassive,
+    }
+    await registry.trigger_level_up(stats, new_level=2)
+    effect_names = [e.name for e in stats.get_active_effects()]
+    assert "new_dummy_effect" in effect_names
+    assert "legacy_dummy_effect" in effect_names


### PR DESCRIPTION
## Summary
- allow fractional stat gains and preserve them during level-ups
- accept new_level in PlayerLevelUpBonus and tolerate kwargs for legacy passives
- add regression tests for level-up bonuses and passive compatibility

## Testing
- `ruff check backend tests --fix`
- `uv run pytest tests/test_stats_passives.py`
- `./run-tests.sh` *(fails: missing frontend modules, backend test timeouts)*

------
https://chatgpt.com/codex/tasks/task_b_68b91d8b9b9c832c9935e4a8de07e735