### PR TITLE
[FEAT] add loot acknowledgement handler

### DIFF
--- a/frontend/src/lib/components/OverlayHost.svelte
+++ b/frontend/src/lib/components/OverlayHost.svelte
@@ -284,7 +284,7 @@
         gold={roomData.loot?.gold || 0}
         on:select={(e) => dispatch('rewardSelect', e.detail)}
         on:next={() => dispatch('nextRoom')}
-        on:nextRoom={() => dispatch('nextRoom')}
+        on:lootAcknowledge={() => dispatch('lootAcknowledge')}
       />
     </PopupWindow>
   </OverlaySurface>

--- a/frontend/src/lib/components/RewardOverlay.svelte
+++ b/frontend/src/lib/components/RewardOverlay.svelte
@@ -63,7 +63,7 @@
   }
 
   function handleNextRoom() {
-    dispatch('nextRoom'); // Changed from 'next' to 'nextRoom' to match expected event
+    dispatch('lootAcknowledge');
   }
 </script>
 

--- a/frontend/src/lib/systems/uiApi.js
+++ b/frontend/src/lib/systems/uiApi.js
@@ -176,6 +176,16 @@ export async function chooseRelic(relicId) {
   return await sendAction('choose_relic', { relic_id: relicId });
 }
 
+/**
+ * Acknowledge and collect room loot.
+ * @param {string} runId - The current run identifier
+ */
+export async function acknowledgeLoot(runId) {
+  return await handleFetch(`/rewards/loot/${runId}`, {
+    method: 'POST'
+  });
+}
+
 // For backward compatibility with existing code, we can provide fallback functions
 // that use the old API format but internally use the new UI API
 

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -23,7 +23,7 @@
     backOverlay,
     homeOverlay
   } from '$lib';
-  import { updateParty } from '$lib/systems/uiApi.js';
+  import { updateParty, acknowledgeLoot } from '$lib/systems/uiApi.js';
   import { buildRunMenu } from '$lib/components/RunButtons.svelte';
   import { browser, dev } from '$app/environment';
 
@@ -977,6 +977,7 @@
 
   async function handleLootAcknowledge() {
     if (!runId) return;
+    await acknowledgeLoot(runId);
     await handleNextRoom();
   }
 


### PR DESCRIPTION
## Summary
- add `acknowledgeLoot` API helper and use it to advance after loot collection
- emit `lootAcknowledge` from reward overlay and propagate through overlays

## Testing
- `uv tool run ruff check backend --fix`
- `cd frontend && bun run lint:fix`
- `./run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_b_68bb3b47d59c832c8fbfc0516160fafb