### PR TITLE
[BUGFIX] Trigger hit-based passives for Generic ultimate

### DIFF
--- a/backend/plugins/damage_types/generic.py
+++ b/backend/plugins/damage_types/generic.py
@@ -34,6 +34,14 @@ class Generic(DamageTypeBase):
             await BUS.emit_async(
                 "hit_landed", actor, target, dmg, "attack", "generic_ultimate"
             )
+            await registry.trigger_hit_landed(
+                actor,
+                target,
+                dmg,
+                "generic_ultimate",
+                party=allies,
+                foes=enemies,
+            )
             await registry.trigger(
                 "action_taken",
                 actor,


### PR DESCRIPTION
## Summary
- ensure Generic ultimate triggers `hit_landed` passives on each hit

## Testing
- `uv tool run ruff check backend --fix`
- `./run-tests.sh` *(fails: Cannot find module '$app/environment' from '/workspace/Midori-AI-AutoFighter/frontend/src/lib/systems/backendDiscovery.js')*


------
https://chatgpt.com/codex/tasks/task_b_68bdebef217c832cbdc5de39153ecea6