### PR TITLE
[FEAT] enable Bubble Burst area damage

### DIFF
--- a/.codex/implementation/player-foe-reference.md
+++ b/.codex/implementation/player-foe-reference.md
@@ -41,7 +41,8 @@ Passives generally shouldn't be capped unless a designer explicitly specifies a 
 
 - **Ally** (B, random) – applies `ally_passive` on load to grant ally-specific bonuses.
 - **Becca** (B, random) – builds high attack but takes more damage from lower defense.
-- **Bubbles** (A, random) – starts with a default item and applies `bubbles_passive`.
+- **Bubbles** (A, random) – starts with a default item and applies `bubbles_bubble_burst`,
+  switching elements each turn and bursting after three hits per foe.
 - **Carly** (B, Light) – applies `carly_passive`.
 - **Chibi** (A, random) – gains four times the normal benefit from Vitality.
 - **Graygray** (B, random) – applies `graygray_passive`.

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,54 @@
+name: "Copilot Setup Steps"
+
+# Automatically run the setup steps when they are changed to allow for easy validation, and
+# allow manual testing through the repository's "Actions" tab
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+  pull_request:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+
+jobs:
+  # The job MUST be called `copilot-setup-steps` or it will not be picked up by Copilot.
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+
+    # Set the permissions to the lowest permissions possible needed for your steps.
+    # Copilot will be given its own token for its operations.
+    permissions:
+      # If you want to clone the repository as part of your setup steps, for example to install dependencies, you'll need the `contents: read` permission. If you don't clone the repository in your setup steps, Copilot will do this for you automatically after the steps complete.
+      contents: read
+
+    # You can define any steps you want, and they will run before the agent starts.
+    # If you do not check out your code, Copilot will do this for you.
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+      
+      - uses: astral-sh/setup-uv@v6.6.0
+        with:
+          python-version: '3.12'
+      
+      - uses: oven-sh/setup-bun@v2.0.2
+        with:
+          bun-version: latest
+        
+      - name: Set up Docker
+        uses: docker/setup-docker-action@v4
+        env:
+          LIMA_START_ARGS: --cpus 2 --memory 4
+          
+      - name: Setup backend environment
+        working-directory: backend
+        run: |
+          uv venv
+          uv sync
+        
+      - name: Setup frontend environment
+        working-directory: frontend
+        run: |
+          bun install
+          bun run build

--- a/backend/tests/test_bubbles_bubble_burst_logic.py
+++ b/backend/tests/test_bubbles_bubble_burst_logic.py
@@ -1,0 +1,52 @@
+import pytest
+
+from autofighter.effects import EffectManager
+from autofighter.passives import PassiveRegistry
+from autofighter.stats import Stats
+from autofighter.stats import set_battle_active
+from plugins.damage_types import ALL_DAMAGE_TYPES
+from plugins.damage_types import load_damage_type
+from plugins.damage_types.generic import Generic
+from plugins.passives.bubbles_bubble_burst import BubblesBubbleBurst
+
+
+@pytest.mark.asyncio
+async def test_bubbles_random_damage_type():
+    registry = PassiveRegistry()
+    bubbles = Stats(hp=1000, damage_type=Generic())
+    bubbles.passives = ["bubbles_bubble_burst"]
+    await registry.trigger("turn_start", bubbles)
+    assert bubbles.damage_type.id in ALL_DAMAGE_TYPES
+
+
+@pytest.mark.asyncio
+async def test_bubble_burst_stacks_and_dot():
+    set_battle_active(True)
+    try:
+        bubbles = Stats(hp=1000, atk=100, damage_type=load_damage_type("Fire"))
+        ally = Stats(hp=1000, damage_type=Generic())
+        enemy1 = Stats(hp=1000, damage_type=Generic())
+        enemy2 = Stats(hp=1000, damage_type=Generic())
+        enemy1.effect_manager = EffectManager(enemy1)
+        enemy2.effect_manager = EffectManager(enemy2)
+        bubbles.allies = [bubbles, ally]
+        bubbles.enemies = [enemy1, enemy2]
+
+        passive = BubblesBubbleBurst()
+        for _ in range(2):
+            await passive.on_hit_enemy(bubbles, enemy1)
+        await passive.on_hit_enemy(bubbles, enemy2)
+        assert BubblesBubbleBurst.get_bubble_stacks(bubbles, enemy1) == 2
+        assert BubblesBubbleBurst.get_bubble_stacks(bubbles, enemy2) == 1
+
+        await passive.on_hit_enemy(bubbles, enemy1)
+        assert BubblesBubbleBurst.get_bubble_stacks(bubbles, enemy1) == 0
+        assert BubblesBubbleBurst.get_bubble_stacks(bubbles, enemy2) == 1
+        assert bubbles.hp < 1000
+        assert ally.hp < 1000
+        assert enemy1.hp < 1000
+        assert enemy2.hp < 1000
+        assert enemy1.effect_manager.dots
+        assert enemy2.effect_manager.dots
+    finally:
+        set_battle_active(False)


### PR DESCRIPTION
## Summary
- Randomize Bubbles' damage type each turn and apply AoE Bubble Burst damage with DoT
- Document Bubbles' Bubble Burst passive in player roster
- Remove extraneous Bubble Burst reference from README
- Test Bubble Burst stack tracking, AoE damage, and DoT application

## Testing
- `uv tool run ruff check backend --fix`
- `./run-tests.sh` *(fails: numerous backend tests and missing modules)*

------
https://chatgpt.com/codex/tasks/task_b_68bdcea3d070832c997eed7772a7880b