### PR TITLE
Fix Duality Engine apply signature to accept action context

### DIFF
--- a/backend/plugins/passives/lady_fire_and_ice_duality_engine.py
+++ b/backend/plugins/passives/lady_fire_and_ice_duality_engine.py
@@ -24,12 +24,13 @@ class LadyFireAndIceDualityEngine:
 
     async def apply(
         self,
-        target: "Stats",
+        owner: "Stats",
         *,
         foes: Iterable["Stats"] | None = None,
+        **kwargs,
     ) -> None:
         """Apply Lady Fire and Ice's duality mechanics."""
-        entity_id = id(target)
+        entity_id = id(owner)
 
         # Initialize tracking if not present
         if entity_id not in self._last_element:
@@ -37,16 +38,16 @@ class LadyFireAndIceDualityEngine:
             self._flux_stacks[entity_id] = 0
 
         # Determine current element from the damage type
-        current_element = self._determine_current_element(target)
+        current_element = self._determine_current_element(owner)
 
         # Check if alternating or using same element twice
         if self._last_element[entity_id] is not None:
             if current_element != self._last_element[entity_id]:
                 # Alternating elements - gain Elemental Flux stack
-                await self._gain_flux_stack(target)
+                await self._gain_flux_stack(owner)
             else:
                 # Same element twice - consume all stacks for effects
-                await self._consume_flux_stacks(target, foes)
+                await self._consume_flux_stacks(owner, foes)
 
         # Update last element used
         self._last_element[entity_id] = current_element

--- a/backend/tests/test_lady_fire_and_ice_duality_engine.py
+++ b/backend/tests/test_lady_fire_and_ice_duality_engine.py
@@ -16,15 +16,15 @@ async def test_flux_stacks_and_debuff_application():
     foes = [foe]
 
     actor.damage_type = Fire()
-    await passive.apply(actor, foes=foes)
+    await passive.apply(actor, stack_index=0, target=foe, foes=foes)
     assert passive.get_flux_stacks(actor) == 0
 
     actor.damage_type = Ice()
-    await passive.apply(actor, foes=foes)
+    await passive.apply(actor, stack_index=0, target=foe, foes=foes)
     assert passive.get_flux_stacks(actor) == 1
 
     actor.damage_type = Ice()
-    await passive.apply(actor, foes=foes)
+    await passive.apply(actor, stack_index=0, target=foe, foes=foes)
     assert passive.get_flux_stacks(actor) == 0
 
     effects = [


### PR DESCRIPTION
## Summary
- Allow Duality Engine `apply` to accept extra context so foe mitigation debuffs trigger
- Adjust Duality Engine unit test to call `apply` with action metadata

## Testing
- `uv tool run ruff check backend --fix`
- `./run-tests.sh` *(fails: tests/test_battle_snapshot_consistency.py::test_foe_element_stable_across_snapshots)*
- `cd backend && uv run pytest tests/test_lady_fire_and_ice_duality_engine.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68bde8494b98832c86bc56add14092bc