### PR TITLE
[FIX] handle batched events safely

### DIFF
--- a/backend/tests/test_event_bus.py
+++ b/backend/tests/test_event_bus.py
@@ -1,4 +1,6 @@
+import asyncio
 import importlib.util
+import logging
 from pathlib import Path
 
 spec = importlib.util.spec_from_file_location(
@@ -23,3 +25,72 @@ def test_event_bus_emit_and_unsubscribe():
     bus.unsubscribe("test", handler)
     bus.emit("test", 2)
     assert received == [1]
+
+
+def test_emit_batched_within_subscriber():
+    bus = EventBus()
+    received = []
+
+    def inner_handler(value):
+        received.append(value)
+
+    def outer_handler(value):
+        bus.emit_batched("inner", value + 1)
+
+    bus.subscribe("inner", inner_handler)
+    bus.subscribe("outer", outer_handler)
+
+    bus.emit_batched("outer", 1)
+    assert received == [2]
+
+    bus.unsubscribe("inner", inner_handler)
+    bus.unsubscribe("outer", outer_handler)
+
+
+def test_dynamic_batch_interval_thresholds():
+    async def run_scenario(existing: int) -> float:
+        bus = EventBus()
+        internal = event_bus_module.bus
+        intervals = []
+
+        async def capture(interval: float) -> None:
+            intervals.append(interval)
+
+        internal._process_batches_with_interval = capture  # type: ignore[assignment]
+        internal._batched_events["test"] = [()] * existing
+        bus.emit_batched("test", ())
+        await asyncio.sleep(0)
+        internal._batch_timer = None
+        return intervals[0]
+
+    interval_51 = asyncio.run(run_scenario(50))
+    assert interval_51 == max(0.005, 0.016 * 0.5)
+
+    interval_101 = asyncio.run(run_scenario(100))
+    assert interval_101 == 0.001
+
+
+def test_emit_batched_without_loop_logs_debug(caplog):
+    bus = EventBus()
+    with caplog.at_level(logging.DEBUG, logger=event_bus_module.__name__):
+        bus.emit_batched("test", ())
+
+    messages = [record.getMessage() for record in caplog.records]
+    assert any("No running event loop" in msg for msg in messages)
+    assert all("RuntimeError" not in msg for msg in messages)
+
+
+def test_async_callback_without_loop_avoids_runtime_error(caplog):
+    bus = EventBus()
+
+    async def handler(value):
+        pass
+
+    bus.subscribe("test", handler)
+
+    with caplog.at_level(logging.WARNING, logger=event_bus_module.__name__):
+        bus.emit("test", 1)
+
+    messages = [record.getMessage() for record in caplog.records]
+    assert any("called from sync context with no event loop" in msg for msg in messages)
+    assert all("RuntimeError" not in msg for msg in messages)


### PR DESCRIPTION
## Summary
- avoid RuntimeError by snapshotting batched events and preventing re-entrant processing
- prioritize high-load batch threshold before medium threshold to ensure fastest interval
- guard event loop detection so batched sends and async subscribers fall back cleanly without RuntimeError logs
- add regression tests for nested batching, dynamic thresholds, and loopless operation

## Testing
- `uv venv && uv sync`
- `uvx ruff check plugins/event_bus.py tests/test_event_bus.py --fix`
- `uv run pytest tests/test_event_bus.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68beb5cd5ec0832c888de53c09f68633