### PR TITLE
feat: smooth ult gauge transitions

### DIFF
--- a/frontend/.codex/implementation/battle-effects.md
+++ b/frontend/.codex/implementation/battle-effects.md
@@ -19,7 +19,11 @@ These indicators respect Reduced Motion settings and expose
 tooltips for screen readers and mouse users. When a fighter's ultimate
 becomes ready, an element-colored pulse briefly radiates from the
 ultimate ring in `FighterPortrait`; this animation is skipped when
-Reduced Motion is enabled.
+Reduced Motion is enabled. The ultimate gauge in `FighterUIItem` now
+slides its fill and feathered edge with a 0.3s ease-out transition
+while charging. The fill also slowly tilts left and right, the sway
+intensifying up to a one-degree angle around 98% charge. Reduced Motion
+disables both the transition and the tilt.
 
 ## Stained-Glass Palette
 


### PR DESCRIPTION
## Summary
- smooth ultimate gauge fills with height, feather transitions, and charge-scaled sway that respect reduced motion
- note ult-gauge charge animation and tilt in battle-effects implementation guide

## Testing
- `bun run lint`
- `bun test` *(fails: multiple missing module errors and failing assertions)*

------
https://chatgpt.com/codex/tasks/task_b_68bffe7498c0832cae16e1e4c93cc3ef