### PR TITLE
[FIX] integrate effect manager cleanup for Ally Overload

### DIFF
--- a/.codex/tasks/character_passive_ultimate_review.md
+++ b/.codex/tasks/character_passive_ultimate_review.md
@@ -7,7 +7,7 @@ This task list catalogs each playable character's listed passive ability and ult
   - **Actual**: `AllyOverload` grants two attacks per turn, builds 10 charge per action with reduced gains past 120, and Overload quadruples attacks while applying damage bonuses and vulnerabilities. Effects rely on manual `_active_effects` management and lack full effect-system integration.
 - **Ultimate – Random element**: Damage type chosen randomly; ultimate depends on rolled element.
 - **Tasks**:
-  - Integrate Overload effect removal with the `EffectManager` instead of directly editing `_active_effects`.
+  - [x] Integrate Overload effect removal with the `EffectManager` instead of directly editing `_active_effects`.
   - Confirm random element persists across sessions or select a fixed element.
 
 ## Becca

--- a/backend/plugins/passives/ally_overload.py
+++ b/backend/plugins/passives/ally_overload.py
@@ -116,11 +116,8 @@ class AllyOverload:
         ]
 
         for effect_name in effects_to_remove:
-            # Find and remove effects (would need effect system integration)
-            target._active_effects = [
-                effect for effect in target._active_effects
-                if effect.name != effect_name
-            ]
+            # Use effect manager helper to remove by name
+            target.remove_effect_by_name(effect_name)
 
         # Reset to base twin dagger attacks
         target.actions_per_turn = 2


### PR DESCRIPTION
## Summary
- use Stats.remove_effect_by_name in AllyOverload to clean up stance effects
- mark Overload cleanup task complete in passive/ultimate review

## Testing
- `ruff check backend/plugins/passives/ally_overload.py --fix`
- `./run-tests.sh` *(fails: AttributeError in tests/test_wind_ultimate_dot_transfer.py)*

------
https://chatgpt.com/codex/tasks/task_b_68beb159df8c832ca10995646bf74b3e