### PR TITLE
[FIX] ensure Mezzy bulwark siphons allies each turn

### DIFF
--- a/.codex/implementation/player-foe-reference.md
+++ b/.codex/implementation/player-foe-reference.md
@@ -53,7 +53,7 @@ Passives generally shouldn't be capped unless a designer explicitly specifies a 
 - **Lady Light** (B, Light) – baseline fighter themed around light.
 - **Lady of Fire** (B, Fire) – baseline fighter themed around fire.
 - **Luna** (B, Generic) – applies `luna_passive`.
-- **Mezzy** (B, random) – only raises Max HP and takes less damage.
+- **Mezzy** (B, random) – raises Max HP, takes less damage, and siphons stats from healthy allies each turn.
 - **Mimic** (C, random) – copies the player then lowers its stats by 25% on spawn.
 - **Player** (C, chosen) – avatar representing the user and may select any non-Generic damage type.
 

--- a/README.md
+++ b/README.md
@@ -101,11 +101,6 @@ curl -fsSL https://bun.sh/install | bash
 - **Building:** See [BUILD.md](BUILD.md) for building standalone executables
 - **Issues:** Report bugs or request features on [GitHub Issues](../../issues)
 
-## Player Roster
-
-- **Mezzy** – Gluttonous Bulwark siphons stats from healthy allies each turn while boosting her own resilience.
-  See `.codex/implementation/player-foe-reference.md` for the full roster.
-
 ## Troubleshooting
 
 **Docker Compose fails with DNS/network errors:** This is a known issue in some environments. Use the alternative UV & Bun installation method instead.

--- a/README.md
+++ b/README.md
@@ -101,6 +101,11 @@ curl -fsSL https://bun.sh/install | bash
 - **Building:** See [BUILD.md](BUILD.md) for building standalone executables
 - **Issues:** Report bugs or request features on [GitHub Issues](../../issues)
 
+## Player Roster
+
+- **Mezzy** – Gluttonous Bulwark siphons stats from healthy allies each turn while boosting her own resilience.
+  See `.codex/implementation/player-foe-reference.md` for the full roster.
+
 ## Troubleshooting
 
 **Docker Compose fails with DNS/network errors:** This is a known issue in some environments. Use the alternative UV & Bun installation method instead.

--- a/backend/plugins/passives/mezzy_gluttonous_bulwark.py
+++ b/backend/plugins/passives/mezzy_gluttonous_bulwark.py
@@ -20,7 +20,7 @@ class MezzyGluttonousBulwark:
     # Class-level tracking of siphoned stats per ally
     _siphoned_stats: ClassVar[dict[int, dict[str, int]]] = {}
 
-    async def apply(self, target: "Stats") -> None:
+    async def apply(self, target: "Stats", allies: list["Stats"] | None = None, **_: object) -> None:
         """Apply Mezzy's bulk and siphoning mechanics."""
         # Apply 20% damage reduction (permanent while passive is active)
         damage_reduction = StatEffect(
@@ -50,9 +50,10 @@ class MezzyGluttonousBulwark:
         )
         target.add_effect(debuff_immunity)
 
-        # Siphon from allies if we have access to them
-        # In a real battle system, this would be triggered by turn events
-        # For now, this handles the basic setup
+        if allies is None:
+            allies = list(getattr(target, "allies", []))
+        if allies:
+            await self.siphon_from_allies(target, allies)
 
     async def siphon_from_allies(self, mezzy: "Stats", allies: list["Stats"]) -> None:
         """Siphon stats from allies whose HP exceeds 20% of Mezzy's max HP."""


### PR DESCRIPTION
## Summary
- invoke `siphon_from_allies` each turn for Mezzy's Gluttonous Bulwark passive
- document Mezzy's stat siphon ability in README and player/foe reference
- test that Mezzy siphons stats from allies on consecutive turns

## Testing
- `ruff check backend/plugins/passives/mezzy_gluttonous_bulwark.py backend/tests/test_character_passives.py --fix`
- `./run-tests.sh` *(fails: frontend missing assets/modules; backend certain tests timeout)*

------
https://chatgpt.com/codex/tasks/task_b_68bdf8b21fd0832c82fd960327985246