### PR TITLE
[DOC] expand damage type ultimate descriptions

### DIFF
--- a/backend/plugins/damage_types/dark.py
+++ b/backend/plugins/damage_types/dark.py
@@ -10,6 +10,7 @@ from plugins.damage_types._base import DamageTypeBase
 
 @dataclass
 class Dark(DamageTypeBase):
+    """Selfish element that drains allies to fuel overwhelming strikes."""
     id: str = "Dark"
     weakness: str = "Light"
     color: tuple[int, int, int] = (145, 0, 145)
@@ -99,12 +100,7 @@ class Dark(DamageTypeBase):
         allies: list[Stats],
         enemies: list[Stats],
     ) -> bool:
-        """Strike six times, scaling with allied DoT stacks.
-
-        Damage is multiplied by ``ULT_PER_STACK`` for every DoT stack present on
-        the ``allies`` list (including the ``actor``). Each of the six hits
-        emits a ``damage`` event after applying damage.
-        """
+        """Strike a foe six times, scaling with allied DoT stacks."""
 
         if not getattr(actor, "use_ultimate", lambda: False)():
             return False
@@ -129,3 +125,11 @@ class Dark(DamageTypeBase):
 
     def create_dot(self, damage: float, source) -> DamageOverTime | None:
         return damage_effects.create_dot(self.id, damage, source)
+
+    @classmethod
+    def get_ultimate_description(cls) -> str:
+        return (
+            "Multiplies the user's attack by `ULT_PER_STACK` for each DoT stack on allied "
+            "targets, then deals that damage to one enemy six times, emitting a 'damage' "
+            "event after each hit."
+        )

--- a/backend/plugins/damage_types/fire.py
+++ b/backend/plugins/damage_types/fire.py
@@ -12,6 +12,11 @@ from plugins.damage_types._base import DamageTypeBase
 
 @dataclass
 class Fire(DamageTypeBase):
+    """Aggressive element that amplifies damage as the user weakens.
+
+    Fire attacks scale with missing HP and often inflict burning damage over
+    time at the cost of self-inflicted drain.
+    """
     id: str = "Fire"
     weakness: str = "Ice"
     color: tuple[int, int, int] = (255, 0, 0)
@@ -36,6 +41,7 @@ class Fire(DamageTypeBase):
         return dmg
 
     async def ultimate(self, actor: Stats, allies: list[Stats], enemies: list[Stats]) -> bool:
+        """Blast all foes for the caster's attack and try to ignite them."""
         await super().ultimate(actor, allies, enemies)
         base = getattr(actor, "atk", 0)
         living = [foe for foe in enemies if getattr(foe, "hp", 0) > 0]
@@ -70,3 +76,11 @@ class Fire(DamageTypeBase):
 
     def _on_battle_end(self, *_: object) -> None:
         self._drain_stacks = 0
+
+    @classmethod
+    def get_ultimate_description(cls) -> str:
+        return (
+            "Deals the user's attack as damage to every living enemy and rolls "
+            "Blazing Torment on each. Every use adds a drain stack that burns "
+            "the caster for 5% of max HP per stack at the start of their turns."
+        )

--- a/backend/plugins/damage_types/generic.py
+++ b/backend/plugins/damage_types/generic.py
@@ -7,11 +7,17 @@ from plugins.damage_types._base import DamageTypeBase
 
 @dataclass
 class Generic(DamageTypeBase):
+    """Neutral element with no strengths or weaknesses.
+
+    Serves as the baseline damage type focused on consistent damage without
+    side effects.
+    """
     id: str = "Generic"
     weakness: str = "none"
     color: tuple[int, int, int] = (255, 255, 255)
 
     async def ultimate(self, actor, allies, enemies):
+        """Split the user's attack into 64 rapid strikes on one target."""
         if not getattr(actor, "use_ultimate", lambda: False)():
             return False
 

--- a/backend/plugins/damage_types/ice.py
+++ b/backend/plugins/damage_types/ice.py
@@ -8,6 +8,7 @@ from plugins.damage_types._base import DamageTypeBase
 
 @dataclass
 class Ice(DamageTypeBase):
+    """Control element that chills foes and slows their actions."""
     id: str = "Ice"
     weakness: str = "Fire"
     color: tuple[int, int, int] = (0, 255, 255)

--- a/backend/plugins/damage_types/light.py
+++ b/backend/plugins/damage_types/light.py
@@ -10,6 +10,7 @@ from plugins.damage_types._base import DamageTypeBase
 
 @dataclass
 class Light(DamageTypeBase):
+    """Supportive element that heals allies and purges harmful effects."""
     id: str = "Light"
     weakness: str = "Dark"
     color: tuple[int, int, int] = (255, 255, 255)
@@ -31,6 +32,7 @@ class Light(DamageTypeBase):
         return True
 
     async def ultimate(self, actor, allies, enemies):
+        """Fully heal allies, cleanse their DoTs, and weaken enemies."""
         if not getattr(actor, "use_ultimate", lambda: False)():
             return False
         for ally in allies:
@@ -78,3 +80,10 @@ class Light(DamageTypeBase):
             mgr.add_modifier(mod)
         BUS.emit("light_ultimate", actor)
         return True
+
+    @classmethod
+    def get_ultimate_description(cls) -> str:
+        return (
+            "Removes all DoTs from allies—including Shadow Siphon—then heals them to full. "
+            "Enemies receive a 25% defense debuff for 10 turns and a 'light_ultimate' event is emitted."
+        )

--- a/backend/plugins/damage_types/lightning.py
+++ b/backend/plugins/damage_types/lightning.py
@@ -10,6 +10,7 @@ from plugins.damage_types._base import DamageTypeBase
 
 @dataclass
 class Lightning(DamageTypeBase):
+    """Volatile element that detonates DoTs and spreads random shocks."""
     id: str = "Lightning"
     weakness: str = "Wind"
     color: tuple[int, int, int] = (255, 255, 0)
@@ -31,6 +32,7 @@ class Lightning(DamageTypeBase):
                 )
 
     async def ultimate(self, actor, allies, enemies) -> bool:
+        """Zap all foes, seed random DoTs, and build Aftertaste stacks."""
         if not getattr(actor, "use_ultimate", lambda: False)():
             return False
 
@@ -79,3 +81,11 @@ class Lightning(DamageTypeBase):
             BUS.subscribe("battle_end", _clear)
             actor._lightning_aftertaste_handler = _hit
         return True
+
+    @classmethod
+    def get_ultimate_description(cls) -> str:
+        return (
+            "Deals the user's attack as damage to every enemy, then applies ten random "
+            "DoT effects from all elements to each target. Each use grants an Aftertaste "
+            "stack that later echoes extra hits based on the accumulated stacks."
+        )

--- a/backend/plugins/damage_types/wind.py
+++ b/backend/plugins/damage_types/wind.py
@@ -11,6 +11,7 @@ from plugins.damage_types._base import DamageTypeBase
 
 @dataclass
 class Wind(DamageTypeBase):
+    """Agile element that strikes in flurries and erodes defenses."""
     id: str = "Wind"
     weakness: str = "Lightning"
     color: tuple[int, int, int] = (0, 255, 0)
@@ -26,6 +27,7 @@ class Wind(DamageTypeBase):
         return damage_effects.create_dot(self.id, damage, source)
 
     async def ultimate(self, actor, allies, enemies):
+        """Distribute attack across rapid hits on all foes."""
         # Consume ultimate; bail if not ready
         if not getattr(actor, "use_ultimate", lambda: False)():
             return False
@@ -101,3 +103,12 @@ class Wind(DamageTypeBase):
         except Exception:
             pass
         return True
+
+    @classmethod
+    def get_ultimate_description(cls) -> str:
+        return (
+            "Temporarily boosts the user's effect hit rate, then splits their attack "
+            "into repeated strikes distributed across all living enemies. The number "
+            "of hits derives from `wind_ultimate_hits` or `ultimate_hits` allowing "
+            "relics and cards to modify it."
+        )


### PR DESCRIPTION
## Summary
- document element roles for damage type plugins
- describe ultimates and provide detailed descriptions for complex ones

## Testing
- `uv tool run ruff check backend --fix`
- `./run-tests.sh` *(fails: ModuleNotFoundError: No module named 'llms')*
- `uv run python - <<'PY' ...` (guidebook ultimates endpoint returns descriptions)


------
https://chatgpt.com/codex/tasks/task_b_68bff9bfc2a8832cac25ed94c974d5ca