### PR TITLE
fix: parse Hilander stack index correctly

### DIFF
--- a/backend/plugins/passives/hilander_critical_ferment.py
+++ b/backend/plugins/passives/hilander_critical_ferment.py
@@ -84,8 +84,8 @@ class HilanderCriticalFerment:
 
             for effect in ferment_effects:
                 try:
-                    parts = effect.name.split("_")
-                    stack_num = int(parts[3])
+                    parts = effect.name.rsplit("_", 3)
+                    stack_num = int(parts[2])
                     if stack_num > highest_stack:
                         highest_stack = stack_num
                 except (IndexError, ValueError):

--- a/backend/tests/test_character_passives.py
+++ b/backend/tests/test_character_passives.py
@@ -186,6 +186,7 @@ async def test_hilander_aftertaste_and_soft_cap(monkeypatch):
     set_battle_active(False)
 
     assert target.damage_taken > damage_before
+    assert HilanderCriticalFerment.get_stacks(hilander) == 19
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- correctly parse Hilander Critical Ferment stack numbers when consuming stacks
- test Hilander Critical Ferment consumes a stack on critical hit

## Testing
- `uv run ruff check backend/plugins/passives/hilander_critical_ferment.py backend/tests/test_character_passives.py --fix`
- `PYTHONPATH=backend uv run pytest backend/tests/test_character_passives.py::test_hilander_aftertaste_and_soft_cap -q`
- `PYTHONPATH=backend uv run pytest backend/tests/test_character_passives.py::test_hilander_soft_cap_min_chance -q`
- `./run-tests.sh` *(fails: No module named 'langchain_community')*


------
https://chatgpt.com/codex/tasks/task_b_68bea34a11c4832c807cf1d4c377de0d