### PR TITLE
[FIX] ensure bubble burst DoT lasts two turns

### DIFF
--- a/backend/autofighter/effects.py
+++ b/backend/autofighter/effects.py
@@ -391,7 +391,9 @@ class EffectManager:
             "multipliers": effect.multipliers
         })
 
-    def maybe_inflict_dot(self, attacker: Stats, damage: int) -> None:
+    def maybe_inflict_dot(
+        self, attacker: Stats, damage: int, turns: Optional[int] = None
+    ) -> None:
         """Attempt to apply one or more DoT stacks based on effect hit rate.
 
         The attacker's ``effect_hit_rate`` is processed in 100% chunks. Each
@@ -420,6 +422,9 @@ class EffectManager:
             dot = attacker.damage_type.create_dot(damage, attacker)
             if dot is None:
                 break
+
+            if turns is not None:
+                dot.turns = turns
 
             self.add_dot(dot)
             remaining -= 1.0

--- a/backend/plugins/passives/bubbles_bubble_burst.py
+++ b/backend/plugins/passives/bubbles_bubble_burst.py
@@ -88,7 +88,7 @@ class BubblesBubbleBurst:
                 if mgr is None:
                     mgr = EffectManager(combatant)
                     combatant.effect_manager = mgr
-                mgr.maybe_inflict_dot(bubbles, damage)
+                mgr.maybe_inflict_dot(bubbles, damage, turns=2)
 
     @classmethod
     def get_bubble_stacks(cls, bubbles: "Stats", enemy: "Stats") -> int:

--- a/backend/tests/test_bubbles_bubble_burst_logic.py
+++ b/backend/tests/test_bubbles_bubble_burst_logic.py
@@ -49,5 +49,7 @@ async def test_bubble_burst_stacks_and_dot():
         assert enemy2.hp < 1000
         assert enemy1.effect_manager.dots
         assert enemy2.effect_manager.dots
+        assert enemy1.effect_manager.dots[0].turns == 2
+        assert enemy2.effect_manager.dots[0].turns == 2
     finally:
         set_battle_active(False)

--- a/backend/tests/test_wind_multi_target.py
+++ b/backend/tests/test_wind_multi_target.py
@@ -16,9 +16,9 @@ async def test_wind_player_hits_all_foes(monkeypatch):
 
     original = EffectManager.maybe_inflict_dot
 
-    def spy(self, attacker, damage):
+    def spy(self, attacker, damage, turns=None):
         calls.append(self.stats.id)
-        return original(self, attacker, damage)
+        return original(self, attacker, damage, turns)
 
     monkeypatch.setattr(EffectManager, "maybe_inflict_dot", spy)
     node = MapNode(
@@ -49,9 +49,9 @@ async def test_wind_foe_hits_all_party_members(monkeypatch):
 
     original = EffectManager.maybe_inflict_dot
 
-    def spy(self, attacker, damage):
+    def spy(self, attacker, damage, turns=None):
         calls.append(self.stats.id)
-        return original(self, attacker, damage)
+        return original(self, attacker, damage, turns)
 
     monkeypatch.setattr(EffectManager, "maybe_inflict_dot", spy)
     node = MapNode(


### PR DESCRIPTION
## Summary
- let `EffectManager.maybe_inflict_dot` accept an optional turns override
- bubble burst passive explicitly applies a two-turn DoT
- update tests for custom DoT duration

## Testing
- `uv run ruff check backend/autofighter/effects.py backend/plugins/passives/bubbles_bubble_burst.py backend/tests/test_bubbles_bubble_burst_logic.py backend/tests/test_wind_multi_target.py --fix`
- `./run-tests.sh` *(fails: backend tests/test_app.py, backend tests/test_app_without_llm_deps.py, backend tests/test_damage_type_persistence.py, backend tests/test_gacha.py, backend tests/test_new_upgrade_system.py; numerous frontend module errors)*

------
https://chatgpt.com/codex/tasks/task_b_68bdf8e5d644832c9bf2eff2bb617ba9