### PR TITLE
[FIX] Pause polling during overlays

### DIFF
--- a/frontend/.codex/implementation/battle-polling.md
+++ b/frontend/.codex/implementation/battle-polling.md
@@ -6,6 +6,11 @@ no rewards or completion flags have arrived. After roughly three seconds of
 such stalled polling, the function stops the battle, records an error on the
 snapshot, and logs a warning so the reward overlay or reset flow can proceed.
 
+Battle snapshot polling halts any time the rewards or battle review overlays are
+visible. `window.afRewardOpen` and `window.afReviewOpen` flags stop the poller,
+clear its timer, and prevent rescheduling until the "Next Room" action closes
+the overlay and explicitly restarts polling via `startBattlePoll()`.
+
 If a snapshot includes an `error` field, polling halts immediately and the
 error state is surfaced without waiting for combat-over indicators.
 
@@ -20,8 +25,11 @@ another cycle. This prevents repeated error overlays once a run is gone.
 
 The general `pollState` routine uses the same detection. Errors mentioning
 "run ended" or returning a 404 now call `handleRunEnd()` and avoid scheduling
-another poll. Additionally, UI state polling no longer reschedules itself when
-`uiState.mode === 'menu'` to reduce network traffic while in the main menu.
+another poll. All pollers (`pollState`, `pollBattle`, and `pollUIState`) also
+check the overlay flags and refrain from starting or rescheduling while either
+overlay is active. Additionally, UI state polling no longer reschedules itself
+when `uiState.mode === 'menu'` to reduce network traffic while in the main
+menu.
 
 Additionally, ending a run from Settings now immediately sets a global
 `window.afHaltSync = true` flag and clears timers to prevent any further

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -487,6 +487,9 @@
 
   function startBattlePoll() {
     stopBattlePoll(); // Clear any existing timer
+    try {
+      if (typeof window !== 'undefined' && (window.afRewardOpen === true || window.afReviewOpen === true)) return;
+    } catch {}
     if (battleActive && !haltSync && runId) {
       pollBattle();
     }
@@ -494,6 +497,12 @@
 
   async function pollBattle() {
     if (!battleActive || haltSync || !runId) return;
+    try {
+      if (typeof window !== 'undefined' && (window.afRewardOpen === true || window.afReviewOpen === true)) {
+        stopBattlePoll();
+        return;
+      }
+    } catch {}
     try {
       const snap = mapStatuses(await roomAction("0", {"action": "snapshot"}));
       lastBattleSnapshot = snap || lastBattleSnapshot;
@@ -572,6 +581,12 @@
         return;
       }
     }
+    try {
+      if (typeof window !== 'undefined' && (window.afRewardOpen === true || window.afReviewOpen === true)) {
+        stopBattlePoll();
+        return;
+      }
+    } catch {}
     if (battleActive && !haltSync && runId) {
       battleTimer = setTimeout(pollBattle, 1000 / 60);
     }
@@ -587,15 +602,14 @@
   async function pollState() {
     // Don't poll if we're in battle, halted, in menu, or no runId
     if (battleActive || haltSync || !runId) return;
-    // Pause polling while rewards overlay is open
+    // Pause polling while Reward or Battle Review overlays are open
     try {
-      if (typeof window !== 'undefined' && window.afRewardOpen === true) return;
+      if (typeof window !== 'undefined' && (window.afRewardOpen === true || window.afReviewOpen === true)) {
+        stopStatePoll();
+        return;
+      }
     } catch {}
-    // Also pause polling while Battle Review overlay is open
-    try {
-      if (typeof window !== 'undefined' && window.afReviewOpen === true) return;
-    } catch {}
-    
+
     // Don't poll if we're in a menu/overlay (not 'main')
     try {
       const { get } = await import('svelte/store');
@@ -648,6 +662,12 @@
     }
 
     // Schedule next state poll if conditions are still met
+    try {
+      if (typeof window !== 'undefined' && (window.afRewardOpen === true || window.afReviewOpen === true)) {
+        stopStatePoll();
+        return;
+      }
+    } catch {}
     if (!battleActive && !haltSync && runId) {
       stateTimer = setTimeout(pollState, 5000); // Poll every 5 seconds
     }
@@ -742,7 +762,7 @@
         if (!currentRoomType) currentRoomType = mapRooms?.[currentIndex]?.room_type || (endpoint.includes('boss') ? 'battle-boss-floor' : 'battle-normal');
         battleActive = true;
         if (typeof window !== 'undefined') window.afBattleActive = true; // Update global state for ping indicator
-        pollBattle();
+        startBattlePoll();
       } else {
         battleActive = false;
         if (typeof window !== 'undefined') window.afBattleActive = false; // Update global state for ping indicator
@@ -1071,6 +1091,9 @@
 
   function startUIStatePoll() {
     stopUIStatePoll();
+    try {
+      if (typeof window !== 'undefined' && (window.afRewardOpen === true || window.afReviewOpen === true)) return;
+    } catch {}
     if (!haltSync) {
       pollUIState();
     }
@@ -1078,7 +1101,13 @@
 
   async function pollUIState() {
     if (haltSync) return;
-    
+    try {
+      if (typeof window !== 'undefined' && (window.afRewardOpen === true || window.afReviewOpen === true)) {
+        stopUIStatePoll();
+        return;
+      }
+    } catch {}
+
     // Don't poll if we're in a menu/overlay (not 'main') - same protection as old pollState
     try {
       const { get } = await import('svelte/store');
@@ -1134,6 +1163,9 @@
       
       // Continue polling (simplified - no complex battle state management)
       if (!haltSync && uiState.mode !== 'menu') {
+        try {
+          if (typeof window !== 'undefined' && (window.afRewardOpen === true || window.afReviewOpen === true)) return;
+        } catch {}
         uiStateTimer = setTimeout(pollUIState, 1000); // Poll every second
       }
       
@@ -1141,6 +1173,9 @@
       console.warn('UI state polling failed:', e);
       // Retry after delay
       if (!haltSync) {
+        try {
+          if (typeof window !== 'undefined' && (window.afRewardOpen === true || window.afReviewOpen === true)) return;
+        } catch {}
         uiStateTimer = setTimeout(pollUIState, 2000);
       }
     }


### PR DESCRIPTION
## Summary
- pause battle polling when reward or battle review overlays are open
- guard state and UI pollers against running during overlays
- document overlay polling behaviour

## Testing
- `bun run lint`
- `./run-tests.sh` *(fails: ModuleNotFoundError: No module named 'battle_logging', etc.)*

------
https://chatgpt.com/codex/tasks/task_b_68c0a9184874832c8f4eec44cefd8832