### PR TITLE
[FIX] exclude Mimic from player roster

### DIFF
--- a/.codex/implementation/player-foe-reference.md
+++ b/.codex/implementation/player-foe-reference.md
@@ -54,7 +54,6 @@ Passives generally shouldn't be capped unless a designer explicitly specifies a 
 - **Lady of Fire** (B, Fire) – baseline fighter themed around fire.
 - **Luna** (B, Generic) – applies `luna_passive`.
 - **Mezzy** (B, random) – raises Max HP, takes less damage, and siphons stats from healthy allies each turn.
-- **Mimic** (C, random) – copies the player then lowers its stats by 25% on spawn.
 - **Player** (C, chosen) – avatar representing the user and may select any non-Generic damage type.
 
 Characters marked as "random" roll one of the six elements when first loaded

--- a/ABOUTGAME.md
+++ b/ABOUTGAME.md
@@ -170,7 +170,6 @@ The roster in `plugins/players/` currently includes and each entry lists its `Ch
 - Lady of Fire (B, Fire)
 - Luna (B, Generic)
 - Mezzy (B, random damage type)
-- Mimic (C, random damage type)
 - Player (C, chosen damage type)
 
 Characters with a "random damage type" roll their element on first load and reuse that result in future sessions.

--- a/backend/autofighter/gacha.py
+++ b/backend/autofighter/gacha.py
@@ -17,7 +17,7 @@ def _build_pools() -> tuple[list[str], list[str]]:
         cls = getattr(player_plugins, name)
         rarity = getattr(cls, "gacha_rarity", 0)
         cid = getattr(cls, "id", name)
-        if cid in {"player", "luna"}:
+        if cid in {"player", "luna", "mimic"}:
             continue
         if rarity == 5:
             five.append(cid)

--- a/backend/plugins/players/mimic.py
+++ b/backend/plugins/players/mimic.py
@@ -14,7 +14,7 @@ class Mimic(PlayerBase):
     id = "mimic"
     name = "Mimic"
     char_type: CharacterType = CharacterType.C
-    gacha_rarity = 5
+    gacha_rarity = 0
     damage_type: DamageTypeBase = field(
         default_factory=lambda: load_damage_type(choice(ALL_DAMAGE_TYPES))
     )

--- a/backend/services/run_service.py
+++ b/backend/services/run_service.py
@@ -44,6 +44,8 @@ async def start_run(
 
     owned = await asyncio.to_thread(get_owned_players)
     for mid in members:
+        if mid == "mimic":
+            raise ValueError("invalid party")
         if mid != "player" and mid not in owned:
             raise ValueError("unowned character")
 

--- a/backend/tests/test_gacha.py
+++ b/backend/tests/test_gacha.py
@@ -46,6 +46,9 @@ async def test_pull_requires_ticket(app_with_db):
     conn = sqlcipher3.connect(db_path)
     conn.execute("PRAGMA key = 'testkey'")
     conn.execute(
+        "CREATE TABLE IF NOT EXISTS upgrade_items (id TEXT PRIMARY KEY, count INTEGER NOT NULL)"
+    )
+    conn.execute(
         "INSERT OR REPLACE INTO upgrade_items (id, count) VALUES (?, ?)",
         ("ticket", 0)
     )
@@ -73,6 +76,9 @@ async def test_pull_five_star_duplicate(app_with_db):
 
     conn = sqlcipher3.connect(db_path)
     conn.execute("PRAGMA key = 'testkey'")
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS owned_players (id TEXT PRIMARY KEY)"
+    )
     others = [cid for cid in FIVE_STAR if cid != char_id]
     for cid in others:
         conn.execute("INSERT OR IGNORE INTO owned_players (id) VALUES (?)", (cid,))

--- a/backend/tests/test_party_endpoint.py
+++ b/backend/tests/test_party_endpoint.py
@@ -66,12 +66,13 @@ async def test_party_validation(app_with_db):
 
     conn = sqlcipher3.connect(db_path)
     conn.execute("PRAGMA key = 'testkey'")
-    extra = [(pid,) for pid in ["ally", "becca", "carly", "mimic"]]
+    conn.execute("CREATE TABLE IF NOT EXISTS owned_players (id TEXT PRIMARY KEY)")
+    extra = [(pid,) for pid in ["ally", "becca", "carly", "graygray"]]
     conn.executemany("INSERT INTO owned_players (id) VALUES (?)", extra)
     resp = await client.post(
         "/run/start",
         json={
-            "party": ["player", "luna", "ally", "becca", "carly", "mimic"],
+            "party": ["player", "luna", "ally", "becca", "carly", "graygray"],
         },
     )
     assert resp.status_code == 400


### PR DESCRIPTION
## Summary
- Remove Mimic from gacha pools and player selection
- Reject Mimic in run service party validation
- Update docs and tests to reflect Mimic removal

## Testing
- `uv run ruff check . --fix`
- `uv run pytest tests/test_gacha.py` *(fails: assert 200 == 403, sqlcipher3.dbapi2.OperationalError: no such table: upgrade_items, assert 1 >= 2)*
- `uv run pytest tests/test_party_endpoint.py`


------
https://chatgpt.com/codex/tasks/task_b_68bffacbe1a8832c9e174f3ad7fa9ef4