### PR TITLE
[FEAT] add five-pull option

### DIFF
--- a/frontend/.codex/implementation/pulls-menu.md
+++ b/frontend/.codex/implementation/pulls-menu.md
@@ -1,0 +1,6 @@
+# Pulls Menu
+
+The `PullsMenu.svelte` component lets players spend gacha tickets. It shows
+current pity and ticket counts and provides buttons for one, five, or ten
+pulls. Each button disables when the player lacks enough tickets. Pull results
+list the type, id, rarity, and stacks of each item.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -35,8 +35,10 @@ browser reads this value instead of scanning the network directly.
   (open the Party overlay to refresh), but do not retroactively modify an
   active battle.
 - Pulls: Calls `/gacha/pull` so players can recruit 5★ or 6★ characters or
-  earn 1★–4★ upgrade items between runs. Pity raises the odds of higher‑tier
-  items; auto‑crafting is an optional toggle under Crafting.
+  earn 1★–4★ upgrade items between runs. Buttons for **Pull 1**, **Pull 5**, and
+  **Pull 10** spend tickets in those amounts and are disabled if you lack
+  enough. Pity raises the odds of higher‑tier items; auto‑crafting is an
+  optional toggle under Crafting.
 - Craft: Lists upgrade items, shows 125×/10× requirements, and offers
   `/gacha/craft` and `/gacha/auto-craft`. The Craft button is disabled until
   enough materials exist.

--- a/frontend/src/lib/components/PullsMenu.svelte
+++ b/frontend/src/lib/components/PullsMenu.svelte
@@ -42,6 +42,7 @@
   <p>Tickets: {items.ticket || 0}</p>
   <div class="actions">
     <button disabled={loading || (items.ticket || 0) < 1} on:click={() => pull(1)}>Pull 1</button>
+    <button disabled={loading || (items.ticket || 0) < 5} on:click={() => pull(5)}>Pull 5</button>
     <button disabled={loading || (items.ticket || 0) < 10} on:click={() => pull(10)}>Pull 10</button>
     <button on:click={close}>Done</button>
   </div>

--- a/frontend/tests/api.test.js
+++ b/frontend/tests/api.test.js
@@ -93,7 +93,12 @@ describe('api calls', () => {
   });
 
   test('pullGacha posts count', async () => {
-    global.fetch = createFetch({ results: [], pity: 0 });
+    const fetchMock = mock(async (url, options) => {
+      const body = JSON.parse(options.body);
+      expect(body).toEqual({ count: 5 });
+      return { ok: true, status: 200, json: async () => ({ results: [], pity: 0 }) };
+    });
+    global.fetch = fetchMock;
     const result = await pullGacha(5);
     expect(result).toEqual({ results: [], pity: 0 });
   });

--- a/frontend/tests/pullsmenu.test.js
+++ b/frontend/tests/pullsmenu.test.js
@@ -4,10 +4,15 @@ import { join } from 'path';
 
 describe('PullsMenu component', () => {
   test('renders pity and buttons', () => {
-    const content = readFileSync(join(import.meta.dir, '../src/lib/PullsMenu.svelte'), 'utf8');
+    const content = readFileSync(
+      join(import.meta.dir, '../src/lib/components/PullsMenu.svelte'),
+      'utf8'
+    );
     expect(content).toContain('data-testid="pulls-menu"');
     expect(content).toContain('Pull 1');
+    expect(content).toContain('Pull 5');
     expect(content).toContain('Pull 10');
     expect(content).toContain('(items.ticket || 0) < 1');
+    expect(content).toContain('(items.ticket || 0) < 5');
   });
 });


### PR DESCRIPTION
## Summary
- add a Pull 5 button to PullsMenu and disable it when tickets are below five
- expect new button in PullsMenu test and verify pullGacha posts a count of 5
- document Pull 5 option in README and implementation docs

## Testing
- [ ] Backend tests *(failing: KeyError in battle snapshot consistency; other import errors)*
- [ ] Frontend tests *(not fully executed)*
- [x] Linting (`uv tool run ruff check backend --fix`, `bun run lint:fix`)
- [ ] Doc sync updates (README and `.codex/implementation` docs; link tasks below)

------
https://chatgpt.com/codex/tasks/task_b_68be0a23673c832c8780fdf5245c3f46