### PR TITLE
[FIX] guard battle room requests

### DIFF
--- a/backend/game.py
+++ b/backend/game.py
@@ -71,6 +71,7 @@ def get_fernet() -> Fernet:
 
 battle_tasks: dict[str, asyncio.Task] = {}
 battle_snapshots: dict[str, dict[str, Any]] = {}
+battle_locks: dict[str, asyncio.Lock] = {}
 
 def _describe_passives(obj: Stats | list[str]) -> list[dict[str, Any]]:
     registry = PassiveRegistry()


### PR DESCRIPTION
## Summary
- prevent overlapping room fetches in Svelte enterRoom
- add battle_locks to serialise battle and boss room state
- guard boss_room against duplicate battle tasks

## Testing
- `ruff check backend/game.py backend/services/room_service.py --fix`
- `bun run lint`
- `./run-tests.sh` *(fails: ModuleNotFoundError: No module named 'battle_logging', etc.)*

------
https://chatgpt.com/codex/tasks/task_b_68bee3da2424832c88c0f6fb17e8da55