### PR TITLE
feat: persist per-character editor settings

### DIFF
--- a/backend/.codex/implementation/player-editor-endpoint.md
+++ b/backend/.codex/implementation/player-editor-endpoint.md
@@ -14,5 +14,11 @@ These allocations persist as an effect descriptor rather than by mutating the
 player's base stats. When a run loads, the saved parameters rebuild a
 long-lived `StatModifier` to apply the chosen multipliers.
 
+Additional endpoints `GET /players/<pid>/editor` and `PUT /players/<pid>/editor`
+persist stat allocations for any roster character. These calls mirror the
+player editor but omit pronouns and damage type. Stats are stored in the save
+data under keys like `player_stats_<pid>` so each character maintains its own
+allocation record.
+
 ## Testing
 - `uv run pytest backend/tests/test_player_editor.py`

--- a/backend/tests/test_character_editor.py
+++ b/backend/tests/test_character_editor.py
@@ -1,0 +1,61 @@
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture()
+def app_with_db(tmp_path, monkeypatch):
+    db_path = tmp_path / "save.db"
+    monkeypatch.setenv("AF_DB_PATH", str(db_path))
+    monkeypatch.setenv("AF_DB_KEY", "testkey")
+    monkeypatch.syspath_prepend(Path(__file__).resolve().parents[1])
+    spec = importlib.util.spec_from_file_location(
+        "app",
+        Path(__file__).resolve().parents[1] / "app.py",
+    )
+    app_module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(app_module)
+    app_module.app.testing = True
+    return app_module.app
+
+
+@pytest.mark.asyncio
+async def test_character_editor_luna(app_with_db):
+    app = app_with_db
+    client = app.test_client()
+
+    resp = await client.put(
+        "/players/luna/editor",
+        json={
+            "hp": 10,
+            "attack": 20,
+            "defense": 30,
+            "crit_rate": 10,
+            "crit_damage": 5,
+        },
+    )
+    assert resp.status_code == 200
+
+    data = await client.get("/players/luna/editor")
+    payload = await data.get_json()
+    assert payload == {
+        "hp": 10,
+        "attack": 20,
+        "defense": 30,
+        "crit_rate": 10,
+        "crit_damage": 5,
+    }
+
+    roster_resp = await client.get("/players")
+    roster = await roster_resp.get_json()
+    luna = next(p for p in roster["players"] if p["id"] == "luna")
+    core = luna["stats"]["core"]
+    offense = luna["stats"]["offense"]
+    defense_block = luna["stats"]["defense"]
+    assert core["hp"] == 1100 and core["max_hp"] == 1100
+    assert offense["atk"] == 120
+    assert defense_block["defense"] == 65
+    assert offense["crit_rate"] == pytest.approx(0.0575, rel=1e-3)
+    assert offense["crit_damage"] == pytest.approx(2.1, rel=1e-3)

--- a/frontend/.codex/implementation/party-ui.md
+++ b/frontend/.codex/implementation/party-ui.md
@@ -22,4 +22,7 @@ Implementation details:
 - `StatTabs.svelte` now embeds an `UpgradePanel` beneath the stats list,
   showing upgrade level and per-star item counts with a button disabled until
   enough materials are available (20×4★ or 100×3★ or 500×2★ or 1000×1★).
+- `StatTabs.svelte` caches per-character stat editor values and persists
+  allocations through `/players/<id>/editor` so non-player tweaks are saved
+  across sessions.
 

--- a/frontend/src/lib/components/PartyPicker.svelte
+++ b/frontend/src/lib/components/PartyPicker.svelte
@@ -199,6 +199,7 @@
             // Bubble an editor change so top-level editorState stays in sync for Start Run
             try { dispatch('editorChange', { damageType: el }); } catch {}
           }}
+          on:editor-change={(e) => dispatch('editorChange', e.detail)}
           on:refresh-roster={refreshRoster}
         />
         <div class="party-actions-inline">

--- a/frontend/src/lib/systems/api.js
+++ b/frontend/src/lib/systems/api.js
@@ -59,6 +59,15 @@ export async function savePlayerConfig(config) {
   return httpPut('/player/editor', config);
 }
 
+// Per-character stat customization
+export async function getCharacterConfig(id) {
+  return httpGet(`/players/${id}/editor`, { cache: 'no-store' });
+}
+
+export async function saveCharacterConfig(id, config) {
+  return httpPut(`/players/${id}/editor`, config);
+}
+
 export async function endRun(runId) {
   return httpRequest(`/run/${runId}`, { method: 'DELETE' }, (r) => r.ok);
 }


### PR DESCRIPTION
## Summary
- allow saving and loading stat allocations for any character
- expose character editor API to frontend
- cache editor configs and refresh stats after saving

## Testing
- `ruff check . --fix`
- `bun run lint:fix`
- `./run-tests.sh` *(fails: tests/test_app.py, others)*

------
https://chatgpt.com/codex/tasks/task_b_68be0b8f7cb4832c98c41a699736df39