### PR TITLE
fix: tie Hilander Aftertaste to stack consumption and unsubscribe crit callbacks

### DIFF
--- a/.codex/tasks/character_passive_ultimate_review.md
+++ b/.codex/tasks/character_passive_ultimate_review.md
@@ -53,6 +53,7 @@ This task list catalogs each playable character's listed passive ability and ult
 - **Ultimate – Random element**
 - **Tasks**:
   - [x] Confirm stack removal works for both crit rate and damage effects.
+  - [x] Gate Aftertaste triggers behind available Ferment stacks.
   - Decide on a fixed element if random damage type is not desired.
 
 ## Kboshi


### PR DESCRIPTION
## Summary
- gate Hilander Aftertaste behind existing Ferment stacks
- unsubscribe critical-hit callbacks when Ferment stacks are exhausted using weak references
- note Aftertaste gating in character passive review tasks

## Testing
- `uv run ruff check backend/plugins/passives/hilander_critical_ferment.py --fix`
- `./run-tests.sh` *(fails: KeyError: 'foes' in test_battle_snapshot_consistency)*

------
https://chatgpt.com/codex/tasks/task_b_68beb1423c7c832cbe61198d3696d7fa