### PR TITLE
Fix run advancement skipping rewards

### DIFF
--- a/backend/.codex/implementation/reward-progression.md
+++ b/backend/.codex/implementation/reward-progression.md
@@ -1,0 +1,11 @@
+# Reward progression and room advancement
+
+The map state blocks advancing to the next room while any post-battle rewards remain unresolved. Three boolean flags gate this progression:
+
+- `awaiting_card` – set when a card reward is offered. If the battle yields no card, this flag stays `False` and does not block advancement.
+- `awaiting_relic` – set when a relic reward is pending. Runs without relic drops leave this flag `False`.
+- `awaiting_loot` – reserved for manual loot flows. The backend currently auto-collects gold and similar drops, so this flag is usually `False`.
+
+`advance_room` refuses to progress while any of these flags are `True`. The UI action handler returns an HTTP 400 error when a client attempts to advance with pending rewards, and the `run_service.advance_room` function raises a `ValueError` so direct calls cannot bypass the restriction.
+
+Reward sequences may also use a `reward_progression` structure to handle multiple reward steps. Once all steps are completed and the `awaiting_*` flags are cleared, room advancement is allowed.

--- a/backend/README.md
+++ b/backend/README.md
@@ -62,6 +62,11 @@ names. Run state is stored through the `SaveManager` in `backend/save.db` by
 default; `compose.yaml` bind-mounts the `backend/` directory so the database is
 persisted on the host.
 
+Room advancement is blocked until all post-battle rewards are resolved
+(`awaiting_card`, `awaiting_relic`, and `awaiting_loot`, which is rarely set
+because loot auto-collects). See `.codex/implementation/reward-progression.md`
+for details.
+
 Player and foe base classes assign a random damage type when none is
 specified, and battles respect these preset elements without rolling new ones.
 

--- a/backend/routes/ui.py
+++ b/backend/routes/ui.py
@@ -242,8 +242,18 @@ async def handle_ui_action() -> tuple[str, int, dict[str, Any]]:
             if not run_id:
                 return jsonify({"error": "No active run"}), 400
 
-            # Check if we're advancing from any reward mode
+            # Load current map state to ensure rewards are resolved
             state, rooms = await asyncio.to_thread(load_map, run_id)
+            if (
+                state.get("awaiting_card")
+                or state.get("awaiting_relic")
+                or state.get("awaiting_loot")
+            ):
+                return (
+                    jsonify({"error": "Cannot advance room while rewards are pending"}),
+                    400,
+                )
+
             progression = state.get("reward_progression")
 
             if progression and progression.get("current_step"):

--- a/backend/services/run_service.py
+++ b/backend/services/run_service.py
@@ -205,6 +205,13 @@ async def advance_room(run_id: str) -> dict[str, object]:
     if not rooms:
         raise ValueError("run not found")
 
+    if (
+        state.get("awaiting_card")
+        or state.get("awaiting_relic")
+        or state.get("awaiting_loot")
+    ):
+        raise ValueError("pending rewards must be collected before advancing")
+
     # Reset live battle state when advancing
     battle_snapshots.pop(run_id, None)
     task = battle_tasks.pop(run_id, None)

--- a/backend/tests/test_reward_gate.py
+++ b/backend/tests/test_reward_gate.py
@@ -1,0 +1,72 @@
+import asyncio
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture()
+def app_with_db(tmp_path, monkeypatch):
+    db_path = tmp_path / "save.db"
+    monkeypatch.setenv("AF_DB_PATH", str(db_path))
+    monkeypatch.setenv("AF_DB_KEY", "testkey")
+    monkeypatch.syspath_prepend(Path(__file__).resolve().parents[1])
+    spec = importlib.util.spec_from_file_location(
+        "app", Path(__file__).resolve().parents[1] / "app.py",
+    )
+    app_module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(app_module)
+    app_module.app.testing = True
+    return app_module.app
+
+
+@pytest.mark.asyncio
+async def test_advance_room_requires_reward_selection(app_with_db):
+    from game import load_map
+    from game import save_map
+
+    app = app_with_db
+    client = app.test_client()
+
+    start_resp = await client.post("/run/start", json={"party": ["player"]})
+    run_id = (await start_resp.get_json())["run_id"]
+
+    # Simulate a battle that grants both card and relic rewards
+    state, rooms = await asyncio.to_thread(load_map, run_id)
+    state.update(
+        {
+            "awaiting_card": True,
+            "awaiting_relic": True,
+            "awaiting_loot": False,
+            "awaiting_next": False,
+            "reward_progression": {
+                "available": ["card", "relic"],
+                "completed": [],
+                "current_step": "card",
+            },
+        }
+    )
+    await asyncio.to_thread(save_map, run_id, state)
+
+    # Cannot advance while rewards are pending
+    resp = await client.post("/ui/action", json={"action": "advance_room"})
+    assert resp.status_code == 400
+
+    # Selecting card still leaves relic to claim
+    await client.post(
+        "/ui/action",
+        json={"action": "choose_card", "params": {"card_id": "micro_blade"}},
+    )
+    resp = await client.post("/ui/action", json={"action": "advance_room"})
+    assert resp.status_code == 400
+
+    # After choosing relic, advancing succeeds
+    await client.post(
+        "/ui/action",
+        json={"action": "choose_relic", "params": {"relic_id": "threadbare_cloak"}},
+    )
+    resp = await client.post("/ui/action", json={"action": "advance_room"})
+    data = await resp.get_json()
+    assert resp.status_code == 200
+    assert data.get("next_room") is not None

--- a/frontend/.codex/implementation/run-helpers.md
+++ b/frontend/.codex/implementation/run-helpers.md
@@ -6,6 +6,9 @@
   summaries/events, catalog lookups, and selecting rewards.
   `handleFetch` normalizes backend errors and reports them via the overlay
   system.
+  `advanceRoom` first loads the current run state and refuses to send the
+  action while any `awaiting_*` reward flags are true, preventing accidental
+  progression past unclaimed rewards.
 - The legacy `runApi.js` module has been removed; all callers should use
   the `uiApi` helpers.
 - `src/lib/MainMenu.svelte`: renders the stained glass side menu from a list of items.

--- a/frontend/src/lib/systems/uiApi.js
+++ b/frontend/src/lib/systems/uiApi.js
@@ -147,6 +147,16 @@ export async function roomAction(roomId = '0', actionData = {}) {
  * Advance to the next room.
  */
 export async function advanceRoom() {
+  const state = await getUIState();
+  const gs = state?.game_state || {};
+  if (gs.awaiting_card || gs.awaiting_relic || gs.awaiting_loot) {
+    const message = 'Cannot advance room until all rewards are collected.';
+    openOverlay('error', { message, traceback: '' });
+    const err = new Error(message);
+    err.status = 400;
+    err.overlayShown = true;
+    throw err;
+  }
   return await sendAction('advance_room');
 }
 

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -801,7 +801,10 @@
   }
   async function handleShopLeave() {
     if (!runId) return;
-    await roomAction('0', { action: 'leave' });
+    roomData = await roomAction('0', { action: 'leave' });
+    if (roomData?.awaiting_card || roomData?.awaiting_relic || roomData?.awaiting_loot) {
+      return;
+    }
     const res = await advanceRoom();
     if (res && typeof res.current_index === 'number') {
       currentIndex = res.current_index;
@@ -834,7 +837,10 @@
   }
   async function handleRestLeave() {
     if (!runId) return;
-    await roomAction("0", {"action": "leave"});
+    roomData = await roomAction("0", {"action": "leave"});
+    if (roomData?.awaiting_card || roomData?.awaiting_relic || roomData?.awaiting_loot) {
+      return;
+    }
     const res = await advanceRoom();
     if (res && typeof res.current_index === 'number') {
       currentIndex = res.current_index;
@@ -860,8 +866,13 @@
     haltSync = false;
     if (typeof window !== 'undefined') window.afHaltSync = false;
     // If rewards are still present, don't attempt to advance.
-    // Only block if there are still selectable choices (cards/relics).
-    if ((roomData?.card_choices?.length || 0) > 0 || (roomData?.relic_choices?.length || 0) > 0) {
+    const awaitingRewards =
+      (roomData?.card_choices?.length || 0) > 0 ||
+      (roomData?.relic_choices?.length || 0) > 0 ||
+      roomData?.awaiting_card ||
+      roomData?.awaiting_relic ||
+      roomData?.awaiting_loot;
+    if (awaitingRewards) {
       return;
     }
     // If the run has ended (defeat), clear state and show defeat popup immediately


### PR DESCRIPTION
## Summary
- prevent frontend from advancing rooms while card, relic, or loot rewards are pending
- gate advance_room calls from shop/rest and generic next-room handlers
- document UI reward gating in frontend run helpers
- explain that reward flags stay false when no card or relic drops and that loot auto-collects

## Testing
- `uv tool run ruff check . --fix` *(fails: .codex/prototypes lint errors)*
- `uv tool run ruff check backend/routes/ui.py backend/services/run_service.py backend/tests/test_reward_gate.py --fix`
- `uv run pytest backend/tests/test_reward_gate.py`
- `./run-tests.sh` *(fails: AttributeError: type object 'Wind' has no attribute '_players')*
- `cd frontend && bun test tests/statepolling.test.js`


------
https://chatgpt.com/codex/tasks/task_b_68bb1ff0a21c832ca48a13d9cb6396e5