### PR TITLE
[FIX] handle attacker info for Graygray counter

### DIFF
--- a/.codex/implementation/player-foe-reference.md
+++ b/.codex/implementation/player-foe-reference.md
@@ -44,7 +44,7 @@ Passives generally shouldn't be capped unless a designer explicitly specifies a 
 - **Bubbles** (A, random) – starts with a default item and applies `bubbles_passive`.
 - **Carly** (B, Light) – applies `carly_passive`.
 - **Chibi** (A, random) – gains four times the normal benefit from Vitality.
-- **Graygray** (B, random) – applies `graygray_passive`.
+- **Graygray** (B, random) – applies `graygray_counter_maestro`, counterattacking when hit.
 - **Hilander** (A, random) – builds increased crit rate and crit damage.
 - **Kboshi** (A, random) – randomly changes damage type; failed switches grant stacking bonuses.
 - **Lady Darkness** (B, Dark) – baseline fighter themed around darkness.

--- a/ABOUTGAME.md
+++ b/ABOUTGAME.md
@@ -158,7 +158,7 @@ The roster in `plugins/players/` currently includes and each entry lists its `Ch
 - Bubbles (A, random damage type)
 - Carly (B, Light) – converts attack growth into defense
 - Chibi (A, Lightning)
-- Graygray (B, random damage type)
+- Graygray (B, random damage type) – retaliates with Counter Maestro after taking damage
 - Hilander (A, random damage type)
 - Kboshi (A, random damage type)
 - Lady Darkness (B, Dark)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Midori AI AutoFighter
 
-A web-based auto-battler game featuring strategic party management, elemental combat, and character progression.
+A web-based auto-battler game featuring strategic party management, elemental combat, and character progression. Characters like Graygray now react to incoming attacks with passives such as Counter Maestro.
 
 ## Quick Start with Docker Compose (Recommended)
 

--- a/backend/autofighter/passives.py
+++ b/backend/autofighter/passives.py
@@ -74,19 +74,11 @@ class PassiveRegistry:
 
             # Also trigger passives with explicit damage_taken trigger
             if getattr(cls, "trigger", None) == "damage_taken":
-                # Special handling for counter-attack passives
-                if hasattr(passive_instance, "counter_attack") and attacker is not None:
-                    stacks = min(count, getattr(cls, "max_stacks", count))
-                    for _ in range(stacks):
-                        await passive_instance.counter_attack(target, attacker, damage)
-
-                # Regular passive application with enhanced context
                 stacks = min(count, getattr(cls, "max_stacks", count))
                 for _ in range(stacks):
                     try:
                         await passive_instance.apply(target, attacker=attacker, damage=damage)
                     except TypeError:
-                        # Fall back to simple apply for existing passives
                         await passive_instance.apply(target)
 
     async def trigger_turn_end(self, target) -> None:

--- a/backend/plugins/passives/graygray_counter_maestro.py
+++ b/backend/plugins/passives/graygray_counter_maestro.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 from typing import ClassVar
+from typing import Optional
 
 from autofighter.stats import StatEffect
 
@@ -20,19 +21,18 @@ class GraygrayCounterMaestro:
     # Track successful counter attacks for +5% attack stacks
     _counter_stacks: ClassVar[dict[int, int]] = {}
 
-    async def apply(self, target: "Stats") -> None:
-        """Apply counter-attack mechanics for Graygray."""
+    async def apply(
+        self,
+        target: "Stats",
+        attacker: Optional["Stats"] = None,
+        damage: int = 0,
+    ) -> None:
+        """Apply counter-attack mechanics for Graygray and retaliate."""
         entity_id = id(target)
 
         # Initialize counter stack tracking if not present
         if entity_id not in self._counter_stacks:
             self._counter_stacks[entity_id] = 0
-
-        # This will be called when Graygray takes damage
-        # We need the attacker info, which should be passed via the event system
-
-        # For now, implement the core mechanic - we'll need to extend this
-        # when we have proper damage event handling
 
         # Increment counter stacks (each successful counter grants attack bonus)
         self._counter_stacks[entity_id] += 1
@@ -63,6 +63,10 @@ class GraygrayCounterMaestro:
             source=self.id,
         )
         target.add_effect(mitigation_buff)
+
+        # Retaliate after applying buffs
+        if attacker is not None:
+            await self.counter_attack(target, attacker, damage)
 
     async def counter_attack(self, defender: "Stats", attacker: "Stats", damage_received: int) -> None:
         """Perform the actual counter attack."""

--- a/backend/plugins/passives/lady_of_fire_infernal_momentum.py
+++ b/backend/plugins/passives/lady_of_fire_infernal_momentum.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
+from typing import Optional
 
 from autofighter.stats import StatEffect
 
@@ -16,7 +17,12 @@ class LadyOfFireInfernalMomentum:
     trigger = "damage_taken"  # Triggers when Lady of Fire takes damage
     max_stacks = 1  # Only one instance per character
 
-    async def apply(self, target: "Stats") -> None:
+    async def apply(
+        self,
+        target: "Stats",
+        attacker: Optional["Stats"] = None,
+        damage: int = 0,
+    ) -> None:
         """Apply Lady of Fire's Infernal Momentum mechanics."""
         # Double the Fire damage type's missing HP damage bonus
         # This would need integration with the Fire damage type system
@@ -31,6 +37,9 @@ class LadyOfFireInfernalMomentum:
             source=self.id,
         )
         target.add_effect(fire_bonus_effect)
+
+        if attacker is not None:
+            await self.counter_attack(target, attacker, damage)
 
     async def counter_attack(self, target: "Stats", attacker: "Stats", damage: int) -> None:
         """Apply burn DoT to attacker when Lady of Fire takes damage."""


### PR DESCRIPTION
## Summary
- ensure Graygray's Counter Maestro receives attacker and damage values and retaliates after buffing
- pass attacker info through damage_taken registry events
- document Graygray's Counter Maestro in player references and README

## Testing
- `uv tool run ruff check backend --fix`
- `./run-tests.sh` *(fails: Cannot find module '$app/environment' etc.)*

------
https://chatgpt.com/codex/tasks/task_b_68bdce911f90832c84579e35d7621524