### PR TITLE
[FEAT] Refine Carly's Guardian's Aegis

### DIFF
--- a/.codex/implementation/player-foe-reference.md
+++ b/.codex/implementation/player-foe-reference.md
@@ -42,7 +42,7 @@ Passives generally shouldn't be capped unless a designer explicitly specifies a 
 - **Ally** (B, random) – applies `ally_passive` on load to grant ally-specific bonuses.
 - **Becca** (B, random) – builds high attack but takes more damage from lower defense.
 - **Bubbles** (A, random) – starts with a default item and applies `bubbles_passive`.
-- **Carly** (B, Light) – applies `carly_passive`.
+- **Carly** (B, Light) – Guardian's Aegis heals the most injured ally, converts attack growth into defense, and shares mitigation on ultimate.
 - **Chibi** (A, random) – gains four times the normal benefit from Vitality.
 - **Graygray** (B, random) – applies `graygray_passive`.
 - **Hilander** (A, random) – builds increased crit rate and crit damage.

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,54 @@
+name: "Copilot Setup Steps"
+
+# Automatically run the setup steps when they are changed to allow for easy validation, and
+# allow manual testing through the repository's "Actions" tab
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+  pull_request:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+
+jobs:
+  # The job MUST be called `copilot-setup-steps` or it will not be picked up by Copilot.
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+
+    # Set the permissions to the lowest permissions possible needed for your steps.
+    # Copilot will be given its own token for its operations.
+    permissions:
+      # If you want to clone the repository as part of your setup steps, for example to install dependencies, you'll need the `contents: read` permission. If you don't clone the repository in your setup steps, Copilot will do this for you automatically after the steps complete.
+      contents: read
+
+    # You can define any steps you want, and they will run before the agent starts.
+    # If you do not check out your code, Copilot will do this for you.
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+      
+      - uses: astral-sh/setup-uv@v6.6.0
+        with:
+          python-version: '3.12'
+      
+      - uses: oven-sh/setup-bun@v2.0.2
+        with:
+          bun-version: latest
+        
+      - name: Set up Docker
+        uses: docker/setup-docker-action@v4
+        env:
+          LIMA_START_ARGS: --cpus 2 --memory 4
+          
+      - name: Setup backend environment
+        working-directory: backend
+        run: |
+          uv venv
+          uv sync
+        
+      - name: Setup frontend environment
+        working-directory: frontend
+        run: |
+          bun install
+          bun run build

--- a/ABOUTGAME.md
+++ b/ABOUTGAME.md
@@ -156,7 +156,7 @@ The roster in `plugins/players/` currently includes and each entry lists its `Ch
 - Ally (B, random damage type)
 - Becca (B, random damage type)
 - Bubbles (A, random damage type)
-- Carly (B, Light) – converts attack growth into defense
+- Carly (B, Light) – Guardian's Aegis heals the most injured ally, converts attack growth into defense, and shares mitigation on ultimate
 - Chibi (A, Lightning)
 - Graygray (B, random damage type)
 - Hilander (A, random damage type)

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A web-based auto-battler game featuring strategic party management, elemental combat, and character progression.
 
+### Character Update
+
+- Carly's Guardian's Aegis now heals the most injured ally, converts attack growth into defense stacks, and shares mitigation with allies on ultimate.
+
 ## Quick Start with Docker Compose (Recommended)
 
 The easiest way to run Midori AI AutoFighter is with Docker Compose. Choose one of the four variants below:

--- a/backend/plugins/passives/carly_guardians_aegis.py
+++ b/backend/plugins/passives/carly_guardians_aegis.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 from typing import ClassVar
+from typing import Optional
 
 from autofighter.stats import StatEffect
 
@@ -17,47 +18,76 @@ class CarlyGuardiansAegis:
     trigger = "turn_start"  # Triggers at start of turn for healing
     max_stacks = 50  # Soft cap - show mitigation stacks with diminished returns past 50
 
-    # Class-level tracking of mitigation stacks gained from being hit
+    # Class-level tracking of mitigation stacks and converted defense stacks
     _mitigation_stacks: ClassVar[dict[int, int]] = {}
+    _attack_baseline: ClassVar[dict[int, int]] = {}
+    _defense_stacks: ClassVar[dict[int, int]] = {}
 
-    async def apply(self, target: "Stats") -> None:
-        """Apply Carly's Guardian's Aegis healing mechanics."""
+    async def apply(self, target: "Stats", party: Optional[list["Stats"]] = None, **_: object) -> None:
+        """Apply Carly's Guardian's Aegis healing and conversion mechanics."""
         entity_id = id(target)
 
-        # Initialize mitigation stack tracking if not present
+        # Initialize tracking dictionaries
         if entity_id not in self._mitigation_stacks:
             self._mitigation_stacks[entity_id] = 0
+        if entity_id not in self._attack_baseline:
+            # Record Carly's starting base attack to measure future growth
+            self._attack_baseline[entity_id] = int(target.get_base_stat("atk"))
+        if entity_id not in self._defense_stacks:
+            self._defense_stacks[entity_id] = 0
 
-        # Heal the most injured ally each turn
-        # This would need party system integration to find allies
-        # For now, apply a small self-heal based on defense
+        # Convert any attack growth into permanent defense stacks
+        base_atk = self._attack_baseline[entity_id]
+        current_atk = int(target.get_base_stat("atk"))
+        growth = current_atk - base_atk
+        if growth > 0:
+            self._defense_stacks[entity_id] += growth
+            target.set_base_stat("atk", base_atk)
+
+            stacks = self._defense_stacks[entity_id]
+            base_defense = min(stacks, 50)
+            excess_stacks = max(0, stacks - 50)
+            defense_bonus = base_defense + excess_stacks * 0.5
+
+            defense_effect = StatEffect(
+                name=f"{self.id}_defense_stacks",
+                stat_modifiers={"defense": defense_bonus},
+                duration=-1,
+                source=self.id,
+            )
+            target.add_effect(defense_effect)
+
+        # Heal the most injured ally or self if none injured
         defense_based_heal = int(target.defense * 0.1)
+        injured: Optional["Stats"] = None
+        if party:
+            injured = min(
+                (a for a in party if a.hp < a.max_hp),
+                key=lambda a: a.hp / a.max_hp,
+                default=None,
+            )
+        recipient = injured if injured is not None else target
 
         heal_effect = StatEffect(
             name=f"{self.id}_defense_heal",
             stat_modifiers={"hp": defense_based_heal},
-            duration=1,  # One turn healing
+            duration=1,
             source=self.id,
         )
-        target.add_effect(heal_effect)
+        recipient.add_effect(heal_effect)
 
         # Apply accumulated mitigation stacks from previous hits with soft cap logic
         if self._mitigation_stacks[entity_id] > 0:
             current_stacks = self._mitigation_stacks[entity_id]
-
-            # Base mitigation from first 50 stacks (2% per stack)
             base_mitigation = min(current_stacks, 50) * 0.02
-
-            # Soft cap: stacks past 50 give reduced benefit (1% instead of 2%)
             excess_stacks = max(0, current_stacks - 50)
             excess_mitigation = excess_stacks * 0.01
-
             total_mitigation = base_mitigation + excess_mitigation
 
             mitigation_effect = StatEffect(
                 name=f"{self.id}_mitigation_stacks",
                 stat_modifiers={"mitigation": total_mitigation},
-                duration=-1,  # Permanent for rest of fight
+                duration=-1,
                 source=self.id,
             )
             target.add_effect(mitigation_effect)
@@ -96,26 +126,27 @@ class CarlyGuardiansAegis:
         )
         target.add_effect(taunt_effect)
 
-    async def on_ultimate_use(self, target: "Stats", allies: list["Stats"]) -> None:
-        """Handle ultimate ability effects - grant mitigation to allies."""
-        # Grant all allies mitigation equal to half of Carly's own
-        mitigation_to_share = target.mitigation * 0.5
+    async def on_ultimate_use(self, target: "Stats", party: list["Stats"]) -> None:
+        """Handle ultimate ability effects - distribute mitigation to allies."""
+        allies = [member for member in party if member is not target]
+        if not allies:
+            return
 
+        total_share = target.mitigation * 0.5
+        per_ally = total_share / len(allies)
         for ally in allies:
-            if ally != target:  # Don't apply to self
-                ally_mitigation_effect = StatEffect(
-                    name=f"{self.id}_shared_mitigation",
-                    stat_modifiers={"mitigation": mitigation_to_share},
-                    duration=3,  # Three turns
-                    source=self.id,
-                )
-                ally.add_effect(ally_mitigation_effect)
+            ally_mitigation_effect = StatEffect(
+                name=f"{self.id}_shared_mitigation",
+                stat_modifiers={"mitigation": per_ally},
+                duration=3,
+                source=self.id,
+            )
+            ally.add_effect(ally_mitigation_effect)
 
-        # Reduce Carly's mitigation by the same amount
         mitigation_reduction_effect = StatEffect(
             name=f"{self.id}_mitigation_reduction",
-            stat_modifiers={"mitigation": -mitigation_to_share},
-            duration=3,  # Three turns
+            stat_modifiers={"mitigation": -total_share},
+            duration=3,
             source=self.id,
         )
         target.add_effect(mitigation_reduction_effect)

--- a/backend/tests/test_carly_guardians_aegis.py
+++ b/backend/tests/test_carly_guardians_aegis.py
@@ -1,0 +1,64 @@
+import pytest
+
+from autofighter.passives import PassiveRegistry
+from autofighter.stats import Stats
+from plugins.passives.carly_guardians_aegis import CarlyGuardiansAegis
+
+
+@pytest.mark.asyncio
+async def test_heals_most_injured_ally():
+    registry = PassiveRegistry()
+    carly = Stats()
+    ally_low = Stats()
+    ally_high = Stats()
+    ally_low.hp = 400
+    ally_high.hp = 700
+    party = [carly, ally_low, ally_high]
+    carly.passives = ["carly_guardians_aegis"]
+
+    await registry.trigger_turn_start(carly, party=party, turn=1)
+
+    heal_effects_low = [e for e in ally_low.get_active_effects() if e.name == "carly_guardians_aegis_defense_heal"]
+    heal_effects_high = [e for e in ally_high.get_active_effects() if e.name == "carly_guardians_aegis_defense_heal"]
+    assert heal_effects_low
+    assert not heal_effects_high
+
+
+@pytest.mark.asyncio
+async def test_attack_growth_converts_to_defense_stacks():
+    registry = PassiveRegistry()
+    carly = Stats()
+    carly.passives = ["carly_guardians_aegis"]
+    baseline = carly.get_base_stat("atk")
+
+    # Trigger once to record baseline
+    await registry.trigger_turn_start(carly, party=[carly], turn=1)
+
+    carly.modify_base_stat("atk", 100)  # growth of 100
+
+    await registry.trigger_turn_start(carly, party=[carly], turn=2)
+
+    assert carly.get_base_stat("atk") == baseline
+    defense_effects = [e for e in carly.get_active_effects() if e.name == "carly_guardians_aegis_defense_stacks"]
+    assert defense_effects
+    assert defense_effects[0].stat_modifiers["defense"] == 75
+
+
+@pytest.mark.asyncio
+async def test_ultimate_distributes_mitigation():
+    carly = Stats()
+    ally1 = Stats()
+    ally2 = Stats()
+    party = [carly, ally1, ally2]
+    passive = CarlyGuardiansAegis()
+
+    await passive.on_ultimate_use(carly, party)
+
+    for ally in (ally1, ally2):
+        effects = [e for e in ally.get_active_effects() if e.name == "carly_guardians_aegis_shared_mitigation"]
+        assert effects
+        assert effects[0].stat_modifiers["mitigation"] == pytest.approx(0.25)
+
+    reduction = [e for e in carly.get_active_effects() if e.name == "carly_guardians_aegis_mitigation_reduction"]
+    assert reduction
+    assert reduction[0].stat_modifiers["mitigation"] == pytest.approx(-0.5)


### PR DESCRIPTION
## Summary
- Heal the most injured ally and convert Carly's attack growth into defense stacks
- Share mitigation among allies on ultimate use
- Document Carly's updated Guardian's Aegis

## Testing
- `ruff check . --fix` *(fails: Module level import not at top of file, trailing whitespace in prototypes)*
- `ruff check backend/plugins/passives/carly_guardians_aegis.py backend/tests/test_carly_guardians_aegis.py --fix`
- `cd backend && uv run pytest tests/test_carly_guardians_aegis.py tests/test_passive_stacks.py::test_carly_guardian_stack_display -q`

------
https://chatgpt.com/codex/tasks/task_b_68bdce81f064832cbc26e41d8ed728f7