### PR TITLE
[FIX] Apply real healing in Carly's Aegis

### DIFF
--- a/backend/plugins/passives/carly_guardians_aegis.py
+++ b/backend/plugins/passives/carly_guardians_aegis.py
@@ -68,6 +68,8 @@ class CarlyGuardiansAegis:
             )
         recipient = injured if injured is not None else target
 
+        await recipient.apply_healing(defense_based_heal, healer=target)
+
         heal_effect = StatEffect(
             name=f"{self.id}_defense_heal",
             stat_modifiers={"hp": defense_based_heal},

--- a/backend/tests/test_carly_guardians_aegis.py
+++ b/backend/tests/test_carly_guardians_aegis.py
@@ -22,6 +22,8 @@ async def test_heals_most_injured_ally():
     heal_effects_high = [e for e in ally_high.get_active_effects() if e.name == "carly_guardians_aegis_defense_heal"]
     assert heal_effects_low
     assert not heal_effects_high
+    expected_heal = int(carly.defense * 0.1)
+    assert ally_low.hp == 400 + expected_heal
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- heal the chosen ally by calling `Stats.apply_healing`
- assert healed ally gains HP in Guardian's Aegis tests

## Testing
- `ruff check backend/plugins/passives/carly_guardians_aegis.py backend/tests/test_carly_guardians_aegis.py --fix`
- `cd backend && uv run pytest tests/test_carly_guardians_aegis.py tests/test_passive_stacks.py::test_carly_guardian_stack_display -q`


------
https://chatgpt.com/codex/tasks/task_b_68bdd7d5f108832cb611e2cf709f9260