### PR TITLE
[FEATURE] Add Counter Maestro burst damage

### DIFF
--- a/.codex/implementation/player-foe-reference.md
+++ b/.codex/implementation/player-foe-reference.md
@@ -44,7 +44,7 @@ Passives generally shouldn't be capped unless a designer explicitly specifies a 
 - **Bubbles** (A, random) – starts with a default item and applies `bubbles_bubble_burst`, switching elements each turn and bursting after three hits per foe.
 - **Carly** (B, Light) – Guardian's Aegis heals the most injured ally, converts attack growth into defense, and shares mitigation on ultimate.
 - **Chibi** (A, random) – gains four times the normal benefit from Vitality.
-- **Graygray** (B, random) – applies `graygray_counter_maestro`, counterattacking when hit.
+- **Graygray** (B, random) – applies `graygray_counter_maestro`, counterattacking when hit and unleashing a max-HP burst every 50 stacks.
 - **Hilander** (A, random) – builds increased crit rate and crit damage.
 - **Kboshi** (A, random) – randomly changes damage type; failed switches grant stacking bonuses.
 - **Lady Darkness** (B, Dark) – baseline fighter themed around darkness.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Midori AI AutoFighter
 
-A web-based auto-battler game featuring strategic party management, elemental combat, and character progression. Characters like Graygray now react to incoming attacks with passives such as Counter Maestro.
+A web-based auto-battler game featuring strategic party management, elemental combat, and character progression. Characters like Graygray now react to incoming attacks with passives such as Counter Maestro, building counter stacks and unleashing a max-HP burst every 50 hits.
 
 ### Character Update
 

--- a/backend/plugins/passives/graygray_counter_maestro.py
+++ b/backend/plugins/passives/graygray_counter_maestro.py
@@ -38,6 +38,17 @@ class GraygrayCounterMaestro:
         self._counter_stacks[entity_id] += 1
         current_stacks = self._counter_stacks[entity_id]
 
+        # Unleash burst damage for every 50 stacks accumulated
+        while current_stacks >= 50 and attacker is not None:
+            self._counter_stacks[entity_id] -= 50
+            await attacker.apply_damage(
+                target.max_hp,
+                attacker=target,
+                trigger_on_hit=False,
+                action_name="Counter Maestro Burst",
+            )
+            current_stacks = self._counter_stacks[entity_id]
+
         # Apply cumulative attack buff with soft cap logic
         # First 50 stacks: +5% attack per stack
         # Stacks past 50: +2.5% attack per stack (diminished returns)

--- a/backend/tests/test_graygray_counter_maestro_burst.py
+++ b/backend/tests/test_graygray_counter_maestro_burst.py
@@ -1,0 +1,34 @@
+import pytest
+
+from autofighter.passives import PassiveRegistry
+from autofighter.stats import Stats
+from plugins.damage_types.generic import Generic
+from plugins.passives.graygray_counter_maestro import GraygrayCounterMaestro
+
+
+@pytest.mark.asyncio
+async def test_graygray_counter_maestro_burst_consumes_stacks_and_deals_max_hp():
+    registry = PassiveRegistry()
+
+    graygray = Stats(hp=1000, damage_type=Generic())
+    graygray.passives = ["graygray_counter_maestro"]
+
+    attacker = Stats(hp=1000, damage_type=Generic())
+
+    for _ in range(49):
+        await registry.trigger_damage_taken(graygray, attacker, 10)
+
+    assert GraygrayCounterMaestro.get_stacks(graygray) == 49
+    assert attacker.hp > 0
+
+    await registry.trigger_damage_taken(graygray, attacker, 10)
+
+    assert attacker.hp == 0
+    assert attacker.last_damage_taken >= graygray.max_hp
+    assert GraygrayCounterMaestro.get_stacks(graygray) == 0
+
+    attacker2 = Stats(hp=1000, damage_type=Generic())
+    for _ in range(5):
+        await registry.trigger_damage_taken(graygray, attacker2, 10)
+
+    assert GraygrayCounterMaestro.get_stacks(graygray) == 5


### PR DESCRIPTION
## Summary
- trigger Counter Maestro Burst on every 50 stacks to deal max-HP damage
- document Graygray's burst counter and update roster reference
- add tests for stack consumption and burst damage

## Testing
- `uv run ruff check . --fix`
- `./run-tests.sh` *(fail: frontend module resolution errors; backend timeouts for test_app.py, test_damage_type_persistence.py, test_new_upgrade_system.py)*

------
https://chatgpt.com/codex/tasks/task_b_68bde28973dc832cb6759eb97e3e7ea4