### PR TITLE
Respect reduced motion for battle HP bars

### DIFF
--- a/frontend/.codex/implementation/battle-effects.md
+++ b/frontend/.codex/implementation/battle-effects.md
@@ -25,6 +25,10 @@ while charging. The fill also slowly tilts left and right, the sway
 intensifying up to a one-degree angle around 98% charge. Reduced Motion
 disables both the transition and the tilt.
 
+HP bars for party members, foes, and their summons animate their fill widths
+and overheal overlays with short transitions. When Reduced Motion is enabled,
+these transitions are removed for instant updates.
+
 ## Stained-Glass Palette
 
 Effect indicators and bar graphs should reflect the project's stained-glass

--- a/frontend/src/lib/components/BattleView.svelte
+++ b/frontend/src/lib/components/BattleView.svelte
@@ -283,7 +283,7 @@
           
           <!-- HP bar on top -->
           <div class="foe-hp-bar" style={`width: ${getFoeSizePx(foeCount)}px`}>
-            <div class="hp-bar-container">
+            <div class="hp-bar-container" class:reduced={reducedMotion}>
               {#if Number(foe?.shields || 0) > 0 && Number(foe?.max_hp || 0) > 0}
                 <div
                   class="overheal-fill"
@@ -314,7 +314,7 @@
                 >
                   <!-- Summon HP bar -->
                   <div class="summon-hp-bar">
-                    <div class="hp-bar-container">
+                    <div class="hp-bar-container" class:reduced={reducedMotion}>
                       {#if Number(summon?.shields || 0) > 0 && Number(summon?.max_hp || 0) > 0}
                         <div
                           class="overheal-fill"
@@ -353,7 +353,7 @@
         
         <!-- HP bar under the photo -->
         <div class="party-hp-bar">
-          <div class="hp-bar-container">
+          <div class="hp-bar-container" class:reduced={reducedMotion}>
             {#if Number(member?.shields || 0) > 0 && Number(member?.max_hp || 0) > 0}
               <div
                 class="overheal-fill"
@@ -389,7 +389,7 @@
               >
                 <!-- Summon HP bar -->
                 <div class="summon-hp-bar">
-                  <div class="hp-bar-container">
+                  <div class="hp-bar-container" class:reduced={reducedMotion}>
                     {#if Number(summon?.shields || 0) > 0 && Number(summon?.max_hp || 0) > 0}
                       <div
                         class="overheal-fill"
@@ -533,6 +533,14 @@
     transition: width 0.3s linear;
     pointer-events: none;
     z-index: 0; /* below main HP fill */
+  }
+
+  .hp-bar-container.reduced .hp-bar-fill {
+    transition: none;
+  }
+
+  .hp-bar-container.reduced .overheal-fill {
+    transition: none;
   }
 
   .hp-text {


### PR DESCRIPTION
## Summary
- Disable HP bar and overheal transitions when Reduced Motion is enabled
- Document HP bar Reduced Motion behavior in battle effects guide

## Testing
- ⚠️ `uv run ruff check . --fix` (pre-existing lint errors in prototypes)
- ⚠️ `bun run lint` (warnings)


------
https://chatgpt.com/codex/tasks/task_b_68c0017d6368832ca749b2691dd7f8cb