### PR TITLE
[FIX] handle defeat snapshots without ended

### DIFF
--- a/backend/.codex/implementation/battle-defeat.md
+++ b/backend/.codex/implementation/battle-defeat.md
@@ -1,3 +1,3 @@
 # Battle defeat handling
 
-`BattleRoom.resolve` reports a `"defeat"` result when all party members have zero or less HP. `_run_battle` checks for this outcome, clears pending state flags, saves the final snapshot with `ended: true`, and removes the run from storage.
+`BattleRoom.resolve` reports a `"defeat"` result when all party members have zero or less HP and includes `ended: true` in the snapshot. `_run_battle` checks for this outcome, clears pending state flags, saves the final snapshot, and removes the run from storage.

--- a/backend/autofighter/rooms/battle.py
+++ b/backend/autofighter/rooms/battle.py
@@ -743,7 +743,8 @@ class BattleRoom(Room):
                 "room_number": self.node.index,
                 "exp_reward": exp_reward,
                 "enrage": {"active": enrage_active, "stacks": enrage_stacks, "turns": enrage_stacks},
-                        "rdr": temp_rdr,
+                "rdr": temp_rdr,
+                "ended": True,
             }
         # Pick cards with per-item star rolls; ensure unique choices not already owned
         selected_cards: list = []

--- a/backend/tests/test_battle_defeat.py
+++ b/backend/tests/test_battle_defeat.py
@@ -21,6 +21,7 @@ async def test_battle_resolve_reports_defeat():
     foe.id = "dummy"
     result = await room.resolve(party, {}, foe=foe)
     assert result["result"] == "defeat"
+    assert result["ended"] is True
 
 
 @pytest.fixture()
@@ -46,7 +47,7 @@ async def test_run_battle_handles_defeat_cleanup(app_with_db, monkeypatch):
     client = app.test_client()
 
     async def fake_resolve(self, party, data, progress, foe=None):
-        return {"result": "defeat"}
+        return {"result": "defeat", "ended": True}
 
     monkeypatch.setattr(BattleRoom, "resolve", fake_resolve)
 

--- a/backend/tests/test_battle_rewards.py
+++ b/backend/tests/test_battle_rewards.py
@@ -81,6 +81,7 @@ async def test_battle_rewards_defeat(app_with_db, monkeypatch):
             "exp_reward": 0,
             "enrage": {"active": False, "stacks": 0},
             "rdr": party.rdr,
+            "ended": True,
         }
 
     monkeypatch.setattr(BattleRoom, "resolve", fake_resolve)

--- a/frontend/.codex/implementation/battle-polling.md
+++ b/frontend/.codex/implementation/battle-polling.md
@@ -9,6 +9,10 @@ snapshot, and logs a warning so the reward overlay or reset flow can proceed.
 If a snapshot includes an `error` field, polling halts immediately and the
 error state is surfaced without waiting for combat-over indicators.
 
+Snapshots reporting `result: 'defeat'` are treated as complete even if an
+`ended` flag is missing. The poller stops immediately and the defeat overlay
+is shown.
+
 Network failures now cause `handleRunEnd` when the backend reports the run has
 ended. `pollBattle` watches for thrown errors whose message contains
 "run ended" or whose status code is `404` and stops polling without queuing

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -500,7 +500,7 @@
         return;
       }
       const snapHasRewards = hasRewards(snap);
-      const snapCompleted = Boolean(snap?.awaiting_next) || Boolean(snap?.next_room) || (snap?.ended && snap?.result === 'defeat');
+      const snapCompleted = Boolean(snap?.awaiting_next) || Boolean(snap?.next_room) || snap?.result === 'defeat';
       const partyDead = Array.isArray(snap?.party) && snap.party.length > 0 && snap.party.every(m => (m?.hp ?? 1) <= 0);
       const foesDead = Array.isArray(snap?.foes) && snap.foes.length > 0 && snap.foes.every(f => (f?.hp ?? 1) <= 0);
       const combatOver = partyDead || foesDead;
@@ -518,12 +518,12 @@
           stalledTicks = 0;
           
           // Start state polling when battle ends (unless defeated)
-          if (!(snap?.ended && snap?.result === 'defeat')) {
+          if (snap?.result !== 'defeat') {
             startStatePoll();
           }
-          
+
           // If run ended in defeat, immediately return home and show defeat popup
-          if (snap?.ended && snap?.result === 'defeat') {
+          if (snap?.result === 'defeat') {
             handleDefeat();
           }
           // Auto-advance if awaiting_next without any reward choices or loot present
@@ -671,7 +671,7 @@
         return;
       }
       // If this response indicates a defeated run, stop syncing and show popup.
-      if (data?.ended && data?.result === 'defeat') {
+      if (data?.result === 'defeat') {
         handleDefeat();
         return;
       }

--- a/frontend/tests/battlepolling.test.js
+++ b/frontend/tests/battlepolling.test.js
@@ -94,4 +94,14 @@ describe('battle polling', () => {
     expect(cleared).toBe(true);
     expect(setTimeoutCalled).toBe(false);
   });
+
+  test('defeat snapshot triggers defeat overlay and stops polling', () => {
+    const content = readFileSync(
+      join(import.meta.dir, '../src/routes/+page.svelte'),
+      'utf8'
+    );
+    expect(content).toContain("snap?.result === 'defeat'");
+    expect(content).toMatch(/battleActive = false;\n\s+stopBattlePoll\(\);/);
+    expect(content).toMatch(/if \(snap\?\.result === 'defeat'\) {\n\s+handleDefeat\(\);\n\s+}/);
+  });
 });


### PR DESCRIPTION
## Summary
- stop battle polling when snapshot result is `defeat` even without an `ended` flag
- trigger defeat overlay whenever snapshot result is `defeat`
- document defeat snapshots and add a regression test
- mark backend defeat snapshots with `ended: True` and update related tests

## Testing
- `uv run ruff check backend/autofighter/rooms/battle.py backend/tests/test_battle_defeat.py backend/tests/test_battle_rewards.py --fix`
- `PYTHONPATH=backend uv run pytest backend/tests/test_battle_defeat.py backend/tests/test_battle_rewards.py` *(fails: 404 Not Found and KeyError)*
- `bun run lint`
- `bun test tests/battlepolling.test.js` *(fails: Cannot find module '$app/environment')*


------
https://chatgpt.com/codex/tasks/task_b_68bdcebcca1c832c944cb851580af202