### PR TITLE
[FIX] prevent duplicate battle logs

### DIFF
--- a/backend/.codex/implementation/battle-logging.md
+++ b/backend/.codex/implementation/battle-logging.md
@@ -42,7 +42,7 @@ Each battle summary includes:
 The system is automatically integrated into the battle flow:
 
 1. **Run starts**: `start_run_logging(run_id)` is called when a new run begins
-2. **Battle starts**: `start_battle_logging()` is called when a battle begins
+2. **Battle starts**: `start_battle_logging()` is called once after the party and foes are determined, before any battle events
 3. **Battle ends**: `end_battle_logging(result)` is called when a battle ends
 4. **Run ends**: `end_run_logging()` is called when a run ends
 
@@ -148,6 +148,7 @@ Total Events: 45
 - Does not interfere with existing logging to `backend.log`
 - Logs are organized by run ID and battle index for easy navigation
 - Each battle gets its own logger instance to prevent interference
+- Call `start_battle_logging()` only once per battle after participants are set; additional calls finalize the previous battle as "interrupted"
 
 ## Battle Review API
 

--- a/backend/autofighter/rooms/battle.py
+++ b/backend/autofighter/rooms/battle.py
@@ -196,7 +196,7 @@ class BattleRoom(Room):
             member.effect_manager = mgr
             party_effects.append(mgr)
 
-        # Start battle logging BEFORE emitting any events so participants are captured
+        # Start battle logging once before emitting any events so participants are captured
         battle_logger = start_battle_logging()
         try:
             if battle_logger is not None:
@@ -213,9 +213,6 @@ class BattleRoom(Room):
         for f in foes:
             await BUS.emit_async("battle_start", f)
             await registry.trigger("battle_start", f, party=combat_party.members, foes=foes)
-
-        # Start battle logging
-        battle_logger = start_battle_logging()
 
         log.info(
             "Battle start: %s vs %s",

--- a/backend/tests/test_battle_logging_single_start.py
+++ b/backend/tests/test_battle_logging_single_start.py
@@ -1,0 +1,50 @@
+import json
+
+import battle_logging
+from battle_logging import RunLogger
+from battle_logging import end_run_logging
+import pytest
+
+from autofighter.mapgen import MapNode
+from autofighter.party import Party
+from autofighter.rooms.battle import BattleRoom
+from autofighter.stats import Stats
+
+
+@pytest.mark.asyncio
+async def test_battle_logging_single_start(tmp_path):
+    end_run_logging()
+    battle_logging._current_run_logger = RunLogger("test_run", base_logs_path=tmp_path)
+    try:
+        node = MapNode(room_id=0, room_type="battle-normal", floor=1, index=1, loop=1, pressure=0)
+        room = BattleRoom(node)
+        player = Stats()
+        player._base_max_hp = 10
+        player.hp = 10
+        player._base_atk = 1000
+        player._base_defense = 0
+        player.id = "p1"
+        foe = Stats()
+        foe._base_max_hp = 1
+        foe.hp = 1
+        foe._base_atk = 0
+        foe._base_defense = 0
+        foe.id = "f1"
+        party = Party(members=[player])
+
+        await room.resolve(party, {}, foe=foe)
+
+        run_logger = battle_logging._current_run_logger
+        assert run_logger.battle_count == 1
+
+        battle_dir = tmp_path / "runs" / "test_run" / "battles"
+        folders = list(battle_dir.iterdir())
+        assert len(folders) == 1
+
+        summary_file = folders[0] / "summary" / "battle_summary.json"
+        with open(summary_file) as f:
+            summary = json.load(f)
+        assert summary["battle_id"].endswith("_1")
+        assert summary["result"] != "interrupted"
+    finally:
+        end_run_logging()


### PR DESCRIPTION
## Summary
- ensure battle logging is started only once per battle
- document single-call requirement for battle logging
- add regression test preventing extra "interrupted" logs

## Testing
- `uv run ruff check . --fix` *(fails: trailing whitespace in .codex/prototypes)*
- `uv run ruff check backend/autofighter/rooms/battle.py backend/tests/test_battle_logging_single_start.py --fix`
- `PYTHONPATH=backend uv run pytest backend/tests/test_battle_logging.py backend/tests/test_battle_logging_single_start.py`

------
https://chatgpt.com/codex/tasks/task_b_68b92730c270832cb2cbf3d2d6b47364