### PR TITLE
feat: animate pull results dealing

### DIFF
--- a/frontend/src/lib/components/PullResultsOverlay.svelte
+++ b/frontend/src/lib/components/PullResultsOverlay.svelte
@@ -1,19 +1,29 @@
 <script>
   import { onMount, createEventDispatcher } from 'svelte';
+  import { crossfade } from 'svelte/transition';
+  import { cubicOut } from 'svelte/easing';
+  import jsfxr from 'jsfxr';
   import CurioChoice from './CurioChoice.svelte';
   import { getRewardArt } from '../systems/rewardLoader.js';
   import { getCharacterImage } from '../systems/assetLoader.js';
   import { formatName } from '../systems/craftingUtils.js';
 
   export let results = [];
+  export let reducedMotion = false;
 
   const dispatch = createEventDispatcher();
-  let queue = [];
+  let stack = [];
   let visible = [];
+  let isBatch = false;
+  let dealSfx;
+
+  const [send, receive] = crossfade({
+    duration: () => (reducedMotion ? 0 : 400),
+    easing: cubicOut
+  });
 
   function toRenderable(r) {
     if (!r || typeof r !== 'object') return r;
-    // Backend provides: { type: 'character'|'item', id, rarity, stacks? }
     if (r.type === 'character') {
       const id = String(r.id || '');
       const stars = Number(r.rarity || 5) || 5;
@@ -24,14 +34,12 @@
         name: id,
         stars,
         about,
-        // Use character portrait for the glyph image, keep relic-style frame
         artUrl: getCharacterImage(id)
       };
     }
     if (r.type === 'item') {
-      const key = String(r.id || ''); // e.g., 'fire_3'
+      const key = String(r.id || '');
       const stars = Number(r.rarity || 1) || 1;
-      // Normalize for itemArt keys: 'fire_3' -> 'fire3'
       const normalized = key.replace('_', '');
       const artUrl = getRewardArt('item', normalized);
       return {
@@ -42,20 +50,37 @@
         artUrl
       };
     }
-    // Fallback: pass through unchanged
     return r;
   }
 
   onMount(() => {
-    queue = Array.isArray(results) ? results.map(toRenderable) : [];
-    showNext();
+    const mapped = Array.isArray(results) ? results.map(toRenderable) : [];
+    isBatch = mapped.length === 5 || mapped.length === 10;
+    if (isBatch) {
+      stack = mapped;
+      if (!reducedMotion) {
+        try {
+          dealSfx = new Audio(jsfxr([0,,0.05,,0.2,,0.1,0.4,,0.3,0.2,,,,,,,,1,,0.5]));
+          dealSfx.volume = 0.5;
+        } catch {}
+      }
+      dealNext();
+    } else {
+      visible = mapped;
+    }
   });
 
-  function showNext() {
-    if (queue.length === 0) return;
-    visible = [...visible, queue.shift()];
-    if (queue.length > 0) {
-      setTimeout(showNext, 400);
+  function playDeal() {
+    if (reducedMotion || !dealSfx) return;
+    try { dealSfx.cloneNode().play(); } catch {}
+  }
+
+  function dealNext() {
+    if (stack.length === 0) return;
+    visible = [...visible, stack.shift()];
+    playDeal();
+    if (stack.length > 0) {
+      setTimeout(dealNext, reducedMotion ? 0 : 400);
     }
   }
 
@@ -65,20 +90,30 @@
 </script>
 
 <div class="layout">
+  {#if isBatch}
+    <div class="stack" aria-hidden={stack.length === 0}>
+      {#each stack as r, i (r.id)}
+        <div class="card" style={`--i: ${i}`} out:send={{ key: r.id }}>
+          <CurioChoice entry={r} disabled={true} />
+        </div>
+      {/each}
+    </div>
+  {/if}
   <div class="choices">
-    {#each visible as r, i (i)}
-      <div class="reveal" style={`--delay: ${i * 120}ms`}>
+    {#each visible as r (r.id)}
+      <div class="card" in:receive={{ key: r.id }}>
         <CurioChoice entry={r} disabled={true} />
       </div>
     {/each}
   </div>
-  {#if queue.length === 0 && visible.length}
+  {#if stack.length === 0 && visible.length}
     <button class="done" on:click={close}>Done</button>
   {/if}
 </div>
 
 <style>
   .layout {
+    position: relative;
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -90,19 +125,22 @@
     gap: 0.75rem;
     justify-content: center;
   }
+  .stack {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 0;
+    height: 0;
+  }
+  .stack .card {
+    position: absolute;
+    transform: translate(calc(var(--i) * 4px), calc(var(--i) * 4px));
+  }
   .done {
     padding: 0.5rem 1rem;
     background: #0a0a0a;
     color: #fff;
     border: 2px solid #fff;
     cursor: pointer;
-  }
-  .reveal {
-    opacity: 0;
-    animation: overlay-reveal 0.4s forwards;
-  }
-  @keyframes overlay-reveal {
-    from { transform: translateY(-20px); opacity: 0; }
-    to { transform: translateY(0); opacity: 1; }
   }
 </style>

--- a/frontend/tests/pullresultsoverlay.test.js
+++ b/frontend/tests/pullresultsoverlay.test.js
@@ -3,13 +3,13 @@ import { readFileSync } from 'fs';
 import { join } from 'path';
 
 describe('PullResultsOverlay component', () => {
-  test('queues results and reveals sequentially', () => {
+  test('stacks results and deals sequentially', () => {
     const content = readFileSync(
       join(import.meta.dir, '../src/lib/components/PullResultsOverlay.svelte'),
       'utf8'
     );
-    expect(content).toContain('CurioChoice');
-    expect(content).toContain('queue = Array.isArray(results) ? [...results] : []');
-    expect(content).toContain('setTimeout(showNext');
+    expect(content).toContain('crossfade');
+    expect(content).toContain('stack =');
+    expect(content).toContain('dealNext');
   });
 });


### PR DESCRIPTION
## Summary
- animate pull results as stacked deck that deals cards into view
- add optional sound and reduced-motion support
- update overlay test for new dealing behavior

## Testing
- `bun run lint:fix`
- `./run-tests.sh` *(fails: Cannot find module '$app/environment', missing assets, ENOENT errors)*

------
https://chatgpt.com/codex/tasks/task_b_68c02af4da54832caab93fa32fda406f