### PR TITLE
task: add run logging metrics and character ability audit tasks

### DIFF
--- a/.codex/tasks/17001dd5-character-ability-audit.md
+++ b/.codex/tasks/17001dd5-character-ability-audit.md
@@ -1,0 +1,10 @@
+# Audit character ultimates and passives
+
+Several characters may have mismatched descriptions and behaviors.
+
+## Tasks
+- Coder, compile a list of all playable characters with their documented ultimates and passives.
+- Coder, inspect implementation to determine actual in-game effects for each ultimate and passive.
+- Coder, note discrepancies between documentation and behavior, including missing or incorrect effects.
+- Task Master, create follow-up fix tasks for each discrepancy discovered.
+- Reviewer, validate findings with targeted tests or playthroughs.

--- a/.codex/tasks/652fcf47-run-logging-metrics.md
+++ b/.codex/tasks/652fcf47-run-logging-metrics.md
@@ -1,0 +1,10 @@
+# Backend run logging and metrics
+
+We need more comprehensive telemetry for player runs.
+
+## Tasks
+- Coder, record which character is chosen at the start of each run and write it to the run history table.
+- Coder, log every battle in the run, labeling weak encounters and bosses separately.
+- Coder, persist cumulative counts for total battles, weak battles, and bosses defeated to the database at run end.
+- Coder, add retrieval methods or endpoints to surface these metrics for analytics.
+- Reviewer, add or extend tests to cover the new logging paths.


### PR DESCRIPTION
## Summary
- add task for logging player run metrics and persisting them to the database
- add task to audit character ultimates and passives for doc vs behavior mismatches

## Testing
- `uv run ruff check . --fix --exclude .codex/prototypes`
- `PYTHONPATH=backend uv run pytest backend/tests/test_character_passives.py::test_hilander_aftertaste_and_soft_cap -q`
- `./run-tests.sh` *(fails: missing frontend modules)*

------
https://chatgpt.com/codex/tasks/task_b_68bea5c6bb2c832c8d7264c777568f4b