### PR TITLE
Handle missing battle snapshots by auto-starting combat

### DIFF
--- a/backend/.codex/implementation/battle-snapshots.md
+++ b/backend/.codex/implementation/battle-snapshots.md
@@ -24,6 +24,10 @@ poll for results:
   Supported ranks are `"normal"`, `"prime"`, `"glitched prime"`, `"boss"`, and
   `"glitched boss"`.
 
+- Requesting a battle `snapshot` with none available will now start the fight
+  using the current room state and return the newly created snapshot instead of
+  raising an error.
+
 These snapshots are stored in `game.battle_snapshots` and polled by the
 frontend during combat.
 

--- a/backend/services/room_service.py
+++ b/backend/services/room_service.py
@@ -45,9 +45,10 @@ async def battle_room(run_id: str, data: dict[str, Any]) -> dict[str, Any]:
 
     if action == "snapshot":
         snap = battle_snapshots.get(run_id)
-        if snap is None:
-            raise LookupError("no battle")
-        return snap
+        if snap is not None:
+            return snap
+        action = ""
+        data = {k: v for k, v in data.items() if k != "action"}
 
     if action == "pause":
         if run_id in battle_tasks:
@@ -289,9 +290,10 @@ async def boss_room(run_id: str, data: dict[str, Any]) -> dict[str, Any]:
     action = data.get("action", "")
     if action == "snapshot":
         snap = battle_snapshots.get(run_id)
-        if snap is None:
-            raise LookupError("no battle")
-        return snap
+        if snap is not None:
+            return snap
+        action = ""
+        data = {k: v for k, v in data.items() if k != "action"}
 
     state, rooms = await asyncio.to_thread(load_map, run_id)
     try:

--- a/backend/tests/test_battle_snapshot_reload.py
+++ b/backend/tests/test_battle_snapshot_reload.py
@@ -1,0 +1,56 @@
+import asyncio
+import importlib.util
+from pathlib import Path
+import sys
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from game import battle_snapshots
+from game import load_map
+from game import save_map
+from services.room_service import battle_room
+from services.room_service import boss_room
+from services.run_service import start_run
+
+
+@pytest.fixture()
+def app_module(tmp_path, monkeypatch):
+    db_path = tmp_path / "save.db"
+    monkeypatch.setenv("AF_DB_PATH", str(db_path))
+    monkeypatch.setenv("AF_DB_KEY", "testkey")
+    spec = importlib.util.spec_from_file_location(
+        "app", Path(__file__).resolve().parents[1] / "app.py",
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.mark.asyncio
+async def test_battle_snapshot_reload_starts_battle(app_module):
+    run_info = await start_run(["player"])
+    run_id = run_info["run_id"]
+    assert run_id not in battle_snapshots
+
+    snap = await battle_room(run_id, {"action": "snapshot"})
+    assert snap["result"] == "battle"
+    assert run_id in battle_snapshots
+
+
+@pytest.mark.asyncio
+async def test_boss_snapshot_reload_starts_battle(app_module):
+    run_info = await start_run(["player"])
+    run_id = run_info["run_id"]
+
+    state, rooms = await asyncio.to_thread(load_map, run_id)
+    state["rooms"][state["current"]]["room_type"] = "battle-boss-floor"
+    await asyncio.to_thread(save_map, run_id, state)
+
+    assert run_id not in battle_snapshots
+
+    snap = await boss_room(run_id, {"action": "snapshot"})
+    assert snap["result"] == "boss"
+    assert run_id in battle_snapshots


### PR DESCRIPTION
## Summary
- start battle automatically when requesting a snapshot before combat begins
- document that missing snapshots trigger battle initialization
- add tests covering battle and boss snapshot reload behavior

## Testing
- `uv run ruff check backend/services/room_service.py backend/tests/test_battle_snapshot_reload.py --fix`
- `uv run -m pytest backend/tests/test_battle_snapshot_reload.py`

------
https://chatgpt.com/codex/tasks/task_b_68bb2f8554a8832ca0911f679f23ed69