### PR TITLE
[FEATURE] Add 64-hit Generic ultimate

### DIFF
--- a/.codex/implementation/damage-healing.md
+++ b/.codex/implementation/damage-healing.md
@@ -4,6 +4,7 @@ Summaries of elemental damage behaviors and ongoing effect plugins.
 
 ## Elemental Damage
 
+- **[Generic](../../backend/plugins/damage_types/generic.py)** – Baseline element with an ultimate that splits the user's attack into 64 rapid strikes on a single target, counting each hit as a separate action.
 - **[Fire](../../backend/plugins/damage_types/fire.py)** – Scales damage by missing HP and applies [Blazing Torment](../../backend/plugins/dots/blazing_torment.py), a stackable DoT that ticks when the target acts. Its ultimate hits every foe with the caster's attack and rolls Blazing Torment on each, then adds a drain stack that burns the user for 5% max HP per stack at the start of their turns.
 - **[Ice](../../backend/plugins/damage_types/ice.py)** – Inflicts [Frozen Wound](../../backend/plugins/dots/frozen_wound.py), reducing `actions_per_turn` and adding a 1% miss chance per stack. Some abilities instead use [Cold Wound](../../backend/plugins/dots/cold_wound.py) which caps at five stacks.
 - **[Lightning](../../backend/plugins/damage_types/lightning.py)** – Pops every active DoT for 25% of its damage on hit and applies [Charged Decay](../../backend/plugins/dots/charged_decay.py), a DoT that stuns on its final tick.

--- a/backend/plugins/damage_types/generic.py
+++ b/backend/plugins/damage_types/generic.py
@@ -1,5 +1,8 @@
+import asyncio
 from dataclasses import dataclass
 
+from autofighter.passives import PassiveRegistry
+from autofighter.stats import BUS
 from plugins.damage_types._base import DamageTypeBase
 
 
@@ -8,3 +11,37 @@ class Generic(DamageTypeBase):
     id: str = "Generic"
     weakness: str = "none"
     color: tuple[int, int, int] = (255, 255, 255)
+
+    async def ultimate(self, actor, allies, enemies):
+        if not getattr(actor, "use_ultimate", lambda: False)():
+            return False
+
+        registry = PassiveRegistry()
+        target_pool = (
+            [a for a in allies if a.hp > 0]
+            if getattr(actor, "plugin_type", "") == "foe"
+            else [e for e in enemies if e.hp > 0]
+        )
+        if not target_pool:
+            return True
+        target = target_pool[0]
+
+        base = actor.atk // 64
+        remainder = actor.atk % 64
+        for i in range(64):
+            dmg = base + (1 if i < remainder else 0)
+            await target.apply_damage(dmg, attacker=actor, action_name="Generic Ultimate")
+            await BUS.emit_async(
+                "hit_landed", actor, target, dmg, "attack", "generic_ultimate"
+            )
+            await registry.trigger(
+                "action_taken",
+                actor,
+                target=target,
+                damage=dmg,
+                party=allies,
+                foes=enemies,
+            )
+            if i % 5 == 0:
+                await asyncio.sleep(0)
+        return True

--- a/backend/tests/test_generic_ultimate.py
+++ b/backend/tests/test_generic_ultimate.py
@@ -1,0 +1,50 @@
+import pytest
+
+from autofighter.stats import BUS
+from autofighter.stats import Stats
+from plugins.damage_types.generic import Generic
+from plugins.passives.luna_lunar_reservoir import LunaLunarReservoir
+
+
+class Actor(Stats):
+    def use_ultimate(self) -> bool:  # pragma: no cover - simple helper
+        if not self.ultimate_ready:
+            return False
+        self.ultimate_charge = 0
+        self.ultimate_ready = False
+        BUS.emit("ultimate_used", self)
+        return True
+
+
+@pytest.mark.asyncio
+async def test_generic_ultimate_hits_and_passive_triggers():
+    LunaLunarReservoir._charge_points.clear()
+
+    actor = Actor(damage_type=Generic(), passives=["luna_lunar_reservoir"])
+    actor.id = "luna"
+    actor._base_atk = 64
+    actor._base_defense = 0
+    actor._base_crit_rate = 0
+
+    target = Stats()
+    target.id = "target"
+    target._base_defense = 0
+    target.dodge_odds = 0
+
+    actor.ultimate_charge = 15
+    actor.ultimate_ready = True
+
+    hits = {"count": 0}
+
+    def count_hit(*_args):
+        hits["count"] += 1
+
+    BUS.subscribe("hit_landed", count_hit)
+    try:
+        result = await actor.damage_type.ultimate(actor, [actor], [target])
+    finally:
+        BUS.unsubscribe("hit_landed", count_hit)
+
+    assert result is True
+    assert hits["count"] == 64
+    assert LunaLunarReservoir.get_charge(actor) == 64


### PR DESCRIPTION
## Summary
- implement 64-hit Generic damage type ultimate with per-hit action triggers
- document Generic element ultimate behavior
- test Generic ultimate hit count and passive stacking

## Testing
- `uv tool run ruff check backend --fix`
- `./run-tests.sh` *(fails: Cannot find module in frontend tests)*

------
https://chatgpt.com/codex/tasks/task_b_68bde7f63c04832c94d1c356c6591639