### PR TITLE
[ENHANCEMENT] add passive descriptions

### DIFF
--- a/backend/plugins/passives/advanced_combat_synergy.py
+++ b/backend/plugins/passives/advanced_combat_synergy.py
@@ -84,3 +84,11 @@ class AdvancedCombatSynergy:
     def get_stacks(cls, target) -> int:
         """Return current synergy stacks for display purposes."""
         return cls._synergy_stacks.get(id(target), 0)
+
+    @classmethod
+    def get_description(cls) -> str:
+        return (
+            "Grants allies +10 attack for 3 turns when hitting a foe below 50% HP. "
+            "If 3+ allies are alive at turn start, gains +5 attack per ally for that turn. "
+            "Each action builds up to 3 stacks, adding +3 attack and +1% crit rate per stack."
+        )

--- a/backend/plugins/passives/ally_overload.py
+++ b/backend/plugins/passives/ally_overload.py
@@ -165,3 +165,11 @@ class AllyOverload:
     def get_stacks(cls, target: "Stats") -> int:
         """Return current overload charge for UI display."""
         return cls._overload_charge.get(id(target), 0)
+
+    @classmethod
+    def get_description(cls) -> str:
+        return (
+            "Twin daggers grant two attacks per action and build 10 charge, decaying by 5 when inactive. "
+            "At 100 charge, Overload activates: attack count doubles again, damage +30%, and damage taken +40%, "
+            "draining 20 charge per turn. Charge gain halves above 120."
+        )

--- a/backend/plugins/passives/attack_up.py
+++ b/backend/plugins/passives/attack_up.py
@@ -20,3 +20,10 @@ class AttackUp:
             source=self.id,
         )
         target.add_effect(effect)
+
+    @classmethod
+    def get_description(cls) -> str:
+        return (
+            f"Grants +{cls.amount} attack at battle start. "
+            f"Stacks display as {cls.stack_display}."
+        )

--- a/backend/plugins/passives/becca_menagerie_bond.py
+++ b/backend/plugins/passives/becca_menagerie_bond.py
@@ -259,3 +259,10 @@ class BeccaMenagerieBond:
     def get_cooldown(cls, target: "Stats") -> int:
         """Get remaining summon cooldown."""
         return cls._summon_cooldown.get(id(target), 0)
+
+    @classmethod
+    def get_description(cls) -> str:
+        return (
+            "Spend 10% current HP to summon a jellyfish. "
+            "Each former jellyfish leaves a spirit granting +5% attack and defense per stack."
+        )

--- a/backend/plugins/passives/bubbles_bubble_burst.py
+++ b/backend/plugins/passives/bubbles_bubble_burst.py
@@ -111,3 +111,11 @@ class BubblesBubbleBurst:
     def get_attack_buff_stacks(cls, target: "Stats") -> int:
         """Get current number of permanent attack buffs from bubble bursts."""
         return cls.get_stacks(target)
+
+    @classmethod
+    def get_description(cls) -> str:
+        return (
+            "Changes element randomly each turn. Hitting a foe adds a bubble; "
+            "at 3 stacks bubbles burst for area damage and give +10% attack "
+            "per burst (+5% after 20 stacks)."
+        )

--- a/backend/plugins/passives/carly_guardians_aegis.py
+++ b/backend/plugins/passives/carly_guardians_aegis.py
@@ -197,3 +197,11 @@ class CarlyGuardiansAegis:
             "mitigation": cls._mitigation_stacks.get(entity_id, 0),
             "overcharged": cls._overcharged.get(entity_id, False),
         }
+
+    @classmethod
+    def get_description(cls) -> str:
+        return (
+            "Heals the most injured ally for 10% of Carly's defense each turn. "
+            "Attack gains convert into defense stacks up to 50. "
+            "Taking hits builds mitigation stacks that can overcharge and share defense."
+        )

--- a/backend/plugins/passives/graygray_counter_maestro.py
+++ b/backend/plugins/passives/graygray_counter_maestro.py
@@ -100,3 +100,11 @@ class GraygrayCounterMaestro:
     def get_stacks(cls, target: "Stats") -> int:
         """Return current counter stacks for UI display."""
         return cls._counter_stacks.get(id(target), 0)
+
+    @classmethod
+    def get_description(cls) -> str:
+        return (
+            "Counterattacks whenever hit, dealing 50% of damage received. "
+            "Each counter grants +5% attack up to 50 stacks, then +2.5% beyond, "
+            "and provides 10% mitigation for one turn. At 50 stacks, unleashes a burst for max HP damage."
+        )

--- a/backend/plugins/passives/hilander_critical_ferment.py
+++ b/backend/plugins/passives/hilander_critical_ferment.py
@@ -123,3 +123,11 @@ class HilanderCriticalFerment:
             for effect in getattr(target, "_active_effects", [])
             if effect.name.startswith(f"{cls.id}_crit_stack_") and effect.name.endswith("_rate")
         )
+
+    @classmethod
+    def get_description(cls) -> str:
+        return (
+            "Each hit grants +5% crit rate and +10% crit damage. "
+            "Beyond 20 stacks, stack gain odds drop 5% per extra stack (min 1%). "
+            "A critical hit triggers Aftertaste and consumes one stack."
+        )

--- a/backend/plugins/passives/ixia_tiny_titan.py
+++ b/backend/plugins/passives/ixia_tiny_titan.py
@@ -106,3 +106,11 @@ class IxiaTinyTitan:
     def get_vitality_bonus(cls, target: "Stats") -> float:
         """Get current Vitality bonus for an entity."""
         return cls._vitality_bonuses.get(id(target), 0.0)
+
+    @classmethod
+    def get_description(cls) -> str:
+        return (
+            "Taking damage increases Vitality by 0.01 permanently. "
+            "Each 0.01 Vitality grants 4x HP gain, converts 500% of Vitality to attack, "
+            "adds 5% mitigation, and reduces defense by 25."
+        )

--- a/backend/plugins/passives/kboshi_flux_cycle.py
+++ b/backend/plugins/passives/kboshi_flux_cycle.py
@@ -124,3 +124,11 @@ class KboshiFluxCycle:
     def get_stacks(cls, target: "Stats") -> int:
         """Return current damage bonus stacks."""
         return cls.get_damage_stacks(target)
+
+    @classmethod
+    def get_description(cls) -> str:
+        return (
+            "80% chance each turn to switch to a new element. "
+            "Failing to switch grants a 20% attack bonus and a small HoT for that turn; "
+            "switching clears stacks and applies -2% mitigation to foes per stack."
+        )

--- a/backend/plugins/passives/lady_darkness_eclipsing_veil.py
+++ b/backend/plugins/passives/lady_darkness_eclipsing_veil.py
@@ -78,3 +78,10 @@ class LadyDarknessEclipsingVeil:
     def get_attack_bonus(cls, target: "Stats") -> int:
         """Get current attack bonus from debuff resistances."""
         return cls._attack_bonuses.get(id(target), 0)
+
+    @classmethod
+    def get_description(cls) -> str:
+        return (
+            "Extends DoTs by one turn and siphons 1% of each DoT tick as healing. "
+            "Resisting a debuff grants +5% attack, stacking indefinitely."
+        )

--- a/backend/plugins/passives/lady_echo_resonant_static.py
+++ b/backend/plugins/passives/lady_echo_resonant_static.py
@@ -108,3 +108,10 @@ class LadyEchoResonantStatic:
     def get_party_crit_stacks(cls, attacker: "Stats") -> int:
         """Get current party crit rate stacks."""
         return cls._party_crit_stacks.get(id(attacker), 0)
+
+    @classmethod
+    def get_description(cls) -> str:
+        return (
+            "Chain lightning hits deal +10% damage per DoT on the target. "
+            "Consecutive hits on the same foe grant the party +2% crit rate per stack, up to 20%."
+        )

--- a/backend/plugins/passives/lady_fire_and_ice_duality_engine.py
+++ b/backend/plugins/passives/lady_fire_and_ice_duality_engine.py
@@ -129,3 +129,10 @@ class LadyFireAndIceDualityEngine:
     def get_last_element(cls, target: "Stats") -> str:
         """Get last element used by an entity."""
         return cls._last_element.get(id(target), None)
+
+    @classmethod
+    def get_description(cls) -> str:
+        return (
+            "Alternating fire and ice attacks builds Flux stacks, boosting burn and chill potency by 5% each. "
+            "Using the same element twice consumes stacks to heal allies for 10 HP per stack over 3 turns and reduce foe mitigation by 2% per stack."
+        )

--- a/backend/plugins/passives/lady_light_radiant_aegis.py
+++ b/backend/plugins/passives/lady_light_radiant_aegis.py
@@ -86,3 +86,10 @@ class LadyLightRadiantAegis:
     def get_attack_bonus(cls, target: "Stats") -> int:
         """Get current attack bonus from DoT cleanses."""
         return cls._attack_bonuses.get(id(target), 0)
+
+    @classmethod
+    def get_description(cls) -> str:
+        return (
+            "HoTs grant shields equal to 50% of the heal and +5% effect resistance for one turn. "
+            "Cleansing a DoT heals 5% of max HP and gives Lady Light +2% attack per cleanse."
+        )

--- a/backend/plugins/passives/lady_of_fire_infernal_momentum.py
+++ b/backend/plugins/passives/lady_of_fire_infernal_momentum.py
@@ -68,3 +68,10 @@ class LadyOfFireInfernalMomentum:
             source=self.id,
         )
         target.add_effect(hot_effect)
+
+    @classmethod
+    def get_description(cls) -> str:
+        return (
+            "Doubles the Fire missing HP damage bonus to 60%. "
+            "Taking damage burns attackers for 25% of damage dealt and self-inflicted Fire damage grants a HoT worth 50% of that damage for two turns."
+        )

--- a/backend/plugins/passives/luna_lunar_reservoir.py
+++ b/backend/plugins/passives/luna_lunar_reservoir.py
@@ -97,3 +97,10 @@ class LunaLunarReservoir:
     def get_display(cls, target: "Stats") -> str:
         """Display a spinner when charge is full and draining."""
         return "spinner" if cls.get_charge(target) >= 200 else "number"
+
+    @classmethod
+    def get_description(cls) -> str:
+        return (
+            "Gains 1 charge per action; attack count scales from 2 up to 32 at 85+ charge. "
+            "Charge beyond 200 grants 0.025% dodge per point and drains 50 charge each turn."
+        )

--- a/backend/plugins/passives/mezzy_gluttonous_bulwark.py
+++ b/backend/plugins/passives/mezzy_gluttonous_bulwark.py
@@ -126,3 +126,11 @@ class MezzyGluttonousBulwark:
                     source=f"{self.id}_gain",
                 )
                 mezzy.add_effect(mezzy_buff)
+
+    @classmethod
+    def get_description(cls) -> str:
+        return (
+            "Reduces damage taken by 20% and increases max HP by 10%. "
+            "Siphons 1% of attack, defense, and max HP from allies above 20% of her max HP each turn, "
+            "returning half when they fall below. Also grants 50% debuff resistance."
+        )

--- a/backend/plugins/passives/mimic_player_copy.py
+++ b/backend/plugins/passives/mimic_player_copy.py
@@ -156,3 +156,9 @@ class MimicPlayerCopy:
     def get_copied_passive(cls, target: "Stats") -> str:
         """Get the passive copied from player."""
         return cls._copied_passive.get(id(target), None)
+
+    @classmethod
+    def get_description(cls) -> str:
+        return (
+            "Copies the player's stats at battle start with a 25% reduction and copies the player's passive at half strength while blocking other buffs."
+        )

--- a/backend/plugins/passives/player_level_up_bonus.py
+++ b/backend/plugins/passives/player_level_up_bonus.py
@@ -43,3 +43,7 @@ class PlayerLevelUpBonus:
             source=self.id,
         )
         target.add_effect(level_up_bonus)
+
+    @classmethod
+    def get_description(cls) -> str:
+        return "Increases all level-up stat gains by 35%, enhancing growth to 1.35× the base amount."

--- a/backend/plugins/passives/room_heal.py
+++ b/backend/plugins/passives/room_heal.py
@@ -14,3 +14,10 @@ class RoomHeal:
         # Support monkeypatching: if class attribute differs from original default, use class attribute
         heal_amount = type(self).amount if type(self).amount != 1 else self.amount
         await target.apply_healing(heal_amount)
+
+    @classmethod
+    def get_description(cls) -> str:
+        return (
+            f"Heals {cls.amount} HP after each battle. "
+            f"Stacks display as {cls.stack_display}."
+        )


### PR DESCRIPTION
## Summary
- document passive plugins with `get_description`
- surface passive summaries in `/guidebook/passives`

## Testing
- `ruff check backend/plugins/passives --fix`
- `./run-tests.sh` *(fails: backend and frontend tests/timeouts)*


------
https://chatgpt.com/codex/tasks/task_b_68bff9c7bc5c832cb653ffa4562a35e1