### PR TITLE
[bugfix] prevent summons from appearing as party members

### DIFF
--- a/.codex/implementation/summons-system.md
+++ b/.codex/implementation/summons-system.md
@@ -18,6 +18,8 @@ The Midori AI AutoFighter now has a unified summons system that provides a consi
 - Event-driven cleanup (battle end, summoner defeat, turn expiration)
 - Configurable summon limits per summoner
 - Integration with party system for battle participation
+  (summons fight alongside the party but are excluded from party snapshots
+  and reported separately under `party_summons` to avoid duplicate listings)
 - Thread-safe class-level tracking
 
 ### Key Features

--- a/backend/autofighter/rooms/battle.py
+++ b/backend/autofighter/rooms/battle.py
@@ -22,6 +22,7 @@ from autofighter.effects import create_stat_buff
 from autofighter.mapgen import MapNode
 from autofighter.relics import apply_relics
 from autofighter.relics import relic_choices
+from autofighter.summons import Summon
 from autofighter.summons import SummonManager
 from plugins.damage_types import ALL_DAMAGE_TYPES
 
@@ -276,7 +277,11 @@ class BattleRoom(Room):
             await progress(
                 {
                     "result": "battle",
-                    "party": [_serialize(m) for m in combat_party.members],
+                    "party": [
+                        _serialize(m)
+                        for m in combat_party.members
+                        if not isinstance(m, Summon)
+                    ],
                     "foes": [_serialize(f) for f in foes],
                     "party_summons": _collect_summons(combat_party.members),
                     "foe_summons": _collect_summons(foes),
@@ -414,7 +419,11 @@ class BattleRoom(Room):
                             await progress(
                                 {
                                     "result": "battle",
-                                    "party": [_serialize(m) for m in combat_party.members],
+                                    "party": [
+                                        _serialize(m)
+                                        for m in combat_party.members
+                                        if not isinstance(m, Summon)
+                                    ],
                                     "foes": [_serialize(f) for f in foes],
                                     "party_summons": _collect_summons(combat_party.members),
                                     "foe_summons": _collect_summons(foes),
@@ -521,7 +530,11 @@ class BattleRoom(Room):
                         await progress(
                             {
                                 "result": "battle",
-                                "party": [_serialize(m) for m in combat_party.members],
+                                "party": [
+                                    _serialize(m)
+                                    for m in combat_party.members
+                                    if not isinstance(m, Summon)
+                                ],
                                 "foes": [_serialize(f) for f in foes],
                                 "party_summons": _collect_summons(combat_party.members),
                                 "foe_summons": _collect_summons(foes),
@@ -641,7 +654,11 @@ class BattleRoom(Room):
                 await progress(
                     {
                         "result": "battle",
-                        "party": [_serialize(m) for m in combat_party.members],
+                        "party": [
+                            _serialize(m)
+                            for m in combat_party.members
+                            if not isinstance(m, Summon)
+                        ],
                         "foes": [_serialize(f) for f in foes],
                         "party_summons": _collect_summons(combat_party.members),
                         "foe_summons": _collect_summons(foes),


### PR DESCRIPTION
## Summary
- ensure battle snapshots omit summoned units from the party list
- document how summons are reported separately from party members

## Testing
- `uv tool run ruff check backend --fix`
- `./run-tests.sh` *(fails: no running event loop; missing async plugin; ModuleNotFoundError: llms; missing battle_logging, etc.)*


------
https://chatgpt.com/codex/tasks/task_b_68b924d2acd4832cb80b22e3072d8889