### PR TITLE
feat: unify character editor and add crit stats

### DIFF
--- a/.codex/implementation/game-workflow.md
+++ b/.codex/implementation/game-workflow.md
@@ -24,8 +24,9 @@ Source code lives under the backend:
 - Selecting *New Run* starts a Battle Room that exchanges event-bus-driven turns with stat-based accuracy, scaled foes, floating damage numbers, attack effects, status icons, and an overtime warning after 100 turns (500 for floor bosses) that grants an Enraged buff. The loop pauses briefly between actions so the async server stays responsive.
 - Active runs persist across page reloads. The frontend caches `runId` and the next room in `localStorage`, verifies the ID via `/map/<run_id>` on startup, and resumes the current room if valid; invalid IDs are cleared.
  - Rest Rooms grant access to gacha pulls and party swapping without advancing the run, and at least two must appear on each floor via `RestRoom.should_spawn`.
- - Shop Rooms sell upgrade items and cards with gold pricing, star ratings, floor-based inventory scaling, and reroll costs. Purchases add items to inventory, and class-level tracking ensures at least two appear per floor.
- - Event Rooms present text prompts with selectable options that deterministically modify stats or inventory using seeded randomness. They may occur after battles without consuming the floor's room count.
+- Shop Rooms sell upgrade items and cards with gold pricing, star ratings, floor-based inventory scaling, and reroll costs. Purchases add items to inventory, and class-level tracking ensures at least two appear per floor.
+- Upgrade items convert into upgrade points via the `UpgradePanel`, letting any character spend points on stats through `/players/<id>/upgrade` and `/players/<id>/upgrade-stat`.
+- Event Rooms present text prompts with selectable options that deterministically modify stats or inventory using seeded randomness. They may occur after battles without consuming the floor's room count.
  - Chat Rooms let players send a single message to an LLM character. Usage is limited to six chats per floor, and rooms should not spawn once the limit is reached.
 
 ## Wave preparation

--- a/.codex/implementation/party-picker.md
+++ b/.codex/implementation/party-picker.md
@@ -6,7 +6,7 @@ The Svelte `PartyPicker` component lets players choose up to four allies before 
 
 - **`PartyRoster`** – lists owned characters and handles selection. Rows tint the outline and element icon with `getElementColor` for quick damage-type recognition. Selection uses two-way binding on `previewId` so the parent can preview or modify the party.
 - **`PlayerPreview`** – shows a large portrait of the currently selected character or a placeholder message when none is chosen.
-- **`StatTabs`** – renders a tabbed stats panel with Core, Offense, and Defense groups and exposes a **Add to party** / **Remove from party** toggle via a `toggle` event.
+- **`StatTabs`** – renders a tabbed stats panel (Core, Offense, Defense) and embeds a reusable **`CharacterEditor`** for both players and NPCs. Sliders allow adjusting HP, Attack, Defense, Crit Rate, and Crit Damage, with player changes auto‑saved via the backend. A **Add to party** / **Remove from party** toggle is exposed via a `toggle` event.
 
 The layout uses percentage-based columns so the roster, preview, and stats panels all shrink with the viewport. Content is wrapped in `MenuPanel`, which sizes itself just under the overlay surface to avoid a surrounding scrollbar. Preview portraits scale without a minimum size so they remain visible on small screens.
 

--- a/.codex/implementation/party-ui.md
+++ b/.codex/implementation/party-ui.md
@@ -1,0 +1,7 @@
+# Party UI
+
+The party management interface uses a unified `CharacterEditor` inside `StatTabs` for both player and non‑player characters. The editor exposes sliders for HP, Attack, Defense, Crit Rate, and Crit Damage. Player edits persist via `/player/editor` while NPC tweaks remain local for previewing.
+
+An `UpgradePanel` sits below the editor so any character can convert upgrade items into points and spend them on specific stats using the shared `/players/<id>/upgrade` and `/players/<id>/upgrade-stat` endpoints.
+
+`StatTabs` no longer includes the old Effects tab; all characters share the same scrollable stat view and slider controls.

--- a/.codex/implementation/playable-flow.md
+++ b/.codex/implementation/playable-flow.md
@@ -6,7 +6,7 @@ endpoint with the selected party. The backend creates a run in the encrypted
 `AF_DB_PASSWORD`) and returns a `run_id` with the initial map layout.
 
 After confirming the lineup in a modal PartyPicker, the client immediately
-switches to the map view showing upcoming rooms. The confirmation buttons sit in a stained-glass row so they match other UI controls. A matching stained-glass bar in the top-left now provides quick navigation: the diamond icon returns home, the user icon opens the Player Editor, the cog opens Settings, and the arrow steps back to the prior view. Players can reopen the map at
+switches to the map view showing upcoming rooms. The confirmation buttons sit in a stained-glass row so they match other UI controls. A matching stained-glass bar in the top-left now provides quick navigation: the diamond icon returns home, the user icon opens the Character Editor, the cog opens Settings, and the arrow steps back to the prior view. Players can reopen the map at
 any time via the **Map** button, which fetches the latest floor state and
 renders nodes in `MapDisplay.svelte` with the boss at the top, the current room highlighted at the bottom, and future rooms grayed out. The **Edit** button loads the player's
 configuration and opens `PlayerEditor` so pronouns, damage type, and starting

--- a/.codex/implementation/player-customization.md
+++ b/.codex/implementation/player-customization.md
@@ -1,12 +1,12 @@
-# Player Editor
+# Character Editor
 
-`PlayerEditor` now connects to backend endpoints and is launched from the main
+The `CharacterEditor` connects to backend endpoints and is launched from the main
 menu's **Edit** button or automatically before a run, so players can set custom
 pronouns up to 15 characters, pick a starting damage type—Light, Dark, Wind,
 Lightning, Fire, or Ice—and allocate stat points before starting a run.
 
 - Players start with 100 base points and may gain bonus points from owning 100 of each damage type's 4★ upgrade items.
-- Sliders for HP, Attack, and Defense clamp so the sum never exceeds the available pool.
+- Sliders for HP, Attack, Defense, Crit Rate, and Crit Damage clamp so the sum never exceeds the available pool.
 - Each point grants a 1% multiplier to the chosen stat, doubling it at 100 points.
 - A label displays remaining points.
 - The Confirm button is disabled until the 100 base points are spent. Bonus points are optional and unspent amounts stay in the inventory.
@@ -29,6 +29,6 @@ Player customization is applied during character instantiation rather than as te
 
 ## Persistence notes
 
-The component dispatches numeric `hp`, `attack`, and `defense` values alongside a `damageType` field that the page converts to the API's `damage_type` key, so edited stats persist after saving and reloading.
+The component dispatches numeric `hp`, `attack`, `defense`, `critRate`, and `critDamage` values alongside a `damageType` field that the page converts to the API's keys, so edited stats persist after saving and reloading.
 
 Customization is applied during player instantiation, ensuring consistent stats while maintaining all editor functionality.

--- a/backend/game.py
+++ b/backend/game.py
@@ -81,7 +81,7 @@ def _describe_passives(obj: Stats | list[str]) -> list[dict[str, Any]]:
 
 def _load_player_customization() -> tuple[str, dict[str, int]]:
     pronouns = ""
-    stats: dict[str, int] = {"hp": 0, "attack": 0, "defense": 0}
+    stats: dict[str, int] = {"hp": 0, "attack": 0, "defense": 0, "crit_rate": 0, "crit_damage": 0}
     with get_save_manager().connection() as conn:
         conn.execute(
             "CREATE TABLE IF NOT EXISTS options (key TEXT PRIMARY KEY, value TEXT)"
@@ -109,6 +109,8 @@ def _apply_player_customization(player: PlayerBase) -> None:
         "max_hp_mult": 1 + loaded.get("hp", 0) * 0.01,
         "atk_mult": 1 + loaded.get("attack", 0) * 0.01,
         "defense_mult": 1 + loaded.get("defense", 0) * 0.01,
+        "crit_rate_mult": 1 + loaded.get("crit_rate", 0) * 0.01,
+        "crit_damage_mult": 1 + loaded.get("crit_damage", 0) * 0.01,
     }
 
     log.debug(

--- a/backend/routes/players.py
+++ b/backend/routes/players.py
@@ -4,7 +4,6 @@ import asyncio
 from dataclasses import fields
 import json
 import logging
-import random
 from typing import Dict
 from typing import List
 
@@ -291,6 +290,8 @@ async def get_player_editor() -> tuple[str, int, dict[str, object]]:
             "hp": stats.get("hp", 0),
             "attack": stats.get("attack", 0),
             "defense": stats.get("defense", 0),
+            "crit_rate": stats.get("crit_rate", 0),
+            "crit_damage": stats.get("crit_damage", 0),
         }
     )
 
@@ -304,9 +305,11 @@ async def update_player_editor() -> tuple[str, int, dict[str, str]]:
         hp = int(data.get("hp", 0))
         attack = int(data.get("attack", 0))
         defense = int(data.get("defense", 0))
+        crit_rate = int(data.get("crit_rate", 0))
+        crit_damage = int(data.get("crit_damage", 0))
     except (TypeError, ValueError):
         return jsonify({"error": "invalid stats"}), 400
-    total = hp + attack + defense
+    total = hp + attack + defense + crit_rate + crit_damage
     if len(pronouns) > 15:
         return jsonify({"error": "invalid pronouns"}), 400
     allowed = {"Light", "Dark", "Wind", "Lightning", "Fire", "Ice"}
@@ -316,12 +319,14 @@ async def update_player_editor() -> tuple[str, int, dict[str, str]]:
         return jsonify({"error": "over-allocation"}), 400
 
     log.debug(
-        "Updating player editor: pronouns=%s, damage_type=%s, hp=%d, attack=%d, defense=%d",
+        "Updating player editor: pronouns=%s, damage_type=%s, hp=%d, attack=%d, defense=%d, crit_rate=%d, crit_damage=%d",
         pronouns,
         damage_type,
         hp,
         attack,
         defense,
+        crit_rate,
+        crit_damage,
     )
 
     def update_player_data():
@@ -337,7 +342,13 @@ async def update_player_editor() -> tuple[str, int, dict[str, str]]:
                 "INSERT OR REPLACE INTO options (key, value) VALUES (?, ?)",
                 (
                     "player_stats",
-                    json.dumps({"hp": hp, "attack": attack, "defense": defense}),
+                    json.dumps({
+                        "hp": hp,
+                        "attack": attack,
+                        "defense": defense,
+                        "crit_rate": crit_rate,
+                        "crit_damage": crit_damage,
+                    }),
                 ),
             )
             if damage_type:
@@ -353,7 +364,6 @@ async def update_player_editor() -> tuple[str, int, dict[str, str]]:
 
 # Constants for new upgrade system
 UPGRADEABLE_STATS = ["max_hp", "atk", "defense", "crit_rate", "crit_damage"]
-STAT_BOOST_PERCENTAGES = {1: 0.001, 2: 0.02, 3: 0.03, 4: 0.04}  # 0.1%, 2%, 3%, 4%
 PLAYER_POINTS_VALUES = {1: 1, 2: 150, 3: 22500, 4: 3375000}
 
 
@@ -420,17 +430,6 @@ def _add_player_upgrade_points(player_id: str, points: int):
         conn.commit()
 
 
-def _add_stat_upgrade(player_id: str, stat_name: str, upgrade_percent: float, source_star: int):
-    """Add a stat upgrade record for a player."""
-    with get_save_manager().connection() as conn:
-        _create_upgrade_tables()
-        conn.execute("""
-            INSERT INTO player_stat_upgrades (player_id, stat_name, upgrade_percent, source_star)
-            VALUES (?, ?, ?, ?)
-        """, (player_id, stat_name, upgrade_percent, source_star))
-        conn.commit()
-
-
 def _spend_player_upgrade_points(player_id: str, points: int, stat_name: str, upgrade_percent: float) -> bool:
     """Spend upgrade points for a specific stat upgrade. Returns True if successful."""
     with get_save_manager().connection() as conn:
@@ -468,16 +467,11 @@ async def get_player_upgrade(pid: str):
             stat_name = upgrade["stat_name"]
             stat_totals[stat_name] = stat_totals.get(stat_name, 0) + upgrade["upgrade_percent"]
 
-        result = {
+        return {
             "stat_upgrades": stat_upgrades,
             "stat_totals": stat_totals,
+            "upgrade_points": _get_player_upgrade_points(pid),
         }
-
-        # If this is the player character, include points
-        if pid == "player":
-            result["upgrade_points"] = _get_player_upgrade_points(pid)
-
-        return result
 
     new_data = await asyncio.to_thread(fetch_new_upgrade_data)
 
@@ -521,64 +515,40 @@ async def upgrade_player(pid: str):
         return jsonify({"error": "item_count must be at least 1"}), 400
 
     def perform_upgrade():
+        total_points = 0
+        consumed_items = {}
+        points_per_item = PLAYER_POINTS_VALUES[star_level]
+
         if pid == "player":
-            # Player character: use any damage type items for points
-            total_points = 0
-            consumed_items = {}
-
-            # Try to consume items of the specified star level from any damage type
-            points_per_item = PLAYER_POINTS_VALUES[star_level]
             items_needed = item_count
-
-            # Check all damage types for items of this star level
             for damage_type in ["generic", "light", "dark", "wind", "lightning", "fire", "ice"]:
                 item_key = f"{damage_type}_{star_level}"
                 available = items.get(item_key, 0)
-
                 if available > 0:
-                    consume_count = min(available, items_needed)
-                    items[item_key] -= consume_count
-                    consumed_items[item_key] = consume_count
-                    total_points += consume_count * points_per_item
-                    items_needed -= consume_count
-
+                    consume = min(available, items_needed)
+                    items[item_key] -= consume
+                    consumed_items[item_key] = consume
+                    total_points += consume * points_per_item
+                    items_needed -= consume
                     if items_needed <= 0:
                         break
-
             if items_needed > 0:
                 return {"error": f"insufficient {star_level}★ items (need {item_count}, found {item_count - items_needed})"}
-
-            # Add points to player
-            _add_player_upgrade_points(pid, total_points)
-
-            return {
-                "points_gained": total_points,
-                "items_consumed": consumed_items,
-                "total_points": _get_player_upgrade_points(pid)
-            }
         else:
-            # Other characters: must match damage type, give random stat boost
-            element = inst.element_id.lower()  # Convert to lowercase to match item keys
+            element = inst.element_id.lower()
             item_key = f"{element}_{star_level}"
-
             if items.get(item_key, 0) < item_count:
                 return {"error": f"insufficient {element} {star_level}★ items"}
-
-            # Consume items and apply random stat upgrades
             items[item_key] -= item_count
-            upgrade_percent = STAT_BOOST_PERCENTAGES[star_level]
-            upgrades_applied = []
+            consumed_items[item_key] = item_count
+            total_points = item_count * points_per_item
 
-            for _ in range(item_count):
-                # Pick random stat
-                stat_name = random.choice(UPGRADEABLE_STATS)
-                _add_stat_upgrade(pid, stat_name, upgrade_percent, star_level)
-                upgrades_applied.append({"stat": stat_name, "percent": upgrade_percent})
-
-            return {
-                "upgrades_applied": upgrades_applied,
-                "items_consumed": {item_key: item_count}
-            }
+        _add_player_upgrade_points(pid, total_points)
+        return {
+            "points_gained": total_points,
+            "items_consumed": consumed_items,
+            "total_points": _get_player_upgrade_points(pid),
+        }
 
     result = await asyncio.to_thread(perform_upgrade)
 
@@ -591,7 +561,7 @@ async def upgrade_player(pid: str):
     # Get updated information
     new_data = await asyncio.to_thread(lambda: {
         "stat_upgrades": _get_player_stat_upgrades(pid),
-        "upgrade_points": _get_player_upgrade_points(pid) if pid == "player" else None
+        "upgrade_points": _get_player_upgrade_points(pid),
     })
 
     return jsonify({
@@ -603,9 +573,7 @@ async def upgrade_player(pid: str):
 
 @bp.post("/players/<pid>/upgrade-stat")
 async def upgrade_player_stat(pid: str):
-    """Spend upgrade points on a specific stat (player character only)."""
-    if pid != "player":
-        return jsonify({"error": "stat upgrades only available for player character"}), 400
+    """Spend upgrade points on a specific stat."""
 
     data = await request.get_json(silent=True) or {}
     stat_name = data.get("stat_name")

--- a/backend/tests/test_player_editor.py
+++ b/backend/tests/test_player_editor.py
@@ -35,6 +35,8 @@ async def test_player_editor_update_and_fetch(app_with_db):
             "hp": 10,
             "attack": 20,
             "defense": 30,
+            "crit_rate": 15,
+            "crit_damage": 5,
         },
     )
     assert resp.status_code == 200
@@ -47,6 +49,8 @@ async def test_player_editor_update_and_fetch(app_with_db):
         "hp": 10,
         "attack": 20,
         "defense": 30,
+        "crit_rate": 15,
+        "crit_damage": 5,
     }
 
     stats_resp = await client.get("/player/stats")
@@ -57,6 +61,8 @@ async def test_player_editor_update_and_fetch(app_with_db):
     assert core["hp"] == 1100 and core["max_hp"] == 1100
     assert offense["atk"] == 120
     assert defense_block["defense"] == 65
+    assert offense["crit_rate"] == pytest.approx(0.0575, rel=1e-3)
+    assert offense["crit_damage"] == pytest.approx(2.1, rel=1e-3)
 
     conn = sqlcipher3.connect(db_path)
     conn.execute("PRAGMA key = 'testkey'")
@@ -77,6 +83,8 @@ async def test_player_editor_validation(app_with_db):
             "hp": 200,
             "attack": 0,
             "defense": 0,
+            "crit_rate": 0,
+            "crit_damage": 0,
         },
     )
     assert resp.status_code == 400
@@ -95,6 +103,8 @@ async def test_player_editor_snapshot_during_run(app_with_db):
             "hp": 10,
             "attack": 0,
             "defense": 0,
+            "crit_rate": 0,
+            "crit_damage": 0,
         },
     )
     resp = await client.post("/run/start", json={"party": ["player"]})
@@ -108,6 +118,8 @@ async def test_player_editor_snapshot_during_run(app_with_db):
             "hp": 0,
             "attack": 20,
             "defense": 0,
+            "crit_rate": 0,
+            "crit_damage": 0,
         },
     )
     assert resp2.status_code == 200

--- a/backend/tests/test_player_editor_backend.py
+++ b/backend/tests/test_player_editor_backend.py
@@ -77,9 +77,11 @@ def test_player_editor_endpoints(base_url: str):
     test_settings = {
         "pronouns": "they",
         "damage_type": "Fire",
-        "hp": 60,
+        "hp": 50,
         "attack": 20,
-        "defense": 20
+        "defense": 20,
+        "crit_rate": 5,
+        "crit_damage": 5,
     }
     status, data = make_request(f"{base_url}/player/editor", "PUT", test_settings)
     print(f"   PUT /player/editor -> Status: {status}")
@@ -97,7 +99,7 @@ def test_player_editor_endpoints(base_url: str):
     if status == 200:
         print(f"   Saved settings: {data}")
         # Check if the settings match what we sent
-        for key in ["hp", "attack", "defense"]:
+        for key in ["hp", "attack", "defense", "crit_rate", "crit_damage"]:
             if data.get(key) != test_settings[key]:
                 print(f"   WARNING: {key} mismatch! Expected {test_settings[key]}, got {data.get(key)}")
     else:
@@ -114,13 +116,15 @@ def test_player_editor_endpoints(base_url: str):
         defense_stats = data.get("stats", {}).get("defense", {})
 
         print(f"   Core stats: HP={core.get('hp')}, Max HP={core.get('max_hp')}")
-        print(f"   Offense stats: ATK={offense.get('atk')}")
+        print(f"   Offense stats: ATK={offense.get('atk')}, CRIT Rate={offense.get('crit_rate')}, CRIT DMG={offense.get('crit_damage')}")
         print(f"   Defense stats: DEF={defense_stats.get('defense')}")
 
         # Calculate expected values
-        expected_max_hp = int(1000 * 1.6)  # 60% boost
+        expected_max_hp = int(1000 * 1.5)  # 50% boost
         expected_atk = int(100 * 1.2)      # 20% boost
         expected_def = int(50 * 1.2)       # 20% boost
+        expected_cr = 0.05 * 1.05
+        expected_cd = 2.0 * 1.05
 
         print("\n   Expected values:")
         print(f"   Max HP: {expected_max_hp} (got {core.get('max_hp')})")
@@ -142,6 +146,16 @@ def test_player_editor_endpoints(base_url: str):
             print("   ✓ DEF is correct!")
         else:
             print("   ✗ DEF mismatch - customization may not be applied")
+
+        if abs(offense.get('crit_rate', 0) - expected_cr) < 1e-6:
+            print("   ✓ CRIT Rate is correct!")
+        else:
+            print("   ✗ CRIT Rate mismatch")
+
+        if abs(offense.get('crit_damage', 0) - expected_cd) < 1e-6:
+            print("   ✓ CRIT DMG is correct!")
+        else:
+            print("   ✗ CRIT DMG mismatch")
 
     else:
         print(f"   Error: {data}")

--- a/backend/tests/test_player_stats_persistence.py
+++ b/backend/tests/test_player_stats_persistence.py
@@ -27,7 +27,15 @@ async def test_player_stats_persist_between_battles(app_with_db):
 
     await client.put(
         "/player/editor",
-        json={"pronouns": "they", "damage_type": "Fire", "hp": 10, "attack": 20, "defense": 30},
+        json={
+            "pronouns": "they",
+            "damage_type": "Fire",
+            "hp": 10,
+            "attack": 20,
+            "defense": 30,
+            "crit_rate": 10,
+            "crit_damage": 5,
+        },
     )
     resp = await client.post("/run/start", json={"party": ["player"]})
     run_id = (await resp.get_json())["run_id"]

--- a/frontend/src/lib/components/OverlayHost.svelte
+++ b/frontend/src/lib/components/OverlayHost.svelte
@@ -13,7 +13,7 @@
   import CraftingMenu from './CraftingMenu.svelte';
   import BattleReview from './BattleReview.svelte';
   import RewardOverlay from './RewardOverlay.svelte';
-  import PlayerEditor from './PlayerEditor.svelte';
+  import CharacterEditor from './CharacterEditor.svelte';
   import InventoryPanel from './InventoryPanel.svelte';
   import SettingsMenu from './SettingsMenu.svelte';
   import RunChooser from './RunChooser.svelte';
@@ -223,7 +223,7 @@
 
 {#if $overlayView === 'editor'}
   <OverlaySurface zIndex={1300}>
-    <PlayerEditor
+    <CharacterEditor
       {...editorState}
       on:close={() => dispatch('back')}
       on:save={(e) => { dispatch('editorSave', e.detail); dispatch('back'); }}

--- a/frontend/src/lib/index.js
+++ b/frontend/src/lib/index.js
@@ -1,7 +1,7 @@
 // place files you want to import through the `$lib` alias in this folder.
 
 export { default as PartyPicker } from './components/PartyPicker.svelte';
-export { default as PlayerEditor } from './components/PlayerEditor.svelte';
+export { default as CharacterEditor } from './components/CharacterEditor.svelte';
 export { default as InventoryPanel } from './components/InventoryPanel.svelte';
 export { default as RoomView } from './components/RoomView.svelte';
 export { default as OverlaySurface } from './components/OverlaySurface.svelte';

--- a/frontend/src/lib/systems/api.js
+++ b/frontend/src/lib/systems/api.js
@@ -110,6 +110,7 @@ export async function craftItems() {
   });
 }
 
+// Player customization (pronouns, damage_type, hp, attack, defense, crit_rate, crit_damage)
 export async function getPlayerConfig() {
   return handleFetch(`/player/editor`, { cache: 'no-store' });
 }
@@ -201,9 +202,9 @@ export async function upgradeCharacter(id, starLevel, itemCount = 1) {
   });
 }
 
-// Spend player upgrade points on a specific stat (player only)
-export async function upgradePlayerStat(points, statName = 'atk') {
-  return handleFetch(`/players/player/upgrade-stat`, {
+// Spend upgrade points on a specific stat for the given character
+export async function upgradeStat(id, points, statName = 'atk') {
+  return handleFetch(`/players/${id}/upgrade-stat`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ points, stat_name: statName })

--- a/frontend/tests/api.test.js
+++ b/frontend/tests/api.test.js
@@ -8,11 +8,12 @@ import {
   setAutoCraft,
   getUpgrade,
   upgradeCharacter,
+  upgradeStat,
   wipeData,
   getLrmConfig,
   setLrmModel,
   testLrmModel
-} from '../src/lib/api.js';
+} from '../src/lib/systems/api.js';
 import {
   startRun,
   updateParty,
@@ -157,5 +158,11 @@ describe('api calls', () => {
     global.fetch = createFetch({ level: 1, items: {} });
     const result = await upgradeCharacter('player');
     expect(result).toEqual({ level: 1, items: {} });
+  });
+
+  test('upgradeStat spends points', async () => {
+    global.fetch = createFetch({ stat_upgraded: 'atk', points_spent: 1 });
+    const result = await upgradeStat('player', 1, 'atk');
+    expect(result).toEqual({ stat_upgraded: 'atk', points_spent: 1 });
   });
 });

--- a/frontend/tests/charactereditor.test.js
+++ b/frontend/tests/charactereditor.test.js
@@ -2,13 +2,14 @@ import { describe, expect, test } from 'bun:test';
 import { readFileSync } from 'fs';
 import { join } from 'path';
 
-describe('PlayerEditor component', () => {
+describe('CharacterEditor component', () => {
   test('contains editor fields', () => {
-    const content = readFileSync(join(import.meta.dir, '../src/lib/PlayerEditor.svelte'), 'utf8');
-    expect(content).toContain('data-testid="player-editor"');
+    const content = readFileSync(join(import.meta.dir, '../src/lib/components/CharacterEditor.svelte'), 'utf8');
+    expect(content).toContain('data-testid="character-editor"');
     expect(content).toContain('label for="pronouns"');
     expect(content).toContain('label for="damage"');
     expect(content).toContain('damageType');
-    expect(content).toContain('hp: +hp');
+    expect(content).toContain('Crit Rate');
+    expect(content).toContain('Crit Damage');
   });
 });

--- a/frontend/tests/erroroverlay.test.js
+++ b/frontend/tests/erroroverlay.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, test, mock } from 'bun:test';
-import { getPlayers } from '../src/lib/api.js';
+import { getPlayers } from '../src/lib/systems/api.js';
 import { overlayView, overlayData, homeOverlay } from '../src/lib/OverlayController.js';
 import { get } from 'svelte/store';
 import { readFileSync } from 'fs';

--- a/frontend/tests/upgradepanel.test.js
+++ b/frontend/tests/upgradepanel.test.js
@@ -7,8 +7,8 @@ describe('UpgradePanel component', () => {
     // Note: file path reflects the component location in src/lib/components
     const content = readFileSync(join(import.meta.dir, '../src/lib/components/UpgradePanel.svelte'), 'utf8');
     expect(content).toContain('data-testid="upgrade-panel"');
-    expect(content).toContain('Use items'); // section label
-    expect(content).toContain('Convert to Points'); // player flow button text
-    expect(content).toContain('Spend points'); // player stat spend UI
+    expect(content).toContain('Convert items'); // section label
+    expect(content).toContain('Convert to Points'); // unified button text
+    expect(content).toContain('Spend points'); // stat spend UI
   });
 });


### PR DESCRIPTION
## Summary
- replace PlayerEditor with reusable CharacterEditor supporting crit sliders
- embed editor for all characters and remove obsolete Effects tab
- expand player API to persist crit rate/damage settings
- convert item upgrades into shared points for all characters
- document unified upgrade panel and point flow

## Testing
- `ruff check backend frontend --fix`
- `bun run lint`
- `./run-tests.sh` *(fails: ModuleNotFoundError: No module named 'battle_logging')*
- `bun test` *(fails: 37 fail, 11 errors)*

------
https://chatgpt.com/codex/tasks/task_b_68bb40ede1b4832c8f235f693d012908