### PR TITLE
[UI] Darken warp and inventory borders

### DIFF
--- a/frontend/src/lib/components/Inventory.svelte
+++ b/frontend/src/lib/components/Inventory.svelte
@@ -363,6 +363,7 @@
 
 <style>
   .star-rail-inventory {
+    --glass-border: 1.5px solid rgba(0,0,0,0.6);
     display: flex;
     flex-direction: column;
     height: 100%;

--- a/frontend/src/lib/components/PullsMenu.svelte
+++ b/frontend/src/lib/components/PullsMenu.svelte
@@ -275,6 +275,9 @@
 </MenuPanel>
 
 <style>
+  .warp-menu {
+    --glass-border: 1.5px solid rgba(0,0,0,0.6);
+  }
   /* Header styling matching Guidebook/Inventory */
   .warp-header {
     display: flex;


### PR DESCRIPTION
## Summary
- Darken PullsMenu glass border via new `.warp-menu` override
- Ensure Inventory panel uses darker `--glass-border`

## Testing
- `uv tool run ruff check backend --fix`
- `cd frontend && bun run lint:fix`
- `./run-tests.sh` *(fails: module resolution issues in frontend tests)*

------
https://chatgpt.com/codex/tasks/task_b_68c0a91989f4832cbf10b751f912beb7