### PR TITLE
feat: add battle state cleanup and metrics

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -46,6 +46,10 @@ The backend uses a queued, buffered logging pipeline:
 - Records land in a rotating log file at `logs/backend.log`.
 - A `RichHandler` remains attached for colorful console output.
 
+## Performance and Memory Metrics
+
+`GET /performance/metrics` exposes the sizes of the in-memory battle tracking structures (`battle_tasks`, `battle_snapshots`, and `battle_locks`) along with current process memory usage (via `psutil` if installed or `tracemalloc` otherwise). Operators can trigger manual cleanup of completed battles with `POST /performance/gc`, which purges stale state and runs garbage collection.
+
 The root endpoint returns a simple status payload including the configured flavor. Set `UV_EXTRA` (default `"default"`) to label this instance. Additional routes support
 starting runs with a seeded 45-room map, updating the party, retrieving floor
 maps, listing available player characters, returning room background images,

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
 import traceback
@@ -13,6 +14,7 @@ from game import _run_battle  # noqa: F401
 from game import _scale_stats  # noqa: F401
 from game import battle_snapshots  # noqa: F401
 from game import battle_tasks  # noqa: F401
+from game import cleanup_battle_state
 from game import get_fernet  # noqa: F401
 from game import get_save_manager  # noqa: F401
 from game import load_map  # noqa: F401
@@ -85,6 +87,17 @@ async def handle_exception(e: Exception):
     response.headers["Access-Control-Allow-Headers"] = "Content-Type"
     response.headers["Access-Control-Allow-Methods"] = "GET, POST, PUT, DELETE, OPTIONS"
     return response
+
+
+async def _cleanup_loop() -> None:
+    while True:
+        await asyncio.sleep(300)
+        await cleanup_battle_state()
+
+
+@app.before_serving
+async def start_background_tasks() -> None:
+    asyncio.create_task(_cleanup_loop())
 
 
 if __name__ == "__main__":

--- a/backend/routes/performance.py
+++ b/backend/routes/performance.py
@@ -3,11 +3,19 @@ Event bus performance monitoring endpoint.
 Provides real-time metrics about event bus performance and health.
 """
 import time
+import tracemalloc
 
+from game import cleanup_battle_state
+from game import get_battle_state_sizes
 from quart import Blueprint
 from quart import jsonify
 
 from autofighter.stats import BUS
+
+try:
+    import psutil
+except Exception:  # pragma: no cover - optional dependency
+    psutil = None
 
 perf_bp = Blueprint('performance', __name__)
 
@@ -51,6 +59,18 @@ async def get_event_bus_metrics():
             health_status['status'] = 'unhealthy'
             health_status['error_rate'] = total_errors / total_events if total_events > 0 else 0
 
+        state_sizes = get_battle_state_sizes()
+        memory: dict[str, int] = {}
+        if psutil is not None:
+            process = psutil.Process()
+            info = process.memory_info()
+            memory = {'rss': info.rss, 'vms': info.vms}
+        else:
+            if not tracemalloc.is_tracing():
+                tracemalloc.start()
+            current, peak = tracemalloc.get_traced_memory()
+            memory = {'current': current, 'peak': peak}
+
         return jsonify({
             'health': health_status,
             'metrics': metrics,
@@ -59,7 +79,9 @@ async def get_event_bus_metrics():
                 'total_errors': total_errors,
                 'error_rate': total_errors / total_events if total_events > 0 else 0,
                 'slow_events_count': len(slow_events)
-            }
+            },
+            'battle_state': state_sizes,
+            'memory': memory,
         })
 
     except Exception as e:
@@ -124,3 +146,10 @@ async def clear_metrics():
             'status': 'error',
             'error': str(e)
         }), 500
+
+
+@perf_bp.route('/gc', methods=['POST'])
+async def trigger_cleanup():
+    """Trigger manual battle state cleanup."""
+    await cleanup_battle_state()
+    return jsonify({'status': 'ok'})


### PR DESCRIPTION
## Summary
- add async cleanup_battle_state helper and battle state metrics
- schedule periodic battle state cleanup on startup
- expose manual cleanup endpoint and memory metrics

## Testing
- `uv run ruff check backend --fix`
- `./run-tests.sh` *(fails: Cannot find module '$app/environment'...)*

------
https://chatgpt.com/codex/tasks/task_b_68bef5f82000832c9cfb364ab190caf0