### PR TITLE
Add passive stack display metadata

### DIFF
--- a/.codex/implementation/plugin-system.md
+++ b/.codex/implementation/plugin-system.md
@@ -25,6 +25,10 @@ The following categories are bundled:
 - `plugin_type` – category string used by the loader when registering the class【F:plugins/plugin_loader.py†L67-L72】
 - `id` *(optional)* – unique identifier; defaults to the class name【F:plugins/plugin_loader.py†L70-L72】
 - Category-specific methods (`attack`, `apply`, `tick`, etc.) invoked by game systems
+- Passive plugins expose stack metadata with `stack_display`:
+  - `spinner` for single-stack or always-active effects (`max_stacks == 1`)
+  - `pips` for passives without a stack limit or with a `max_stacks` cap of five or fewer
+  - `number` for passives with a numeric `max_stacks` cap above five
 - During discovery the loader injects the event bus as `bus` on each class【F:plugins/plugin_loader.py†L67-L74】
 
 ## Event Bus Integration

--- a/backend/plugins/passives/advanced_combat_synergy.py
+++ b/backend/plugins/passives/advanced_combat_synergy.py
@@ -18,6 +18,7 @@ class AdvancedCombatSynergy:
     name = "Advanced Combat Synergy"
     trigger = "hit_landed"  # Primary trigger
     max_stacks = 3
+    stack_display = "pips"
 
     # Class-level state for tracking synergy stacks per entity
     _synergy_stacks: ClassVar[dict[int, int]] = {}

--- a/backend/plugins/passives/ally_overload.py
+++ b/backend/plugins/passives/ally_overload.py
@@ -16,6 +16,7 @@ class AllyOverload:
     name = "Overload"
     trigger = "action_taken"  # Triggers when Ally takes any action
     max_stacks = 120  # Soft cap - show charge level with diminished returns past 120
+    stack_display = "number"
 
     # Class-level tracking of overload charge and stance for each entity
     _overload_charge: ClassVar[dict[int, int]] = {}

--- a/backend/plugins/passives/attack_up.py
+++ b/backend/plugins/passives/attack_up.py
@@ -10,6 +10,7 @@ class AttackUp:
     name = "Attack Up"
     trigger = "battle_start"
     amount = 5
+    stack_display = "pips"
 
     async def apply(self, target, **kwargs) -> None:
         stack_index = kwargs.get('stack_index', 0)

--- a/backend/plugins/passives/becca_menagerie_bond.py
+++ b/backend/plugins/passives/becca_menagerie_bond.py
@@ -19,6 +19,7 @@ class BeccaMenagerieBond:
     name = "Menagerie Bond"
     trigger = "action_taken"  # Triggers when Becca acts
     max_stacks = 1  # Only one instance per character
+    stack_display = "spinner"
 
     # Class-level tracking of summon state and spirit bonuses
     _summon_cooldown: ClassVar[dict[int, int]] = {}  # entity_id -> turns_remaining

--- a/backend/plugins/passives/bubbles_bubble_burst.py
+++ b/backend/plugins/passives/bubbles_bubble_burst.py
@@ -20,6 +20,7 @@ class BubblesBubbleBurst:
     name = "Bubble Burst"
     trigger = "turn_start"  # Triggers at start of Bubbles' turn
     max_stacks = 20  # Soft cap - show attack buff stacks with diminished returns past 20
+    stack_display = "number"
 
     # Track bubble stacks per enemy target
     _bubble_stacks: ClassVar[dict[int, dict[int, int]]] = {}  # bubbles_id -> {target_id -> stacks}

--- a/backend/plugins/passives/carly_guardians_aegis.py
+++ b/backend/plugins/passives/carly_guardians_aegis.py
@@ -17,6 +17,7 @@ class CarlyGuardiansAegis:
     name = "Guardian's Aegis"
     trigger = "turn_start"  # Triggers at start of turn for healing
     max_stacks = 50  # Soft cap - show mitigation stacks with diminished returns past 50
+    stack_display = "number"
 
     # Class-level tracking of mitigation stacks and converted defense stacks
     _mitigation_stacks: ClassVar[dict[int, int]] = {}

--- a/backend/plugins/passives/chibi_tiny_titan.py
+++ b/backend/plugins/passives/chibi_tiny_titan.py
@@ -16,6 +16,7 @@ class ChibiTinyTitan:
     name = "Tiny Titan"
     trigger = "damage_taken"  # Triggers when Chibi takes damage to increase Vitality
     max_stacks = 1  # Only one instance per character
+    stack_display = "spinner"
 
     # Class-level tracking of accumulated Vitality bonuses
     _vitality_bonuses: ClassVar[dict[int, float]] = {}

--- a/backend/plugins/passives/graygray_counter_maestro.py
+++ b/backend/plugins/passives/graygray_counter_maestro.py
@@ -17,6 +17,7 @@ class GraygrayCounterMaestro:
     name = "Counter Maestro"
     trigger = "damage_taken"  # Triggers when Graygray takes damage
     max_stacks = 50  # Soft cap - show counter attack stacks with diminished returns past 50
+    stack_display = "number"
 
     # Track successful counter attacks for +5% attack stacks
     _counter_stacks: ClassVar[dict[int, int]] = {}

--- a/backend/plugins/passives/hilander_critical_ferment.py
+++ b/backend/plugins/passives/hilander_critical_ferment.py
@@ -14,6 +14,7 @@ class HilanderCriticalFerment:
     id = "hilander_critical_ferment"
     name = "Critical Ferment"
     trigger = "hit_landed"  # Triggers when Hilander lands a hit
+    stack_display = "pips"  # Unlimited stacks with numeric fallback past five
 
     async def apply(self, target: "Stats") -> None:
         """Apply crit building mechanics for Hilander."""

--- a/backend/plugins/passives/kboshi_flux_cycle.py
+++ b/backend/plugins/passives/kboshi_flux_cycle.py
@@ -22,6 +22,7 @@ class KboshiFluxCycle:
     id = "kboshi_flux_cycle"
     name = "Flux Cycle"
     trigger = "turn_start"  # Triggers at start of Kboshi's turn
+    stack_display = "pips"
 
     # Track accumulated damage bonuses and HoT stacks per entity
     _damage_stacks: ClassVar[dict[int, int]] = {}

--- a/backend/plugins/passives/lady_darkness_eclipsing_veil.py
+++ b/backend/plugins/passives/lady_darkness_eclipsing_veil.py
@@ -16,6 +16,7 @@ class LadyDarknessEclipsingVeil:
     name = "Eclipsing Veil"
     trigger = "turn_start"  # Triggers at start of turn for DoT management
     max_stacks = 1  # Only one instance per character
+    stack_display = "spinner"
 
     # Class-level tracking of attack bonuses from debuff resistance
     _attack_bonuses: ClassVar[dict[int, int]] = {}

--- a/backend/plugins/passives/lady_echo_resonant_static.py
+++ b/backend/plugins/passives/lady_echo_resonant_static.py
@@ -17,6 +17,7 @@ class LadyEchoResonantStatic:
     name = "Resonant Static"
     trigger = "hit_landed"  # Triggers when Lady Echo lands a hit
     max_stacks = 1  # Only one instance per character
+    stack_display = "spinner"
 
     # Class-level tracking of current target and consecutive hits
     _current_target: ClassVar[dict[int, int]] = {}  # entity_id -> target_id

--- a/backend/plugins/passives/lady_fire_and_ice_duality_engine.py
+++ b/backend/plugins/passives/lady_fire_and_ice_duality_engine.py
@@ -17,6 +17,7 @@ class LadyFireAndIceDualityEngine:
     name = "Duality Engine"
     trigger = "action_taken"  # Triggers when Lady Fire and Ice attacks
     max_stacks = 1  # Only one instance per character
+    stack_display = "spinner"
 
     # Class-level tracking of last element used and flux stacks
     _last_element: ClassVar[dict[int, str]] = {}

--- a/backend/plugins/passives/lady_light_radiant_aegis.py
+++ b/backend/plugins/passives/lady_light_radiant_aegis.py
@@ -16,6 +16,7 @@ class LadyLightRadiantAegis:
     name = "Radiant Aegis"
     trigger = "action_taken"  # Triggers when Lady Light acts (heals)
     max_stacks = 1  # Only one instance per character
+    stack_display = "spinner"
 
     # Class-level tracking of attack bonuses from cleansing DoTs
     _attack_bonuses: ClassVar[dict[int, int]] = {}

--- a/backend/plugins/passives/lady_of_fire_infernal_momentum.py
+++ b/backend/plugins/passives/lady_of_fire_infernal_momentum.py
@@ -16,6 +16,7 @@ class LadyOfFireInfernalMomentum:
     name = "Infernal Momentum"
     trigger = "damage_taken"  # Triggers when Lady of Fire takes damage
     max_stacks = 1  # Only one instance per character
+    stack_display = "spinner"
 
     async def apply(
         self,

--- a/backend/plugins/passives/luna_lunar_reservoir.py
+++ b/backend/plugins/passives/luna_lunar_reservoir.py
@@ -16,6 +16,7 @@ class LunaLunarReservoir:
     name = "Lunar Reservoir"
     trigger = "action_taken"  # Triggers when Luna takes any action
     max_stacks = 200  # Show charge level 0-200
+    stack_display = "number"
 
     # Class-level tracking of charge points for each entity
     _charge_points: ClassVar[dict[int, int]] = {}
@@ -91,3 +92,8 @@ class LunaLunarReservoir:
     def get_stacks(cls, target: "Stats") -> int:
         """Return current charge points for UI display."""
         return cls._charge_points.get(id(target), 0)
+
+    @classmethod
+    def get_display(cls, target: "Stats") -> str:
+        """Display a spinner when charge is full and draining."""
+        return "spinner" if cls.get_charge(target) >= 200 else "number"

--- a/backend/plugins/passives/mezzy_gluttonous_bulwark.py
+++ b/backend/plugins/passives/mezzy_gluttonous_bulwark.py
@@ -16,6 +16,7 @@ class MezzyGluttonousBulwark:
     name = "Gluttonous Bulwark"
     trigger = "turn_start"  # Triggers at start of Mezzy's turn
     max_stacks = 1  # Only one instance per character
+    stack_display = "spinner"
 
     # Class-level tracking of siphoned stats per ally
     _siphoned_stats: ClassVar[dict[int, dict[str, int]]] = {}

--- a/backend/plugins/passives/mimic_player_copy.py
+++ b/backend/plugins/passives/mimic_player_copy.py
@@ -17,6 +17,7 @@ class MimicPlayerCopy:
     name = "Player Copy"
     trigger = "battle_start"  # Triggers at start of battle to copy player
     max_stacks = 1  # Only one instance per character
+    stack_display = "spinner"
 
     # Class-level tracking of copied stats and passives
     _copied_stats: ClassVar[dict[int, dict]] = {}  # entity_id -> copied_stats

--- a/backend/plugins/passives/player_level_up_bonus.py
+++ b/backend/plugins/passives/player_level_up_bonus.py
@@ -15,6 +15,7 @@ class PlayerLevelUpBonus:
     name = "Enhanced Growth"
     trigger = "level_up"  # Triggers when Player levels up
     max_stacks = 1  # Only one instance per character
+    stack_display = "spinner"
 
     async def apply(self, target: "Stats", new_level: int) -> None:
         """Apply enhanced level-up gains for Player (1.35x multiplier).

--- a/backend/plugins/passives/room_heal.py
+++ b/backend/plugins/passives/room_heal.py
@@ -8,6 +8,7 @@ class RoomHeal:
     name = "Room Heal"
     trigger = "battle_end"
     amount = 1
+    stack_display = "pips"
 
     async def apply(self, target, **kwargs) -> None:
         # Support monkeypatching: if class attribute differs from original default, use class attribute

--- a/backend/tests/test_passive_display.py
+++ b/backend/tests/test_passive_display.py
@@ -1,0 +1,60 @@
+from autofighter.passives import PassiveRegistry
+from autofighter.stats import Stats
+from plugins.damage_types.generic import Generic
+
+
+def _get_passive(description, pid):
+    return next((p for p in description if p["id"] == pid), None)
+
+
+def test_display_spinner():
+    registry = PassiveRegistry()
+    fighter = Stats(hp=100, damage_type=Generic())
+    fighter.passives = ["player_level_up_bonus"]
+    info = registry.describe(fighter)
+    passive = _get_passive(info, "player_level_up_bonus")
+    assert passive is not None
+    assert passive["max_stacks"] == 1
+    assert passive["display"] == "spinner"
+
+
+def test_display_pips():
+    registry = PassiveRegistry()
+    fighter = Stats(hp=100, damage_type=Generic())
+    fighter.passives = ["attack_up", "advanced_combat_synergy"]
+    info = registry.describe(fighter)
+    attack_up = _get_passive(info, "attack_up")
+    assert attack_up is not None
+    assert attack_up["max_stacks"] is None
+    assert attack_up["display"] == "pips"
+
+    synergy = _get_passive(info, "advanced_combat_synergy")
+    assert synergy is not None
+    assert synergy["max_stacks"] == 3
+    assert synergy["display"] == "pips"
+
+
+def test_display_number():
+    registry = PassiveRegistry()
+    fighter = Stats(hp=100, damage_type=Generic())
+    fighter.passives = ["bubbles_bubble_burst"]
+    info = registry.describe(fighter)
+    passive = _get_passive(info, "bubbles_bubble_burst")
+    assert passive is not None
+    assert passive["max_stacks"] == 20
+    assert passive["display"] == "number"
+
+
+def test_luna_display_spinner_when_charged():
+    registry = PassiveRegistry()
+    fighter = Stats(hp=100, damage_type=Generic())
+    fighter.passives = ["luna_lunar_reservoir"]
+    # add charge above threshold
+    from plugins.passives.luna_lunar_reservoir import LunaLunarReservoir
+
+    LunaLunarReservoir.add_charge(fighter, amount=250)
+
+    info = registry.describe(fighter)
+    passive = _get_passive(info, "luna_lunar_reservoir")
+    assert passive is not None
+    assert passive["display"] == "spinner"

--- a/frontend/.codex/implementation/battle-effects.md
+++ b/frontend/.codex/implementation/battle-effects.md
@@ -5,11 +5,17 @@
 includes an `id`, optional `name`, `stacks`, `turns`, and `source` along
 with `damage` or `healing` values. `StatusIcons.svelte` and
 `FighterPortrait.svelte` consume these arrays to render icons with stack
-counts and tooltips showing effect details. Fighter portraits now also
-display passive stack indicators beside the element chip: passives with
-five or fewer maximum stacks render pips that fill as stacks accrue,
-larger finite stacks show `current/max`, and unlimited stacks display the
-raw count. These indicators respect Reduced Motion settings and expose
+counts and tooltips showing effect details. `FighterUIItem.svelte`
+renders passive stack indicators beside the element chip. Each passive
+descriptor exposes a `display` hint:
+
+- `spinner` passives show an animated spinner.
+- `pips` render up to five filled pips, switching to a numeric count when stacks exceed five.
+- `number` renders the stack count, or `count/max` when a maximum applies.
+
+CombatViewer lists passive effects and applies the same display hints within its status panels.
+
+These indicators respect Reduced Motion settings and expose
 tooltips for screen readers and mouse users. When a fighter's ultimate
 becomes ready, an element-colored pulse briefly radiates from the
 ultimate ring in `FighterPortrait`; this animation is skipped when

--- a/frontend/src/lib/components/CombatViewer.svelte
+++ b/frontend/src/lib/components/CombatViewer.svelte
@@ -11,6 +11,7 @@
   import PartyRoster from './PartyRoster.svelte';
   import PlayerPreview from './PlayerPreview.svelte';
   import { Circle } from 'lucide-svelte';
+  import Spinner from './Spinner.svelte';
 
   export let party = [];
   export let foes = [];
@@ -198,12 +199,17 @@
                 source: 'passive',
                 stacks: 1,
                 max_stacks: 1,
+                display: 'spinner',
                 overcharged: false
               };
             }
             const stackData = passive.stacks;
             const count = typeof stackData === 'object' ? stackData.mitigation ?? 0 : stackData ?? 1;
             const overcharged = typeof stackData === 'object' && stackData.overcharged;
+            const max = passive.max_stacks ?? count ?? 1;
+            const display = passive.display ?? (
+              passive.max_stacks == null ? 'pips' : passive.max_stacks === 1 ? 'spinner' : 'number'
+            );
             return {
               name: passive.name || passive.id || 'Unknown',
               id: passive.id || passive.name || 'unknown',
@@ -211,7 +217,8 @@
               about: passive.description || 'Passive ability',
               source: 'passive',
               stacks: count,
-              max_stacks: passive.max_stacks ?? count ?? 1,
+              max_stacks: max,
+              display,
               overcharged
             };
           });
@@ -492,14 +499,25 @@
                   <div class="effect-name">
                     {formatEffect(effect)}
                     {#if activeTab === 'passives'}
-                      {#if effect.max_stacks && effect.max_stacks <= 5}
-                        <span class="pips">
-                          {#each Array(effect.max_stacks) as _, i}
-                            <Circle class={`pip-icon${i < effect.stacks ? ' filled' : ''}`} />
-                          {/each}
-                        </span>
-                      {:else if effect.stacks !== undefined && effect.max_stacks}
-                        <span class="pip-count">{effect.stacks}/{effect.max_stacks}</span>
+                      {#if effect.display === 'spinner'}
+                        <Spinner style="color: var(--el-color)" size="0.75rem" thickness="2px" />
+                      {:else if effect.display === 'pips'}
+                        {#if effect.stacks <= 5}
+                          <span class="pips">
+                            {#each Array(effect.stacks) as _, i (i)}
+                              <Circle
+                                class="pip-icon filled"
+                                stroke="none"
+                                fill="currentColor"
+                                aria-hidden="true"
+                              />
+                            {/each}
+                          </span>
+                        {:else}
+                          <span class="pip-count">{effect.stacks}</span>
+                        {/if}
+                      {:else if effect.display === 'number'}
+                        <span class="pip-count">{effect.max_stacks ? `${effect.stacks}/${effect.max_stacks}` : effect.stacks}</span>
                       {/if}
                     {/if}
                   </div>

--- a/frontend/src/lib/components/NavBar.svelte
+++ b/frontend/src/lib/components/NavBar.svelte
@@ -6,6 +6,7 @@
 <script>
   import { Diamond, Users, Settings, Swords, ArrowLeft, Package, Eye } from 'lucide-svelte';
   import { createEventDispatcher } from 'svelte';
+  import Spinner from './Spinner.svelte';
 
   export let battleActive = false;
   export let viewMode = 'main';
@@ -76,7 +77,7 @@
     {/if}
   </div>
   <div class="snapshot-panel" class:active={snapshotLoading}>
-    <div class="spinner"></div>
+    <Spinner style="color:#fff" size="1rem" thickness="2px" />
     <span>Syncing...</span>
   </div>
 </div>
@@ -89,6 +90,4 @@
   .icon-btn:disabled { opacity: 0.4; cursor: not-allowed; }
   .snapshot-panel { display: flex; align-items: center; gap: 0.4rem; padding: 0.5rem 0.7rem; border-radius: 0; background: var(--glass-bg); box-shadow: var(--glass-shadow); border: var(--glass-border); backdrop-filter: var(--glass-filter); opacity: 0; transition: opacity 0.2s; }
   .snapshot-panel.active { opacity: 0.99; }
-  .spinner { width: 1rem; height: 1rem; border: 2px solid #fff; border-right-color: transparent; border-radius: 50%; animation: spin 0.8s linear infinite; }
-  @keyframes spin { to { transform: rotate(360deg); } }
 </style>

--- a/frontend/src/lib/components/Spinner.svelte
+++ b/frontend/src/lib/components/Spinner.svelte
@@ -1,0 +1,17 @@
+<script>
+  export let size = '1rem';
+  export let thickness = '2px';
+</script>
+
+<div class="spinner" style={`width: ${size}; height: ${size}; border-width: ${thickness};`}></div>
+
+<style>
+  .spinner {
+    border-style: solid;
+    border-color: currentColor;
+    border-right-color: transparent;
+    border-radius: 50%;
+    animation: spin 0.8s linear infinite;
+  }
+  @keyframes spin { to { transform: rotate(360deg); } }
+</style>

--- a/frontend/tests/battleview.test.js
+++ b/frontend/tests/battleview.test.js
@@ -6,6 +6,7 @@ const battleView = readFileSync(join(import.meta.dir, '../src/lib/BattleView.sve
 const enrageIndicator = readFileSync(join(import.meta.dir, '../src/lib/battle/EnrageIndicator.svelte'), 'utf8');
 const statusIcons = readFileSync(join(import.meta.dir, '../src/lib/battle/StatusIcons.svelte'), 'utf8');
 const fighterPortrait = readFileSync(join(import.meta.dir, '../src/lib/battle/FighterPortrait.svelte'), 'utf8');
+const fighterUIItem = readFileSync(join(import.meta.dir, '../src/lib/battle/FighterUIItem.svelte'), 'utf8');
 
 describe('BattleView enrage handling', () => {
   test('uses EnrageIndicator component', () => {
@@ -59,8 +60,14 @@ describe('BattleView layout and polling', () => {
   });
 
   test('displays passive stack indicators', () => {
-    expect(fighterPortrait).toContain('fighter.passives');
-    expect(fighterPortrait).toContain('passive-indicators');
+    expect(fighterUIItem).toContain('fighter.passives');
+    expect(fighterUIItem).toContain('passive-indicators');
+  });
+
+  test('supports spinner, pips, and numeric passive displays', () => {
+    expect(fighterUIItem).toContain("p.display === 'spinner'");
+    expect(fighterUIItem).toContain("p.display === 'pips'");
+    expect(fighterUIItem).toContain("p.display === 'number'");
   });
 
   test('uses normalized element for portraits', () => {

--- a/frontend/tests/combatviewer.test.js
+++ b/frontend/tests/combatviewer.test.js
@@ -1,0 +1,22 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+const combatViewer = readFileSync(join(import.meta.dir, '../src/lib/components/CombatViewer.svelte'), 'utf8');
+
+describe('CombatViewer passive display modes', () => {
+  test('renders spinner display', () => {
+    expect(combatViewer).toContain("effect.display === 'spinner'");
+    expect(combatViewer).toContain('<Spinner');
+  });
+
+  test('renders pips with numeric fallback', () => {
+    expect(combatViewer).toContain("effect.display === 'pips'");
+    expect(combatViewer).toContain('effect.stacks <= 5');
+    expect(combatViewer).toContain('pip-count');
+  });
+
+  test('renders numeric count display', () => {
+    expect(combatViewer).toContain("effect.display === 'number'");
+  });
+});


### PR DESCRIPTION
## Summary
- declare `stack_display` hints on all passive plugins
- have passive registry derive descriptor display from `stack_display`
- document passive `stack_display` options and test spinner/pips/number cases
- render passive stack indicators in the frontend based on display hints and reuse a shared spinner component
- respect display hints in CombatViewer and expand frontend tests
- refine default display logic to use pips for small caps and allow dynamic display for Luna's reservoir
- render passive stack indicators via FighterUIItem and drop duplicate portrait code

## Testing
- `uv tool run ruff check backend --fix`
- `bun run lint`
- `./run-tests.sh` *(fails: missing frontend modules such as `$app/environment` and absent Svelte files)*

------
https://chatgpt.com/codex/tasks/task_b_68be8052a698832cabb476e94efb31d3