### PR TITLE
[FIX] Annotate status handler with Response

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -24,6 +24,7 @@ from game import save_party  # noqa: F401
 from llms.torch_checker import is_torch_available
 from logging_config import configure_logging
 from quart import Quart
+from quart import Response
 from quart import jsonify
 from quart import request
 from routes.assets import bp as assets_bp
@@ -56,7 +57,7 @@ BACKEND_FLAVOR = os.getenv("UV_EXTRA", "default")
 
 
 @app.get("/")
-async def status() -> tuple[str, int, dict[str, str]]:
+async def status() -> Response:
     return jsonify({"status": "ok", "flavor": BACKEND_FLAVOR})
 
 


### PR DESCRIPTION
## Summary
- annotate backend status endpoint with quart Response for accurate typing

## Testing
- [ ] Backend tests (fail: missing modules and async plugin errors)
- [ ] Frontend tests
- [x] Linting
- [ ] Doc sync updates (README and `.codex/implementation` docs; link tasks below)

## Checklist
- [ ] Linked or updated relevant `.codex/tasks` entries
- [ ] Updated player roster and foe docs if adding or modifying fighters or enemies

------
https://chatgpt.com/codex/tasks/task_b_68ba8e5ee368832c8d610e9e19abf066