### PR TITLE
[ENH] apply flux debuff to foes

### DIFF
--- a/.codex/implementation/player-foe-reference.md
+++ b/.codex/implementation/player-foe-reference.md
@@ -46,7 +46,7 @@ Passives generally shouldn't be capped unless a designer explicitly specifies a 
 - **Chibi** (A, random) – gains four times the normal benefit from Vitality.
 - **Graygray** (B, random) – applies `graygray_counter_maestro`, counterattacking when hit.
 - **Hilander** (A, random) – builds increased crit rate and crit damage.
-- **Kboshi** (A, random) – randomly changes damage type; failed switches grant stacking bonuses.
+- **Kboshi** (A, random) – randomly changes damage type; failed switches grant stacking bonuses. Switching elements consumes stacks and inflicts a brief mitigation debuff on all foes.
 - **Lady Darkness** (B, Dark) – baseline fighter themed around darkness.
 - **Lady Echo** (B, Lightning) – baseline fighter themed around echoes.
 - **Lady Fire and Ice** (B, Fire or Ice) – baseline fighter themed around fire and ice.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A web-based auto-battler game featuring strategic party management, elemental co
 ### Character Update
 
 - Carly's Guardian's Aegis now heals the most injured ally, converts attack growth into defense stacks, and shares mitigation with allies on ultimate.
+- Kboshi's Flux Cycle now applies a one-turn mitigation debuff to all foes when his element changes.
 
 ## Quick Start with Docker Compose (Recommended)
 

--- a/backend/plugins/passives/kboshi_flux_cycle.py
+++ b/backend/plugins/passives/kboshi_flux_cycle.py
@@ -61,16 +61,31 @@ class KboshiFluxCycle:
 
             # Element successfully changed - remove accumulated stacks
             if self._damage_stacks[entity_id] > 0 or self._hot_stacks[entity_id] > 0:
+                stacks = self._damage_stacks[entity_id]
+
                 # Remove existing bonus effects
                 target._active_effects = [
-                    effect for effect in target._active_effects
-                    if not effect.name.startswith(f"{self.id}_damage_bonus") and
-                       not effect.name.startswith(f"{self.id}_hot_heal")
+                    effect
+                    for effect in target._active_effects
+                    if not effect.name.startswith(f"{self.id}_damage_bonus")
+                    and not effect.name.startswith(f"{self.id}_hot_heal")
                 ]
 
                 # Reset stacks
                 self._damage_stacks[entity_id] = 0
                 self._hot_stacks[entity_id] = 0
+
+                # Apply mitigation debuff to foes for one turn
+                if stacks > 0:
+                    mitigation = stacks * -0.02
+                    for foe in getattr(target, "enemies", []):
+                        debuff = StatEffect(
+                            name=f"{self.id}_mitigation_debuff",
+                            stat_modifiers={"mitigation": mitigation},
+                            duration=1,
+                            source=self.id,
+                        )
+                        foe.add_effect(debuff)
         else:
             # Element failed to change - gain damage bonus and HoT
             self._damage_stacks[entity_id] += 1


### PR DESCRIPTION
## Summary
- debuff foes when Kboshi shifts elements to mitigate their defenses for one turn
- document Flux Cycle mitigation debuff on Kboshi

## Testing
- `ruff check . --fix` *(fails: E402 Module level import not at top of file, F841, etc.)*
- `./run-tests.sh` *(fails: Cannot find module '$app/environment', ENOENT file not found, etc.)*

------
https://chatgpt.com/codex/tasks/task_b_68bde378bc68832ca77c9ca84f5c52a1