### PR TITLE
[FIX] Reapply user level after exp gain

### DIFF
--- a/.codex/implementation/user-level-service.md
+++ b/.codex/implementation/user-level-service.md
@@ -1,0 +1,11 @@
+# User Level Service
+
+Tracks persistent user experience and level progression.
+
+## Functions
+- `get_user_state()` – return current level, experience, and next level threshold.
+- `get_user_level()` – convenience wrapper returning only the level.
+- `gain_user_exp(amount)` – add experience and handle level ups.
+- `apply_user_level_to_party(party)` – reapply level-based stat hooks to every party member.
+
+Use `apply_user_level_to_party` after user experience changes so party stats reflect the latest level.

--- a/backend/autofighter/rooms/battle.py
+++ b/backend/autofighter/rooms/battle.py
@@ -13,6 +13,7 @@ from battle_logging import end_battle_logging
 
 # Import battle logging
 from battle_logging import start_battle_logging
+from services.user_level_service import apply_user_level_to_party
 from services.user_level_service import gain_user_exp
 from services.user_level_service import get_user_level
 
@@ -795,6 +796,7 @@ class BattleRoom(Room):
             try:
                 level = get_user_level()
                 gain_user_exp(int(exp_reward / max(1, level)))
+                apply_user_level_to_party(party)
             except Exception:
                 pass
         party_data = [_serialize(p) for p in party.members]

--- a/backend/services/user_level_service.py
+++ b/backend/services/user_level_service.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+from autofighter.party import Party
+from autofighter.stats import apply_status_hooks
+
 
 def user_exp_to_level(level: int) -> int:
     base = 100
@@ -58,3 +61,8 @@ def gain_user_exp(amount: int) -> dict[str, int]:
             ("user_exp", str(exp)),
         )
     return {"level": level, "exp": exp, "next_level_exp": next_exp}
+
+
+def apply_user_level_to_party(party: Party) -> None:
+    for member in party.members:
+        apply_status_hooks(member)


### PR DESCRIPTION
## Summary
- reapply user-level stat bonuses to party after EXP gain
- centralize level-based stat updates in user level service and document helper

## Testing
- [ ] Backend tests
- [ ] Frontend tests
- [x] Linting
- [x] Doc sync updates (README and `.codex/implementation` docs; link tasks below)

## Checklist
- [ ] Linked or updated relevant `.codex/tasks` entries
- [ ] Updated player roster and foe docs if adding or modifying fighters or enemies


------
https://chatgpt.com/codex/tasks/task_b_68bfefbbb8b0832cb10a0696ab74ce51