### PR TITLE
[FEAT] show foe rank in battle review

### DIFF
--- a/frontend/.codex/implementation/battle-review-ui.md
+++ b/frontend/.codex/implementation/battle-review-ui.md
@@ -3,6 +3,7 @@
 The Battle Review interface uses a vertical icon column and a persistent side panel:
 
 - Navigation icons appear in a left-side column. The overview uses a Swords icon, while party and foe entries show their portraits.
+- Foe tabs append the foe's rank after its name using an em dash (e.g., `Slime — Prime`).
 - Selecting an icon swaps the main content without hiding statistics; the right-side stats panel updates for the active entry.
 - `.battle-review-tabs` arranges three columns: `icon-column`, `content-area`, and `stats-panel`.
 - `.icon-btn` provides a square click target with hover and active states.

--- a/frontend/src/lib/components/BattleReview.svelte
+++ b/frontend/src/lib/components/BattleReview.svelte
@@ -110,7 +110,7 @@
   $: foesDisplay = (foeData && foeData.length
     ? foeData
     : (foes && foes.length
-        ? foes.map(id => ({ id }))
+        ? foes.map(f => (typeof f === 'object' ? { ...f } : { id: f }))
         : (summary.foes || []).map(id => ({ id }))
       )
   );
@@ -207,9 +207,11 @@
     // Add foe tabs
     for (const foe of foesDisplay || []) {
       if (foe.id) {
+        const name = foe.name || foe.id;
+        const label = foe.rank ? `${name} — ${foe.rank}` : name;
         tabs.push({
           id: foe.id,
-          label: foe.name || foe.id,
+          label,
           type: 'foe',
           entity: foe
         });

--- a/frontend/tests/battlereview.test.js
+++ b/frontend/tests/battlereview.test.js
@@ -2,7 +2,7 @@ import { describe, expect, test } from 'bun:test';
 import { readFileSync } from 'fs';
 import { join } from 'path';
 
-const review = readFileSync(join(import.meta.dir, '../src/lib/BattleReview.svelte'), 'utf8');
+const review = readFileSync(join(import.meta.dir, '../src/lib/components/BattleReview.svelte'), 'utf8');
 
 describe('BattleReview component', () => {
   test('maps party and foe data', () => {
@@ -18,5 +18,10 @@ describe('BattleReview component', () => {
   test('uses icon column navigation', () => {
     expect(review).toContain('icon-column');
     expect(review).toContain('stats-panel');
+  });
+
+  test('foe tabs show rank when available', () => {
+    expect(review).toMatch(/foe\.rank/);
+    expect(review).toMatch(/\u2014/); // em dash between name and rank
   });
 });


### PR DESCRIPTION
## Summary\n- pass rank through foesDisplay and render \"Name — Rank\" for foe tabs\n- document foe rank usage in battle review UI\n- add tests for rank labels\n\n## Testing\n- `bun run lint`\n- `bun test tests/battlereview.test.js`\n- `./run-tests.sh` *(fails: multiple backend tests such as test_event_bus_batching_performance and test_battle_defeat)*

------
https://chatgpt.com/codex/tasks/task_b_68bb2f0efabc832c97c9d85bb90f62e5