### PR TITLE
feat: show element icon in ultimate gauge

### DIFF
--- a/frontend/src/lib/battle/FighterUIItem.svelte
+++ b/frontend/src/lib/battle/FighterUIItem.svelte
@@ -1,7 +1,7 @@
 <script>
   import { Circle as PipCircle } from 'lucide-svelte';
   import Spinner from '../components/Spinner.svelte';
-  import { getCharacterImage, getElementColor } from '../systems/assetLoader.js';
+  import { getCharacterImage, getElementColor, getElementIcon } from '../systems/assetLoader.js';
 
   export let fighter = {};
   export let position = 'bottom'; // 'top' for foes, 'bottom' for party
@@ -12,6 +12,7 @@
   // Image prioritization: summon_type first, then id as fallback
   $: imageId = fighter?.summon_type || fighter?.id || '';
   $: elColor = getElementColor(fighter.element);
+  $: elIcon = getElementIcon(fighter.element);
   // Make party (bottom) portraits larger for readability
   $: portraitSize = sizePx ? `${sizePx}px` : (size === 'small' ? '48px' : (size === 'medium' ? '96px' : (position === 'bottom' ? '256px' : '96px')));
   
@@ -148,9 +149,10 @@
         class="ult-gauge"
         class:ult-ready={Boolean(fighter?.ultimate_ready)}
         style="--element-color: {elColor}; --p: {Math.max(0, Math.min(1, Number(fighter?.ultimate_charge || 0) / 15))}"
-        aria-label="Ultimate Gauge"
+      aria-label="Ultimate Gauge"
       >
         <div class="ult-fill"></div>
+        <svelte:component this={elIcon} class="ult-icon" aria-hidden="true" />
         {#if !fighter?.ultimate_ready}
           <div class="ult-pulse" style={`animation-duration: ${Math.max(0.4, 1.6 - 1.2 * Math.max(0, Math.min(1, Number(fighter?.ultimate_charge || 0) / 15)))}s`}></div>
         {/if}
@@ -533,6 +535,23 @@
     height: calc(var(--p, 0) * 100%);
     /* Solid single-color fill based on the element color */
     background: color-mix(in oklab, var(--element-color, #6cf) 68%, black);
+    z-index: 0;
+  }
+  .ult-icon {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    width: 60%;
+    height: 60%;
+    filter: grayscale(100%);
+    opacity: 0.5;
+    z-index: 1;
+    pointer-events: none;
+  }
+  .ult-ready .ult-icon {
+    filter: none;
+    opacity: 1;
   }
   /* Breathing pulse while charging; speeds up as --p increases */
   .ult-pulse {
@@ -540,6 +559,7 @@
     inset: 0;
     border-radius: 50%;
     pointer-events: none;
+    z-index: 2;
     background: radial-gradient(circle,
       color-mix(in oklab, var(--element-color, #6cf) 30%, white) 0%,
       transparent 70%);
@@ -578,6 +598,7 @@
     background: radial-gradient(circle, color-mix(in oklab, var(--element-color, #6cf) 50%, white) 0%, transparent 70%);
     opacity: 0.22;
     animation: ult-pulse 1.4s ease-in-out infinite;
+    z-index: 3;
   }
   @keyframes ult-pulse {
     0%, 100% { transform: scale(1); opacity: 0.25; }

--- a/frontend/tests/battleview.test.js
+++ b/frontend/tests/battleview.test.js
@@ -70,6 +70,10 @@ describe('BattleView layout and polling', () => {
     expect(fighterUIItem).toContain("p.display === 'number'");
   });
 
+  test('renders element icon within the ultimate gauge', () => {
+    expect(fighterUIItem).toContain('ult-icon');
+  });
+
   test('uses normalized element for portraits', () => {
     expect(fighterPortrait).toContain('getElementIcon(fighter.element)');
     expect(fighterPortrait).toContain('getElementColor(fighter.element)');


### PR DESCRIPTION
## Summary
- display element icon inside ultimate gauge for fighters
- test coverage updated for new gauge icon

## Testing
- `bun run lint`
- `ruff check . --fix` *(fails: F841 Local variable `total_fighters` is assigned to but never used, W291 Trailing whitespace, ...)*
- `./run-tests.sh` *(fails: ModuleNotFoundError: No module named 'battle_logging'; FAILED tests/test_battle_snapshot_consistency.py::test_foe_element_stable_across_snapshots - KeyError: 'foes')*
- `bun test tests/battleview.test.js` *(fails: ENOENT: no such file or directory, open '/workspace/Midori-AI-AutoFighter/frontend/src/lib/BattleView.svelte')*

------
https://chatgpt.com/codex/tasks/task_b_68bfd5646d90832c979005e423483722