### PR TITLE
[FIX] show spinner rings when portrait-size undefined

### DIFF
--- a/frontend/.codex/implementation/triple-ring-spinner.md
+++ b/frontend/.codex/implementation/triple-ring-spinner.md
@@ -3,4 +3,5 @@
 Renders three concentric rings with element-colored dots. Each dot orbits its ring using the `spin` animation while the rings
 pulse with `pulse`. Animation timing is configurable via the `duration` prop and defaults to theme variables. The component
 also accepts a `color` prop for customizing the ring and dot color and respects the `reducedMotion` flag to disable animations
-when necessary.
+when necessary. Width and height default to `clamp(14px, calc(var(--portrait-size, 96px) * 0.18), 32px)` and can be overridden
+via the `--spinner-size` custom property.

--- a/frontend/src/lib/components/TripleRingSpinner.svelte
+++ b/frontend/src/lib/components/TripleRingSpinner.svelte
@@ -19,9 +19,9 @@
   .triple-ring-spinner {
     position: relative;
     /* Resolve to pixels to ensure correct orbital radii */
-    --spinner-size: var(--spinner-size, clamp(14px, calc(var(--portrait-size) * 0.18), 32px));
-    width: var(--spinner-size);
-    height: var(--spinner-size);
+    --size: var(--spinner-size, clamp(14px, calc(var(--portrait-size, 96px) * 0.18), 32px));
+    width: var(--size);
+    height: var(--size);
   }
   .ring {
     position: absolute;
@@ -33,9 +33,9 @@
     animation: pulse calc(var(--duration) * 2) ease-in-out infinite;
   }
   /* Define absolute ring sizes and their orbit radii in px */
-  .r1 { --ring-size-px: var(--spinner-size); --orbit: calc(var(--spinner-size) / 2); animation-delay: 0s; }
-  .r2 { --ring-size-px: calc(var(--spinner-size) * 0.66); --orbit: calc(var(--spinner-size) * 0.66 / 2); animation-delay: calc(var(--duration) / 3); }
-  .r3 { --ring-size-px: calc(var(--spinner-size) * 0.33); --orbit: calc(var(--spinner-size) * 0.33 / 2); animation-delay: calc(var(--duration) * 2 / 3); }
+  .r1 { --ring-size-px: var(--size); --orbit: calc(var(--size) / 2); animation-delay: 0s; }
+  .r2 { --ring-size-px: calc(var(--size) * 0.66); --orbit: calc(var(--size) * 0.66 / 2); animation-delay: calc(var(--duration) / 3); }
+  .r3 { --ring-size-px: calc(var(--size) * 0.33); --orbit: calc(var(--size) * 0.33 / 2); animation-delay: calc(var(--duration) * 2 / 3); }
   .ring {
     width: var(--ring-size-px);
     height: var(--ring-size-px);


### PR DESCRIPTION
## Summary
- ensure TripleRingSpinner width/height default to 18% of portrait size with 96px fallback
- document spinner size fallback in component doc

## Testing
- `bun run lint:fix`
- `./run-tests.sh` *(fails: various frontend test missing modules; backend tests timed out)*

------
https://chatgpt.com/codex/tasks/task_b_68c02c8b122c832ca824650570690544