### PR TITLE
[FIX] Ensure End Run handles missing IDs

### DIFF
--- a/frontend/.codex/implementation/settings-menu.md
+++ b/frontend/.codex/implementation/settings-menu.md
@@ -13,3 +13,7 @@ for each category:
 checks it for `"llm"` to decide whether the LLM tab should appear. When
 the flavor string omits `"llm"`, the component skips `getLrmConfig()`
 and hides the model selector and test button.
+
+The Gameplay tab's **End Run** button now attempts to end the current run by
+ID and falls back to clearing all runs when the ID is missing or the targeted
+request fails.

--- a/frontend/tests/settingsmenu.test.js
+++ b/frontend/tests/settingsmenu.test.js
@@ -2,6 +2,28 @@ import { describe, expect, test } from 'bun:test';
 import { readFileSync } from 'fs';
 import { join } from 'path';
 
+function buildHandler() {
+  const source = readFileSync(join(import.meta.dir, '../src/lib/components/SettingsMenu.svelte'), 'utf8');
+  const start = source.indexOf('async function handleEndRun');
+  const brace = source.indexOf('{', start);
+  let depth = 1;
+  let i = brace + 1;
+  while (depth > 0 && i < source.length) {
+    if (source[i] === '{') depth++;
+    else if (source[i] === '}') depth--;
+    i++;
+  }
+  const body = source.slice(brace + 1, i - 1);
+  return new Function(
+    'runId',
+    'endRun',
+    'endAllRuns',
+    'getActiveRuns',
+    'dispatch',
+    `let endRunStatus = ''; let endingRun = false; return (async () => {${body} return endRunStatus;})();`
+  );
+}
+
 describe('SettingsMenu component', () => {
   test('renders tab icons and panels', () => {
     const content = readFileSync(join(import.meta.dir, '../src/lib/components/SettingsMenu.svelte'), 'utf8');
@@ -28,21 +50,51 @@ describe('SettingsMenu component', () => {
     expect(content).not.toContain('alert(');
   });
 
-  test('dispatches endRun even if API call fails', async () => {
-    const source = readFileSync(join(import.meta.dir, '../src/lib/components/SettingsMenu.svelte'), 'utf8');
-    const start = source.indexOf('async function handleEndRun');
-    const brace = source.indexOf('{', start);
-    let depth = 1;
-    let i = brace + 1;
-    while (depth > 0 && i < source.length) {
-      if (source[i] === '{') depth++;
-      else if (source[i] === '}') depth--;
-      i++;
-    }
-    const body = source.slice(brace + 1, i - 1);
-    let fired = false;
-    const handler = new Function('runId', 'endRun', 'dispatch', `return (async () => {${body}})();`);
-    await handler('abc', async () => { throw new Error('fail'); }, () => { fired = true; });
-    expect(fired).toBe(true);
+  test('reports success when targeted run ends', async () => {
+    const handler = buildHandler();
+    const calls = [];
+    const dispatches = [];
+    const status = await handler(
+      'abc',
+      async () => { calls.push('endRun'); },
+      () => { calls.push('endAllRuns'); },
+      () => ({ runs: [] }),
+      () => dispatches.push('endRun')
+    );
+    expect(calls).toEqual(['endRun']);
+    expect(dispatches).toEqual(['endRun']);
+    expect(status).toBe('Run ended');
+  });
+
+  test('falls back to endAllRuns when endRun fails', async () => {
+    const handler = buildHandler();
+    const calls = [];
+    const dispatches = [];
+    const status = await handler(
+      'abc',
+      async () => { calls.push('endRun'); throw new Error('fail'); },
+      () => { calls.push('endAllRuns'); },
+      () => ({ runs: [] }),
+      () => dispatches.push('endRun')
+    );
+    expect(calls).toEqual(['endRun', 'endAllRuns']);
+    expect(dispatches).toEqual(['endRun']);
+    expect(status).toBe('Run force-ended');
+  });
+
+  test('uses endAllRuns when runId is missing', async () => {
+    const handler = buildHandler();
+    const calls = [];
+    const dispatches = [];
+    const status = await handler(
+      '',
+      () => { calls.push('endRun'); },
+      () => { calls.push('endAllRuns'); },
+      () => ({ runs: [] }),
+      () => dispatches.push('endRun')
+    );
+    expect(calls).toEqual(['endAllRuns']);
+    expect(dispatches).toEqual(['endRun']);
+    expect(status).toBe('Run force-ended');
   });
 });


### PR DESCRIPTION
## Summary
- allow SettingsMenu's End Run to force-terminate runs when runId is missing or deletion fails
- keep End Run button clickable regardless of runId
- expand SettingsMenu tests to cover forced run termination

## Testing
- `uv tool run ruff check backend --fix`
- `bun run lint:fix`
- `./run-tests.sh` *(fails: RuntimeError no running event loop, ModuleNotFoundError, etc.)*
- `bun test` *(fails: Cannot find module '../src/lib/constants.js', etc.)*


------
https://chatgpt.com/codex/tasks/task_b_68bb3254ed58832c9e9b688ef681b477