### PR TITLE
Improve Duality Engine element tracking

### DIFF
--- a/.codex/implementation/player-foe-reference.md
+++ b/.codex/implementation/player-foe-reference.md
@@ -49,7 +49,7 @@ Passives generally shouldn't be capped unless a designer explicitly specifies a 
 - **Kboshi** (A, random) – randomly changes damage type; failed switches grant stacking bonuses.
 - **Lady Darkness** (B, Dark) – baseline fighter themed around darkness.
 - **Lady Echo** (B, Lightning) – baseline fighter themed around echoes.
-- **Lady Fire and Ice** (B, Fire or Ice) – baseline fighter themed around fire and ice.
+- **Lady Fire and Ice** (B, Fire or Ice) – baseline fighter themed around fire and ice. Duality Engine alternates elements to build Flux and reduces foe mitigation when repeating an element.
 - **Lady Light** (B, Light) – baseline fighter themed around light.
 - **Lady of Fire** (B, Fire) – baseline fighter themed around fire.
 - **Luna** (B, Generic) – applies `luna_passive`.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A web-based auto-battler game featuring strategic party management, elemental co
 ### Character Update
 
 - Carly's Guardian's Aegis now heals the most injured ally, converts attack growth into defense stacks, and shares mitigation with allies on ultimate.
+- Lady Fire and Ice's Duality Engine now tracks current damage type and lowers foe mitigation when repeating an element.
 
 ## Quick Start with Docker Compose (Recommended)
 

--- a/backend/plugins/passives/lady_fire_and_ice_duality_engine.py
+++ b/backend/plugins/passives/lady_fire_and_ice_duality_engine.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 from typing import ClassVar
+from typing import Iterable
 
 from autofighter.stats import StatEffect
 
@@ -21,7 +22,12 @@ class LadyFireAndIceDualityEngine:
     _last_element: ClassVar[dict[int, str]] = {}
     _flux_stacks: ClassVar[dict[int, int]] = {}
 
-    async def apply(self, target: "Stats") -> None:
+    async def apply(
+        self,
+        target: "Stats",
+        *,
+        foes: Iterable["Stats"] | None = None,
+    ) -> None:
         """Apply Lady Fire and Ice's duality mechanics."""
         entity_id = id(target)
 
@@ -30,8 +36,7 @@ class LadyFireAndIceDualityEngine:
             self._last_element[entity_id] = None
             self._flux_stacks[entity_id] = 0
 
-        # Determine current element (would need damage type integration)
-        # For now, assume we can detect if this is fire or ice
+        # Determine current element from the damage type
         current_element = self._determine_current_element(target)
 
         # Check if alternating or using same element twice
@@ -41,17 +46,19 @@ class LadyFireAndIceDualityEngine:
                 await self._gain_flux_stack(target)
             else:
                 # Same element twice - consume all stacks for effects
-                await self._consume_flux_stacks(target)
+                await self._consume_flux_stacks(target, foes)
 
         # Update last element used
         self._last_element[entity_id] = current_element
 
     def _determine_current_element(self, target: "Stats") -> str:
-        """Determine current element being used (simplified)."""
-        # This would normally check the actual damage type
-        # For now, alternate randomly between fire and ice
-        import random
-        return random.choice(["fire", "ice"])
+        """Determine the current element from the target's damage type."""
+        element = getattr(getattr(target, "damage_type", None), "id", "").lower()
+        if "fire" in element:
+            return "fire"
+        if "ice" in element:
+            return "ice"
+        return element
 
     async def _gain_flux_stack(self, target: "Stats") -> None:
         """Gain an Elemental Flux stack."""
@@ -73,13 +80,16 @@ class LadyFireAndIceDualityEngine:
         )
         target.add_effect(flux_effect)
 
-    async def _consume_flux_stacks(self, target: "Stats") -> None:
+    async def _consume_flux_stacks(
+        self,
+        target: "Stats",
+        foes: Iterable["Stats"] | None = None,
+    ) -> None:
         """Consume all flux stacks for beneficial effects."""
         entity_id = id(target)
         stacks_to_consume = self._flux_stacks[entity_id]
 
         if stacks_to_consume > 0:
-            # Apply small HoT to allies (would need party system integration)
             ally_hot_amount = stacks_to_consume * 10  # 10 HP per stack
 
             ally_hot_effect = StatEffect(
@@ -88,19 +98,24 @@ class LadyFireAndIceDualityEngine:
                 duration=3,  # Three turns of HoT
                 source=self.id,
             )
-            # This would be applied to all allies in actual implementation
             target.add_effect(ally_hot_effect)
 
-            # Apply mitigation debuff to foes (would need enemy targeting)
-            # In full implementation, would apply 2% mitigation reduction per stack to enemies
+            if foes:
+                mitigation_reduction = stacks_to_consume * 0.02
+                for foe in foes:
+                    debuff = StatEffect(
+                        name=f"{self.id}_flux_enemy_mitigation",
+                        stat_modifiers={"mitigation": -mitigation_reduction},
+                        duration=3,
+                        source=self.id,
+                    )
+                    foe.add_effect(debuff)
 
-            # Remove flux potency bonus effects
             target._active_effects = [
                 effect for effect in target._active_effects
                 if effect.name != f"{self.id}_flux_potency"
             ]
 
-            # Reset flux stacks
             self._flux_stacks[entity_id] = 0
 
     @classmethod

--- a/backend/tests/test_lady_fire_and_ice_duality_engine.py
+++ b/backend/tests/test_lady_fire_and_ice_duality_engine.py
@@ -1,0 +1,35 @@
+import pytest
+
+from autofighter.stats import Stats
+from plugins.damage_types.fire import Fire
+from plugins.damage_types.ice import Ice
+from plugins.passives.lady_fire_and_ice_duality_engine import (
+    LadyFireAndIceDualityEngine,
+)
+
+
+@pytest.mark.asyncio
+async def test_flux_stacks_and_debuff_application():
+    passive = LadyFireAndIceDualityEngine()
+    actor = Stats()
+    foe = Stats()
+    foes = [foe]
+
+    actor.damage_type = Fire()
+    await passive.apply(actor, foes=foes)
+    assert passive.get_flux_stacks(actor) == 0
+
+    actor.damage_type = Ice()
+    await passive.apply(actor, foes=foes)
+    assert passive.get_flux_stacks(actor) == 1
+
+    actor.damage_type = Ice()
+    await passive.apply(actor, foes=foes)
+    assert passive.get_flux_stacks(actor) == 0
+
+    effects = [
+        e for e in foe.get_active_effects()
+        if e.name == f"{passive.id}_flux_enemy_mitigation"
+    ]
+    assert len(effects) == 1
+    assert effects[0].stat_modifiers["mitigation"] == pytest.approx(-0.02)


### PR DESCRIPTION
## Summary
- Derive Lady Fire and Ice's active element from damage type and apply mitigation debuff to foes when repeating an element
- Document Duality Engine behaviour in README and player reference
- Add unit test for flux stacks and debuff handling

## Testing
- `uv tool run ruff check backend --fix`
- `./run-tests.sh` *(fails: test_100_fallback_effects_stress.py, test_app.py)*
- `uv run pytest tests/test_lady_fire_and_ice_duality_engine.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68bde3756588832c99e1786e9e9ddc4c