### PR TITLE
[REF] refactor damage type lookups

### DIFF
--- a/backend/plugins/damage_types/__init__.py
+++ b/backend/plugins/damage_types/__init__.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from importlib import import_module
 from random import choice
+from typing import Any
 
 from plugins.damage_types._base import DamageTypeBase
 
@@ -28,17 +29,33 @@ def random_damage_type() -> DamageTypeBase:
     return _load_cls(choice(ALL_DAMAGE_TYPES))()
 
 
-def get_damage_type(name: str) -> DamageTypeBase:
-    lowered = name.lower()
-    if "luna" in lowered:
-        return _load_cls("Generic")()
-    if "kboshi" in lowered:
-        return _load_cls("Dark")()
-    if "ixia" in lowered:
-        return _load_cls("Lightning")()
-    matches = [dtype for dtype in ALL_DAMAGE_TYPES if dtype.lower() in lowered]
-    if matches:
-        return _load_cls(choice(matches))()
+def get_damage_type(source: Any) -> DamageTypeBase:
+    """Return a damage type based on the given source.
+
+    The function attempts the following, in order:
+    1. If ``source`` has a ``damage_type`` attribute, return it. If that
+       attribute is a string, load the corresponding damage type class.
+    2. If ``source`` is a string, try to match one of the known damage types
+       within it.
+    3. Fall back to a random damage type.
+    """
+
+    if isinstance(source, DamageTypeBase):
+        return source
+
+    if hasattr(source, "damage_type"):
+        damage_type = getattr(source, "damage_type")
+        if isinstance(damage_type, DamageTypeBase):
+            return damage_type
+        if isinstance(damage_type, str):
+            return load_damage_type(damage_type)
+
+    if isinstance(source, str):
+        lowered = source.lower()
+        matches = [dtype for dtype in ALL_DAMAGE_TYPES if dtype.lower() in lowered]
+        if matches:
+            return _load_cls(choice(matches))()
+
     return random_damage_type()
 
 

--- a/backend/plugins/players/ally.py
+++ b/backend/plugins/players/ally.py
@@ -1,8 +1,10 @@
 from dataclasses import dataclass
 from dataclasses import field
+from random import choice
 
 from autofighter.character import CharacterType
-from plugins.damage_types import get_damage_type
+from plugins.damage_types import ALL_DAMAGE_TYPES
+from plugins.damage_types import load_damage_type
 from plugins.damage_types._base import DamageTypeBase
 from plugins.players._base import PlayerBase
 
@@ -14,6 +16,6 @@ class Ally(PlayerBase):
     char_type: CharacterType = CharacterType.B
     gacha_rarity = 5
     damage_type: DamageTypeBase = field(
-        default_factory=lambda: get_damage_type("Ally")
+        default_factory=lambda: load_damage_type(choice(ALL_DAMAGE_TYPES))
     )
     passives: list[str] = field(default_factory=lambda: ["ally_overload"])

--- a/backend/plugins/players/becca.py
+++ b/backend/plugins/players/becca.py
@@ -1,8 +1,10 @@
 from dataclasses import dataclass
 from dataclasses import field
+from random import choice
 
 from autofighter.character import CharacterType
-from plugins.damage_types import get_damage_type
+from plugins.damage_types import ALL_DAMAGE_TYPES
+from plugins.damage_types import load_damage_type
 from plugins.damage_types._base import DamageTypeBase
 from plugins.players._base import PlayerBase
 
@@ -14,6 +16,6 @@ class Becca(PlayerBase):
     char_type: CharacterType = CharacterType.B
     gacha_rarity = 5
     damage_type: DamageTypeBase = field(
-        default_factory=lambda: get_damage_type("Becca")
+        default_factory=lambda: load_damage_type(choice(ALL_DAMAGE_TYPES))
     )
     passives: list[str] = field(default_factory=lambda: ["becca_menagerie_bond"])

--- a/backend/plugins/players/bubbles.py
+++ b/backend/plugins/players/bubbles.py
@@ -1,8 +1,10 @@
 from dataclasses import dataclass
 from dataclasses import field
+from random import choice
 
 from autofighter.character import CharacterType
-from plugins.damage_types import get_damage_type
+from plugins.damage_types import ALL_DAMAGE_TYPES
+from plugins.damage_types import load_damage_type
 from plugins.damage_types._base import DamageTypeBase
 from plugins.players._base import PlayerBase
 
@@ -14,6 +16,6 @@ class Bubbles(PlayerBase):
     char_type: CharacterType = CharacterType.A
     gacha_rarity = 5
     damage_type: DamageTypeBase = field(
-        default_factory=lambda: get_damage_type("Bubbles")
+        default_factory=lambda: load_damage_type(choice(ALL_DAMAGE_TYPES))
     )
     passives: list[str] = field(default_factory=lambda: ["bubbles_bubble_burst"])

--- a/backend/plugins/players/graygray.py
+++ b/backend/plugins/players/graygray.py
@@ -1,8 +1,10 @@
 from dataclasses import dataclass
 from dataclasses import field
+from random import choice
 
 from autofighter.character import CharacterType
-from plugins.damage_types import get_damage_type
+from plugins.damage_types import ALL_DAMAGE_TYPES
+from plugins.damage_types import load_damage_type
 from plugins.damage_types._base import DamageTypeBase
 from plugins.players._base import PlayerBase
 
@@ -14,6 +16,6 @@ class Graygray(PlayerBase):
     char_type: CharacterType = CharacterType.B
     gacha_rarity = 5
     damage_type: DamageTypeBase = field(
-        default_factory=lambda: get_damage_type("Graygray")
+        default_factory=lambda: load_damage_type(choice(ALL_DAMAGE_TYPES))
     )
     passives: list[str] = field(default_factory=lambda: ["graygray_counter_maestro"])

--- a/backend/plugins/players/hilander.py
+++ b/backend/plugins/players/hilander.py
@@ -1,8 +1,10 @@
 from dataclasses import dataclass
 from dataclasses import field
+from random import choice
 
 from autofighter.character import CharacterType
-from plugins.damage_types import get_damage_type
+from plugins.damage_types import ALL_DAMAGE_TYPES
+from plugins.damage_types import load_damage_type
 from plugins.damage_types._base import DamageTypeBase
 from plugins.players._base import PlayerBase
 
@@ -14,6 +16,6 @@ class Hilander(PlayerBase):
     char_type: CharacterType = CharacterType.A
     gacha_rarity = 5
     damage_type: DamageTypeBase = field(
-        default_factory=lambda: get_damage_type("Hilander")
+        default_factory=lambda: load_damage_type(choice(ALL_DAMAGE_TYPES))
     )
     passives: list[str] = field(default_factory=lambda: ["hilander_critical_ferment"])

--- a/backend/plugins/players/ixia.py
+++ b/backend/plugins/players/ixia.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from dataclasses import field
 
 from autofighter.character import CharacterType
-from plugins.damage_types import get_damage_type
+from plugins.damage_types import load_damage_type
 from plugins.damage_types._base import DamageTypeBase
 from plugins.players._base import PlayerBase
 
@@ -14,6 +14,6 @@ class Ixia(PlayerBase):
     char_type: CharacterType = CharacterType.A
     gacha_rarity = 5
     damage_type: DamageTypeBase = field(
-        default_factory=lambda: get_damage_type("Ixia")
+        default_factory=lambda: load_damage_type("Lightning")
     )
     passives: list[str] = field(default_factory=lambda: ["ixia_tiny_titan"])

--- a/backend/plugins/players/kboshi.py
+++ b/backend/plugins/players/kboshi.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from dataclasses import field
 
 from autofighter.character import CharacterType
-from plugins.damage_types import get_damage_type
+from plugins.damage_types import load_damage_type
 from plugins.damage_types._base import DamageTypeBase
 from plugins.players._base import PlayerBase
 
@@ -14,6 +14,6 @@ class Kboshi(PlayerBase):
     char_type: CharacterType = CharacterType.A
     gacha_rarity = 5
     damage_type: DamageTypeBase = field(
-        default_factory=lambda: get_damage_type("Kboshi")
+        default_factory=lambda: load_damage_type("Dark")
     )
     passives: list[str] = field(default_factory=lambda: ["kboshi_flux_cycle"])

--- a/backend/plugins/players/lady_fire_and_ice.py
+++ b/backend/plugins/players/lady_fire_and_ice.py
@@ -1,8 +1,9 @@
 from dataclasses import dataclass
 from dataclasses import field
+from random import choice
 
 from autofighter.character import CharacterType
-from plugins.damage_types import get_damage_type
+from plugins.damage_types import load_damage_type
 from plugins.damage_types._base import DamageTypeBase
 from plugins.players._base import PlayerBase
 
@@ -14,6 +15,6 @@ class LadyFireAndIce(PlayerBase):
     char_type: CharacterType = CharacterType.B
     gacha_rarity = 6
     damage_type: DamageTypeBase = field(
-        default_factory=lambda: get_damage_type("LadyFireAndIce")
+        default_factory=lambda: load_damage_type(choice(["Fire", "Ice"]))
     )
     passives: list[str] = field(default_factory=lambda: ["lady_fire_and_ice_duality_engine"])

--- a/backend/plugins/players/luna.py
+++ b/backend/plugins/players/luna.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from dataclasses import field
 
 from autofighter.character import CharacterType
-from plugins.damage_types import get_damage_type
+from plugins.damage_types import load_damage_type
 from plugins.damage_types._base import DamageTypeBase
 from plugins.players._base import PlayerBase
 
@@ -14,7 +14,7 @@ class Luna(PlayerBase):
     ##
     char_type: CharacterType = CharacterType.B
     damage_type: DamageTypeBase = field(
-        default_factory=lambda: get_damage_type("Luna")
+        default_factory=lambda: load_damage_type("Generic")
     )
     passives: list[str] = field(default_factory=lambda: ["luna_lunar_reservoir"])
     # UI hint: show numeric actions indicator

--- a/backend/plugins/players/mezzy.py
+++ b/backend/plugins/players/mezzy.py
@@ -1,8 +1,10 @@
 from dataclasses import dataclass
 from dataclasses import field
+from random import choice
 
 from autofighter.character import CharacterType
-from plugins.damage_types import get_damage_type
+from plugins.damage_types import ALL_DAMAGE_TYPES
+from plugins.damage_types import load_damage_type
 from plugins.damage_types._base import DamageTypeBase
 from plugins.players._base import PlayerBase
 
@@ -14,6 +16,6 @@ class Mezzy(PlayerBase):
     char_type: CharacterType = CharacterType.B
     gacha_rarity = 5
     damage_type: DamageTypeBase = field(
-        default_factory=lambda: get_damage_type("Mezzy")
+        default_factory=lambda: load_damage_type(choice(ALL_DAMAGE_TYPES))
     )
     passives: list[str] = field(default_factory=lambda: ["mezzy_gluttonous_bulwark"])

--- a/backend/plugins/players/mimic.py
+++ b/backend/plugins/players/mimic.py
@@ -1,8 +1,10 @@
 from dataclasses import dataclass
 from dataclasses import field
+from random import choice
 
 from autofighter.character import CharacterType
-from plugins.damage_types import get_damage_type
+from plugins.damage_types import ALL_DAMAGE_TYPES
+from plugins.damage_types import load_damage_type
 from plugins.damage_types._base import DamageTypeBase
 from plugins.players._base import PlayerBase
 
@@ -14,6 +16,6 @@ class Mimic(PlayerBase):
     char_type: CharacterType = CharacterType.C
     gacha_rarity = 5
     damage_type: DamageTypeBase = field(
-        default_factory=lambda: get_damage_type("Mimic")
+        default_factory=lambda: load_damage_type(choice(ALL_DAMAGE_TYPES))
     )
     passives: list[str] = field(default_factory=lambda: ["mimic_player_copy"])


### PR DESCRIPTION
## Summary
- simplify `get_damage_type` to inspect an object's `damage_type` attribute or match known types by name
- retain random fallback while removing player-specific logic

## Testing
- `ruff check . --fix` *(fails: multiple lint errors in `.codex/prototypes`)*
- `ruff check backend/plugins/damage_types/__init__.py --fix`
- `./run-tests.sh` *(fails: e.g., `tests/test_800_dots_performance.py::test_many_dots_performance`, `tests/test_accelerate_dependency.py::test_accelerate_missing_error`, `tests/test_arc_lightning.py::test_arc_lightning_chains_damage`)*

------
https://chatgpt.com/codex/tasks/task_b_68bfd22e592c832cb8016f60b3788f9a