### PR TITLE
Display user buff and retain PartyPicker preview

### DIFF
--- a/backend/tests/test_players_user.py
+++ b/backend/tests/test_players_user.py
@@ -1,0 +1,31 @@
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture()
+def app_with_db(tmp_path, monkeypatch):
+    db_path = tmp_path / "save.db"
+    monkeypatch.setenv("AF_DB_PATH", str(db_path))
+    monkeypatch.setenv("AF_DB_KEY", "testkey")
+    monkeypatch.syspath_prepend(Path(__file__).resolve().parents[1])
+    spec = importlib.util.spec_from_file_location(
+        "app", Path(__file__).resolve().parents[1] / "app.py",
+    )
+    app_module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(app_module)
+    app_module.app.testing = True
+    return app_module.app, db_path
+
+
+@pytest.mark.asyncio
+async def test_players_returns_user(app_with_db):
+    app, _ = app_with_db
+    client = app.test_client()
+    resp = await client.get("/players")
+    data = await resp.get_json()
+    assert "user" in data
+    assert isinstance(data["user"], dict)
+

--- a/frontend/src/lib/components/PartyPicker.svelte
+++ b/frontend/src/lib/components/PartyPicker.svelte
@@ -11,6 +11,7 @@
 
   let background = '';
   let roster = [];
+  let userBuffPercent = 0;
 
   export let selected = [];
   export let compact = false;
@@ -131,6 +132,7 @@
   async function refreshRoster() {
     try {
       const data = await getPlayers();
+      userBuffPercent = data.user?.level ?? 0;
       function resolveElement(p) {
         let e = p?.element;
         if (e && typeof e !== 'string') e = e.id || e.name;
@@ -154,7 +156,7 @@
       selected = oldSelected.filter((id) => roster.some((c) => c.id === id));
       const player = roster.find((p) => p.is_player);
       const defaultPreview = player ? player.id : (roster[0]?.id || null);
-      previewId = selected[0] ?? oldPreview ?? defaultPreview;
+      previewId = oldPreview ?? selected[0] ?? defaultPreview;
     } catch (e) {
       if (dev || !browser) {
         const { error } = await import('$lib/systems/logger.js');
@@ -189,7 +191,7 @@
       <PartyRoster {roster} {selected} bind:previewId {reducedMotion} on:toggle={(e) => toggleMember(e.detail)} />
       <PlayerPreview {roster} {previewId} overrideElement={previewElementOverride} />
       <div class="right-col">
-        <StatTabs {roster} {previewId} {selected}
+        <StatTabs {roster} {previewId} {selected} {userBuffPercent}
           on:toggle={(e) => toggleMember(e.detail)}
           on:preview-element={(e) => {
             const el = e.detail.element;

--- a/frontend/src/lib/components/StatTabs.svelte
+++ b/frontend/src/lib/components/StatTabs.svelte
@@ -29,11 +29,12 @@
    * - selected: array of selected character IDs
    *
    * Events:
-   * - toggle: dispatched with the previewId when Add/Remove is clicked
-   */
+  * - toggle: dispatched with the previewId when Add/Remove is clicked
+  */
   export let roster = [];
   export let previewId;
   export let selected = [];
+  export let userBuffPercent = 0;
 
   const statTabs = ['Core', 'Offense', 'Defense'];
   let activeTab = 'Core';
@@ -309,6 +310,7 @@
           style={`color: ${getElementColor((isPlayer && editorVals?.damageType) ? editorVals.damageType : sel.element)}`}
           aria-hidden="true" />
       </div>
+      <div class="buff-note">Global Buff: +{userBuffPercent}%</div>
       <div class="stats-list">
         {#if activeTab === 'Core'}
           <div>
@@ -412,6 +414,7 @@
 .char-name { font-size: 1.2rem; color: #fff; flex: 1; }
 .char-level { font-size: 1rem; color: #ccc; }
 .type-icon { width: 24px; height: 24px; }
+.buff-note { font-size: 0.85rem; color: #ccc; margin-bottom: 0.3rem; }
 .stats-list {
   display: flex;
   flex-direction: column;

--- a/frontend/tests/partypicker.test.js
+++ b/frontend/tests/partypicker.test.js
@@ -4,17 +4,17 @@ import { join } from 'path';
 
 describe('PartyPicker component', () => {
   test('contains party picker markup', () => {
-    const content = readFileSync(join(import.meta.dir, '../src/lib/PartyPicker.svelte'), 'utf8');
+    const content = readFileSync(join(import.meta.dir, '../src/lib/components/PartyPicker.svelte'), 'utf8');
     expect(content).toContain('data-testid="party-picker"');
   });
 
   test('includes add/remove control', () => {
-    const content = readFileSync(join(import.meta.dir, '../src/lib/StatTabs.svelte'), 'utf8');
+    const content = readFileSync(join(import.meta.dir, '../src/lib/components/StatTabs.svelte'), 'utf8');
     expect(content).toContain('Add to party');
   });
 
   test('references updated stat keys', () => {
-    const content = readFileSync(join(import.meta.dir, '../src/lib/StatTabs.svelte'), 'utf8');
+    const content = readFileSync(join(import.meta.dir, '../src/lib/components/StatTabs.svelte'), 'utf8');
     expect(content).toContain('crit_damage');
     expect(content).toContain('effect_hit_rate');
     expect(content).toContain('dodge_odds');
@@ -22,14 +22,14 @@ describe('PartyPicker component', () => {
   });
 
   test('filters unowned characters and normalizes element names', () => {
-    const content = readFileSync(join(import.meta.dir, '../src/lib/PartyPicker.svelte'), 'utf8');
+    const content = readFileSync(join(import.meta.dir, '../src/lib/components/PartyPicker.svelte'), 'utf8');
     expect(content).toContain('filter((p) => p.owned || p.is_player)');
     expect(content).toContain('selected = selected.filter((id) => roster.some((c) => c.id === id))');
     expect(content).toContain('element: resolveElement(p)');
   });
 
   test('orders stats correctly', () => {
-    const content = readFileSync(join(import.meta.dir, '../src/lib/StatTabs.svelte'), 'utf8');
+    const content = readFileSync(join(import.meta.dir, '../src/lib/components/StatTabs.svelte'), 'utf8');
     const coreStart = content.indexOf("{#if activeTab === 'Core'}");
     const coreEnd = content.indexOf("{:else if activeTab === 'Offense'}");
     const coreSection = content.slice(coreStart, coreEnd);
@@ -42,14 +42,20 @@ describe('PartyPicker component', () => {
   });
 
   test('uses element colors for icon and outline', () => {
-    const rosterContent = readFileSync(join(import.meta.dir, '../src/lib/PartyRoster.svelte'), 'utf8');
+    const rosterContent = readFileSync(join(import.meta.dir, '../src/lib/components/PartyRoster.svelte'), 'utf8');
     expect(rosterContent).toContain('style={`border-color: ${getElementColor(char.element)}`}');
     expect(rosterContent).toContain('style={`color: ${getElementColor(char.element)}`}');
   });
 
   test('roster layout snapshot', () => {
-    const content = readFileSync(join(import.meta.dir, '../src/lib/PartyRoster.svelte'), 'utf8');
+    const content = readFileSync(join(import.meta.dir, '../src/lib/components/PartyRoster.svelte'), 'utf8');
     expect(content).toMatchSnapshot();
+  });
+
+  test('preserves preview and passes buff percent', () => {
+    const content = readFileSync(join(import.meta.dir, '../src/lib/components/PartyPicker.svelte'), 'utf8');
+    expect(content).toContain('previewId = oldPreview ?? selected[0] ?? defaultPreview;');
+    expect(content).toContain('<StatTabs {roster} {previewId} {selected} {userBuffPercent}');
   });
 });
 

--- a/frontend/tests/stat-tabs-persistence.test.js
+++ b/frontend/tests/stat-tabs-persistence.test.js
@@ -14,4 +14,9 @@ describe('StatTabs editor persistence', () => {
   test('restores cached values when switching', () => {
     expect(content).toContain('const cached = editorConfigs.get(previewChar.id)');
   });
+
+  test('shows global buff note', () => {
+    expect(content).toContain('export let userBuffPercent = 0');
+    expect(content).toContain('Global Buff: +{userBuffPercent}%');
+  });
 });


### PR DESCRIPTION
## Summary
- expose user level as `userBuffPercent` in PartyPicker and forward to StatTabs
- show global buff percent in StatTabs header
- keep current character preview when refreshing roster
- add regression test confirming `/players` returns a `user` object

## Testing
- `ruff check backend --fix`
- `./run-tests.sh` *(fails: test_chat_room missing llms, various frontend ENOENT/timeout errors)*


------
https://chatgpt.com/codex/tasks/task_b_68bed35b289c832cbe5fbf25188fd341