### PR TITLE
feat: add user level progression

### DIFF
--- a/backend/.codex/implementation/user-level-system.md
+++ b/backend/.codex/implementation/user-level-system.md
@@ -1,0 +1,13 @@
+# User level system
+
+Tracks a global user level and experience stored in the options table.
+
+* `user_level_service.py` persists `user_level` and `user_exp`.
+* `gain_user_exp(amount)` adds experience and handles level ups using
+  a 1.05× growth curve defined by `user_exp_to_level()`.
+* Battle rewards divide experience by the current user level. Party members
+  gain the full amount, then the scaled value is credited to the user through
+  `gain_user_exp()` so character rewards remain unaffected.
+* A status hook applies a 1 % per-level multiplier to all party stats at runtime.
+* Player endpoints expose `{level, exp, next_level_exp}` so the frontend can
+  render progress.

--- a/backend/autofighter/rooms/battle.py
+++ b/backend/autofighter/rooms/battle.py
@@ -13,6 +13,8 @@ from battle_logging import end_battle_logging
 
 # Import battle logging
 from battle_logging import start_battle_logging
+from services.user_level_service import gain_user_exp
+from services.user_level_service import get_user_level
 
 from autofighter.cards import apply_cards
 from autofighter.cards import card_choices
@@ -710,6 +712,11 @@ class BattleRoom(Room):
                 except Exception:
                     # Do not let EXP calculation break battle resolution
                     pass
+            try:
+                level = get_user_level()
+                gain_user_exp(int(exp_reward / max(1, level)))
+            except Exception:
+                pass
         party_data = [_serialize(p) for p in party.members]
         foes_data = [_serialize(f) for f in foes]
         party_summons = _collect_summons(party.members)

--- a/backend/autofighter/stats.py
+++ b/backend/autofighter/stats.py
@@ -596,3 +596,27 @@ def add_status_hook(hook: StatusHook) -> None:
 def apply_status_hooks(stats: "Stats") -> None:
     for hook in STATUS_HOOKS:
         hook(stats)
+
+
+def _apply_user_level(stats: "Stats") -> None:
+    from services.user_level_service import get_user_level
+
+    try:
+        level = get_user_level()
+        mult = 1 + level * 0.01
+        stats._base_max_hp = int(stats._base_max_hp * mult)
+        stats._base_atk = int(stats._base_atk * mult)
+        stats._base_defense = int(stats._base_defense * mult)
+        stats._base_crit_rate *= mult
+        stats._base_crit_damage *= mult
+        stats._base_effect_hit_rate *= mult
+        stats._base_mitigation *= mult
+        stats._base_regain = int(stats._base_regain * mult)
+        stats._base_dodge_odds *= mult
+        stats._base_effect_resistance *= mult
+        stats._base_vitality *= mult
+    except Exception:
+        pass
+
+
+add_status_hook(_apply_user_level)

--- a/backend/routes/players.py
+++ b/backend/routes/players.py
@@ -16,6 +16,7 @@ from game import get_save_manager
 from quart import Blueprint
 from quart import jsonify
 from quart import request
+from services.user_level_service import get_user_state
 
 from autofighter.gacha import GachaManager
 from autofighter.stats import apply_status_hooks
@@ -169,7 +170,7 @@ async def get_players() -> tuple[str, int, dict[str, str]]:
                 "stats": stats,
             }
         )
-    return jsonify({"players": roster})
+    return jsonify({"players": roster, "user": get_user_state()})
 
 
 @bp.get("/player/stats")
@@ -275,7 +276,7 @@ async def player_stats() -> tuple[str, int, dict[str, object]]:
         "base_stats": base_stats,
         "active_effects": active_effects,
     }
-    return jsonify({"stats": stats, "refresh_rate": refresh})
+    return jsonify({"stats": stats, "refresh_rate": refresh, "user": get_user_state()})
 
 
 @bp.get("/player/editor")

--- a/backend/services/user_level_service.py
+++ b/backend/services/user_level_service.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+
+def user_exp_to_level(level: int) -> int:
+    base = 100
+    return int(base * (1.05 ** (level - 1)))
+
+
+def get_user_state() -> dict[str, int]:
+    from game import get_save_manager
+
+    with get_save_manager().connection() as conn:
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS options (key TEXT PRIMARY KEY, value TEXT)"
+        )
+        row = conn.execute(
+            "SELECT value FROM options WHERE key = ?", ("user_level",)
+        ).fetchone()
+        try:
+            level = int(row[0]) if row else 1
+        except (TypeError, ValueError):
+            level = 1
+        row = conn.execute(
+            "SELECT value FROM options WHERE key = ?", ("user_exp",)
+        ).fetchone()
+        try:
+            exp = int(row[0]) if row else 0
+        except (TypeError, ValueError):
+            exp = 0
+    next_level_exp = user_exp_to_level(level)
+    return {"level": level, "exp": exp, "next_level_exp": next_level_exp}
+
+
+def get_user_level() -> int:
+    return get_user_state()["level"]
+
+
+def gain_user_exp(amount: int) -> dict[str, int]:
+    if amount <= 0:
+        return get_user_state()
+    state = get_user_state()
+    exp = state["exp"] + amount
+    level = state["level"]
+    next_exp = user_exp_to_level(level)
+    while exp >= next_exp:
+        exp -= next_exp
+        level += 1
+        next_exp = user_exp_to_level(level)
+    from game import get_save_manager
+
+    with get_save_manager().connection() as conn:
+        conn.execute(
+            "INSERT OR REPLACE INTO options (key, value) VALUES (?, ?)",
+            ("user_level", str(level)),
+        )
+        conn.execute(
+            "INSERT OR REPLACE INTO options (key, value) VALUES (?, ?)",
+            ("user_exp", str(exp)),
+        )
+    return {"level": level, "exp": exp, "next_level_exp": next_exp}

--- a/frontend/.codex/implementation/user-level-bar.md
+++ b/frontend/.codex/implementation/user-level-bar.md
@@ -1,0 +1,8 @@
+# User level bar
+
+The game viewport shows a footer bar indicating global user progress.
+
+* `loadInitialState()` now returns `{ user }` from `/players`.
+* `GameViewport.svelte` renders `.user-level-bar` at the bottom of the view.
+* The inner bar width is `user_exp / next_level_exp` and uses a
+  `linear-gradient(red, green)` background.

--- a/frontend/src/lib/components/GameViewport.svelte
+++ b/frontend/src/lib/components/GameViewport.svelte
@@ -42,6 +42,7 @@
 
   let randomBg = '';
   let roster = [];
+  let userState = { level: 1, exp: 0, next_level_exp: 100 };
   let sfxVolume = 50;
   let musicVolume = 50;
   let voiceVolume = 50;
@@ -61,6 +62,7 @@
     ({ sfxVolume, musicVolume, voiceVolume, framerate, autocraft, reducedMotion } =
       init.settings);
     roster = init.roster;
+    userState = init.user;
     // Ensure music starts after first user gesture if autoplay was blocked
     try {
       const { resumeGameMusic } = await import('../systems/viewportState.js');
@@ -180,6 +182,18 @@
     white-space: nowrap;
   }
   .arrow { margin: 0 0.5rem; opacity: 0.9; }
+  .user-level-bar {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    height: 6px;
+    background: #222;
+  }
+  .user-level-bar .fill {
+    height: 100%;
+    background: linear-gradient(red, green);
+  }
 </style>
 
 <div class="viewport-wrap">
@@ -256,5 +270,14 @@
       on:snapshot-start={() => (snapshotLoading = true)}
       on:snapshot-end={() => (snapshotLoading = false)}
     />
+    <div class="user-level-bar">
+      <div
+        class="fill"
+        style={`width: ${Math.min(
+          100,
+          100 * (userState.exp / userState.next_level_exp)
+        )}%`}
+      />
+    </div>
   </div>
 </div>

--- a/frontend/src/lib/systems/viewportState.js
+++ b/frontend/src/lib/systems/viewportState.js
@@ -21,6 +21,7 @@ export async function loadInitialState() {
     reducedMotion: saved.reducedMotion ?? false,
   };
   let roster = [];
+  let user = { level: 1, exp: 0, next_level_exp: 100 };
   try {
     const data = await getPlayers();
     function resolveElement(p) {
@@ -29,10 +30,11 @@ export async function loadInitialState() {
       return e && !/generic/i.test(String(e)) ? e : 'Generic';
     }
     roster = data.players.map(p => ({ id: p.id, element: resolveElement(p) }));
+    user = data.user || user;
   } catch {
     roster = [];
   }
-  return { settings, roster };
+  return { settings, roster, user };
 }
 
 export function mapSelectedParty(roster, selected) {


### PR DESCRIPTION
## Summary
- track persistent user level and experience
- scale battle rewards and expose user XP to the frontend
- display user XP progress bar in game viewport
- credit scaled user experience after characters gain battle rewards

## Testing
- `uvx ruff check backend/services/user_level_service.py backend/autofighter/stats.py backend/autofighter/rooms/battle.py backend/routes/players.py --fix`
- `./run-tests.sh` *(fails: missing modules and timed-out tests)*

------
https://chatgpt.com/codex/tasks/task_b_68bb40e32eb8832cb36f0ad0fc625133