### PR TITLE
[FEAT] resolve backend URL server-side

### DIFF
--- a/frontend/.codex/implementation/backend-discovery.md
+++ b/frontend/.codex/implementation/backend-discovery.md
@@ -1,0 +1,15 @@
+# Backend discovery
+
+The development server now resolves the backend URL when it starts. A Vite
+plugin probes known container hostnames (`backend`, `backend-llm-*`) and
+`localhost:59002`. The first reachable target becomes the API base and is
+exposed via the `VITE_API_BASE` environment variable and an `/api-base` endpoint
+served by the dev server.
+
+Browser code no longer scans the network. `getApiBase()` reads the injected
+`VITE_API_BASE` value or, in the browser, fetches the `/api-base` endpoint on the
+development server. If neither path works, it falls back to
+`http://localhost:59002`.
+
+`BackendNotReady.svelte` now simply displays the unresolved API base and offers a
+manual **Retry** button instead of polling the backend.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -13,6 +13,10 @@ bun dev
 The development server runs at `http://localhost:59001` and displays a
 high‑contrast icon grid powered by `lucide-svelte`.
 
+At startup the dev server probes common backend hosts and exposes the first
+reachable one as `VITE_API_BASE` and through an `/api-base` endpoint. The
+browser reads this value instead of scanning the network directly.
+
 - Party: Opens a responsive party picker overlay that fetches available
   characters and lets you add/remove allies with one click. Selected members
   are now clearly indicated by an element‑tinted ambient sweep behind their

--- a/frontend/src/lib/components/BackendNotReady.svelte
+++ b/frontend/src/lib/components/BackendNotReady.svelte
@@ -1,16 +1,11 @@
 <script>
   import PopupWindow from './PopupWindow.svelte';
-  import { createEventDispatcher, onMount, onDestroy } from 'svelte';
+  import { createEventDispatcher } from 'svelte';
 
   export let apiBase = '';
   export let message = 'Backend is not ready yet.';
 
   const dispatch = createEventDispatcher();
-
-  let attempts = 0;
-  let retryIntervalMs = 3000;
-  let timerId;
-  let checking = false;
 
   function retry() {
     window.location.reload();
@@ -19,46 +14,17 @@
   function close() {
     dispatch('close');
   }
-
-  async function checkBackend() {
-    if (checking) return;
-    checking = true;
-    attempts += 1;
-    try {
-      const res = await fetch(`${apiBase}/`, { cache: 'no-store' });
-      if (res.ok) {
-        const data = await res.json().catch(() => ({}));
-        if (data && data.flavor) {
-          // Backend is ready; reload to re-run initialization flow
-          window.location.reload();
-          return;
-        }
-      }
-    } catch {}
-    checking = false;
-  }
-
-  onMount(() => {
-    // Kick off an immediate check, then poll periodically.
-    checkBackend();
-    timerId = setInterval(checkBackend, retryIntervalMs);
-  });
-
-  onDestroy(() => {
-    if (timerId) clearInterval(timerId);
-  });
 </script>
 
 <PopupWindow title="Backend Not Ready" on:close={close}>
   <div style="padding: 0.5rem 0.25rem; line-height: 1.4;">
-    <p>The Web UI cannot reach the backend yet.</p>
+    <p>The Web UI cannot reach the backend.</p>
     <p><strong>API:</strong> {apiBase}</p>
     <p style="opacity: 0.85;">{message}</p>
     <p style="margin-top: 0.5rem; display: flex; align-items: center; gap: 0.5rem;">
       <span class="spinner" aria-hidden="true"></span>
-      <span>Please start the backend service. Auto retrying...</span>
+      <span>Start the backend service then choose Retry.</span>
     </p>
-    <p style="opacity: 0.7; font-size: 0.85rem; margin: 0.25rem 0 0;">Attempts: {attempts}</p>
     <div class="stained-glass-row" style="justify-content: flex-end; margin-top: 0.75rem;">
       <button class="icon-btn" on:click={retry}>Retry</button>
       <button class="icon-btn" on:click={close}>Close</button>

--- a/frontend/src/lib/systems/backendDiscovery.js
+++ b/frontend/src/lib/systems/backendDiscovery.js
@@ -1,138 +1,36 @@
-// Backend discovery system for Docker environments
-// Automatically detects which backend service is available and sets the API base URL
-
 import { browser } from '$app/environment';
 
-let discoveredApiBase = null;
-let discoveryPromise = null;
+let cached = null;
 
-// List of possible backend service names in order of preference
-const BACKEND_SERVICES = [
-  'backend',           // Default backend
-  'backend-llm-cuda',  // CUDA-enabled LLM backend
-  'backend-llm-amd',   // AMD-enabled LLM backend  
-  'backend-llm-cpu'    // CPU-only LLM backend
-];
-
-// Fallback for local development
-const DEFAULT_BACKEND = (typeof window !== 'undefined' && browser)
-  ? `${location.protocol}//${location.hostname}:59002`
-  : 'http://localhost:59002';
-
-/**
- * Checks if a backend service is available by making a health check request
- * @param {string} serviceUrl - The base URL to test
- * @returns {Promise<{available: boolean, flavor?: string}>}
- */
-async function checkBackendAvailability(serviceUrl) {
-  try {
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), 3000); // 3 second timeout
-    
-    const response = await fetch(`${serviceUrl}/`, {
-      method: 'GET',
-      headers: { 'Accept': 'application/json' },
-      signal: controller.signal,
-      cache: 'no-store'
-    });
-    
-    clearTimeout(timeoutId);
-    
-    if (response.ok) {
-      const data = await response.json();
-      return { 
-        available: true, 
-        flavor: data.flavor || 'unknown'
-      };
-    }
-    
-    return { available: false };
-  } catch {
-    // Network error, timeout, or other failure
-    return { available: false };
-  }
-}
-
-/**
- * Discovers the available backend service by trying each possible service name
- * @returns {Promise<string>} The discovered API base URL
- */
-async function discoverBackend() {
-  // If we're not in a browser environment, use the env var or default
-  if (!browser) {
-    return import.meta.env.VITE_API_BASE || DEFAULT_BACKEND;
-  }
-  
-  // If VITE_API_BASE is explicitly set, use it directly (for local development)
-  if (import.meta.env.VITE_API_BASE) {
-    return import.meta.env.VITE_API_BASE;
-  }
-  
-  console.log('🔍 Discovering available backend service...');
-  
-  // Try each backend service in order
-  for (const serviceName of BACKEND_SERVICES) {
-    const serviceUrl = `http://${serviceName}:59002`;
-    console.log(`🔍 Checking ${serviceName}...`);
-    
-    const result = await checkBackendAvailability(serviceUrl);
-    
-    if (result.available) {
-      console.log(`✅ Found ${serviceName} (flavor: ${result.flavor})`);
-      return serviceUrl;
-    }
-  }
-  
-  // If no Docker services are available, fall back to localhost
-  console.log('🔍 No Docker backend services found, checking localhost...');
-  const localhostResult = await checkBackendAvailability(DEFAULT_BACKEND);
-  
-  if (localhostResult.available) {
-    console.log(`✅ Using localhost backend (flavor: ${localhostResult.flavor})`);
-    return DEFAULT_BACKEND;
-  }
-  
-  // Nothing is available - return default and let the app handle the error
-  console.warn('⚠️ No backend services are available');
-  return DEFAULT_BACKEND;
-}
-
-/**
- * Gets the API base URL, performing discovery if needed
- * @returns {Promise<string>} The API base URL to use
- */
 export async function getApiBase() {
-  // Return cached result if we already discovered it
-  if (discoveredApiBase) {
-    return discoveredApiBase;
+  if (cached) {
+    return cached;
   }
-  
-  // If discovery is already in progress, wait for it
-  if (discoveryPromise) {
-    return discoveryPromise;
+
+  const envBase = (import.meta.env && import.meta.env.VITE_API_BASE) || process.env.VITE_API_BASE;
+  if (envBase) {
+    cached = envBase;
+    return cached;
   }
-  
-  // Start discovery process
-  discoveryPromise = discoverBackend().then(apiBase => {
-    discoveredApiBase = apiBase;
-    return apiBase;
-  });
-  
-  return discoveryPromise;
+
+  if (browser) {
+    try {
+      const res = await fetch('/api-base', { cache: 'no-store' });
+      cached = await res.text();
+      return cached;
+    } catch {
+      // fall through to default
+    }
+  }
+
+  cached = 'http://localhost:59002';
+  return cached;
 }
 
-/**
- * Resets the discovery cache (useful for testing or reconnection scenarios)
- */
 export function resetDiscovery() {
-  discoveredApiBase = null;
-  discoveryPromise = null;
+  cached = null;
 }
 
-/**
- * Gets the currently discovered API base without triggering discovery
- * @returns {string|null} The cached API base or null if not yet discovered
- */
 export function getCachedApiBase() {
-  return discoveredApiBase;
+  return cached;
 }

--- a/frontend/tests/api.test.js
+++ b/frontend/tests/api.test.js
@@ -21,6 +21,8 @@ import {
   chooseRelic
 } from '../src/lib/uiApi.js';
 
+process.env.VITE_API_BASE = 'http://backend.test';
+
 // Helper to mock fetch
 function createFetch(response, ok = true, status = 200) {
   return mock(async () => ({ ok, status, json: async () => response }));

--- a/frontend/tests/battlepolling.test.js
+++ b/frontend/tests/battlepolling.test.js
@@ -2,6 +2,8 @@ import { readFileSync } from 'fs';
 import { join } from 'path';
 import { describe, test, expect, mock } from 'bun:test';
 
+process.env.VITE_API_BASE = 'http://backend.test';
+
 describe('battle polling', () => {
   test('stops on error snapshots', () => {
     const content = readFileSync(

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -2,6 +2,51 @@ import { sveltekit } from '@sveltejs/kit/vite';
 import { defineConfig } from 'vite';
 import { viteStaticCopy } from 'vite-plugin-static-copy';
 
+function backendDiscoveryPlugin() {
+  const services = [
+    'http://backend:59002',
+    'http://backend-llm-cuda:59002',
+    'http://backend-llm-amd:59002',
+    'http://backend-llm-cpu:59002',
+    'http://localhost:59002'
+  ];
+
+  let resolved = process.env.VITE_API_BASE;
+
+  async function probe(url) {
+    try {
+      const res = await fetch(`${url}/`);
+      return res.ok;
+    } catch {
+      return false;
+    }
+  }
+
+  return {
+    name: 'backend-discovery',
+    async configureServer(server) {
+      if (!resolved) {
+        for (const url of services) {
+          // eslint-disable-next-line no-await-in-loop
+          if (await probe(url)) {
+            resolved = url;
+            break;
+          }
+        }
+        if (!resolved) {
+          resolved = 'http://localhost:59002';
+        }
+        process.env.VITE_API_BASE = resolved;
+        console.log(`[backend] using ${resolved}`);
+      }
+
+      server.middlewares.use('/api-base', (_req, res) => {
+        res.end(resolved);
+      });
+    }
+  };
+}
+
 export default defineConfig({
         plugins: [
                 sveltekit(),
@@ -12,7 +57,8 @@ export default defineConfig({
                                         dest: ''
                                 }
                         ]
-                })
+                }),
+                backendDiscoveryPlugin()
         ],
         assetsInclude: ['**/*.efkefc']
 });


### PR DESCRIPTION
## Summary
- probe backend services at dev-server startup and expose `VITE_API_BASE`
- drop client-side network scanning in backend discovery and rely on server value
- simplify BackendNotReady component and adjust tests for server-provided API base

## Testing
- `bun run lint:fix`
- `./run-tests.sh` *(fails: missing modules, timeouts)*

------
https://chatgpt.com/codex/tasks/task_b_68b9232caa68832ca46d3a573c0cd119