### PR TITLE
[FIX] Avoid duplicate ultimate consumption in Fire

### DIFF
--- a/backend/plugins/damage_types/fire.py
+++ b/backend/plugins/damage_types/fire.py
@@ -36,8 +36,7 @@ class Fire(DamageTypeBase):
         return dmg
 
     async def ultimate(self, actor: Stats, allies: list[Stats], enemies: list[Stats]) -> bool:
-        if not getattr(actor, "use_ultimate", lambda: False)():
-            return False
+        await super().ultimate(actor, allies, enemies)
         base = getattr(actor, "atk", 0)
         living = [foe for foe in enemies if getattr(foe, "hp", 0) > 0]
         if base <= 0 or not living:


### PR DESCRIPTION
## Summary
- prevent Fire ultimate from re-consuming charge so AoE burn executes

## Testing
- `uv run ruff check backend/plugins/damage_types/fire.py --fix`
- `./run-tests.sh` *(fails: Cannot find module '$app/environment' from 'frontend/src/lib/systems/backendDiscovery.js'; ENOENT open 'frontend/src/lib/assets/cards/gray/bg_attack_default_gray.png'; plus missing Svelte files)*

------
https://chatgpt.com/codex/tasks/task_b_68bdd7a75b34832c8d9cfb1265f4d04e