### PR TITLE
Weight Luna foe encounters

### DIFF
--- a/.codex/implementation/player-foe-reference.md
+++ b/.codex/implementation/player-foe-reference.md
@@ -72,6 +72,9 @@ continue this sequence, and the total foe count never exceeds ten.
 Each foe defeated during a battle temporarily raises the party's rare drop rate
 by 55% for that room, increasing gold rewards and element-based item drops.
 
+Luna's foe variant is weighted to appear more often than other characters,
+including in boss encounters when she isn't already in the party.
+
 Foes also expose a `rank` field to describe encounter tier. Supported ranks are
 `normal`, `prime`, `glitched prime`, `boss`, and `glitched boss`. Battle and
 boss room responses include this field for every foe so the frontend can render

--- a/ABOUTGAME.md
+++ b/ABOUTGAME.md
@@ -88,6 +88,8 @@ Each foe defeated during a battle temporarily grants +55% `rdr` for that room, r
 
 The game auto-discovers classes under `plugins/` and `mods/` by `plugin_type` and wires them to a shared event bus. See `.codex/implementation/plugin-system.md` for loader details and examples. Player and foe plugins also expose `prompt` and `about` strings with placeholder text for future character customization.
 
+Luna's foe form is weighted to appear more frequently and may even show up as a boss when she isn't in the player's party.
+
 ### Player Creator
 
 Use the in-game editor to set your pronouns, choose a damage type, and distribute 100 stat points across HP, attack, and defense. Each stat point provides a +1% increase. Spending 100 of each damage type's 4★ upgrade items grants one extra stat point. The customization is stored in the encrypted `save.db` database for new runs.

--- a/backend/tests/test_luna_weighting.py
+++ b/backend/tests/test_luna_weighting.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+import random
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from autofighter.mapgen import MapNode
+from autofighter.party import Party
+from autofighter.rooms import utils
+from plugins.players import Player
+
+
+def test_luna_weighted_selection() -> None:
+    random.seed(0)
+    party = Party(members=[Player()])
+    counts: dict[str, int] = {}
+    for _ in range(200):
+        foe = utils._choose_foe(party)
+        counts[foe.id] = counts.get(foe.id, 0) + 1
+    luna_count = counts.get("luna", 0)
+    assert luna_count > 0
+    counts.pop("luna", None)
+    assert all(luna_count > c for c in counts.values())
+
+
+def test_luna_can_be_boss() -> None:
+    random.seed(0)
+    party = Party(members=[Player()])
+    node = MapNode(room_id=0, room_type="boss", floor=1, index=1, loop=1, pressure=0)
+    foe = utils._build_foes(node, party)[0]
+    assert foe.id == "luna"
+    assert foe.rank == "boss"


### PR DESCRIPTION
## Summary
- Boost Luna's appearance in foe selection and boss fights
- Document Luna's increased encounter chance
- Test weighted foe selection

## Testing
- `uv tool run ruff check backend --fix`
- `uv run pytest backend/tests/test_luna_weighting.py`
- `./run-tests.sh` *(fails: TypeError: Stats.__init__() got an unexpected keyword argument 'atk')*


------
https://chatgpt.com/codex/tasks/task_b_68bec8524d58832cb1e8930a9854c040