### PR TITLE
[FIX] reverse middle ring spin

### DIFF
--- a/frontend/.codex/implementation/triple-ring-spinner.md
+++ b/frontend/.codex/implementation/triple-ring-spinner.md
@@ -1,7 +1,7 @@
 # TripleRingSpinner Component
 
 Renders three concentric rings with element-colored dots. Each dot orbits its ring using the `spin` animation while the rings
-pulse with `pulse`. Animation timing is configurable via the `duration` prop and defaults to theme variables. The component
-also accepts a `color` prop for customizing the ring and dot color and respects the `reducedMotion` flag to disable animations
-when necessary. Width and height default to `clamp(14px, calc(var(--portrait-size, 96px) * 0.18), 32px)` and can be overridden
-via the `--spinner-size` custom property.
+pulse with `pulse`. The middle ring's dot rotates in the opposite direction to the inner and outer rings. Animation timing is
+configurable via the `duration` prop and defaults to theme variables. The component also accepts a `color` prop for customizing
+the ring and dot color and respects the `reducedMotion` flag to disable animations when necessary. Width and height default to
+`clamp(14px, calc(var(--portrait-size, 96px) * 0.18), 32px)` and can be overridden via the `--spinner-size` custom property.

--- a/frontend/src/lib/components/TripleRingSpinner.svelte
+++ b/frontend/src/lib/components/TripleRingSpinner.svelte
@@ -53,6 +53,9 @@
     transform-origin: center;
     animation: spin var(--duration) linear infinite;
   }
+  .r2::before {
+    animation-direction: reverse;
+  }
   @keyframes spin {
     from { transform: rotate(0deg) translateX(var(--orbit)); }
     to { transform: rotate(360deg) translateX(var(--orbit)); }


### PR DESCRIPTION
## Summary
- reverse middle ring animation direction in TripleRingSpinner
- document reversed spin for TripleRingSpinner

## Testing
- `bun run lint`
- `bun test` *(fails: missing OverlayHost.svelte, missing $app/environment, snapshot mismatch, etc.)*
- `./run-tests.sh` *(fails: ModuleNotFoundError: No module named 'llms', and other errors)*

------
https://chatgpt.com/codex/tasks/task_b_68c0a90f6a64832c9cef912b3d986b96