### PR TITLE
[FEATURE] Rework Rusty Buckle bleed and thresholds

### DIFF
--- a/.codex/implementation/relic-inventory.md
+++ b/.codex/implementation/relic-inventory.md
@@ -10,7 +10,7 @@ Relic entries display their stack count and expose their description as tooltip
 text via the `about` field returned by the backend.
 
 ## Implemented Relics
-- 1★ Rusty Buckle – Bleeds the weakest ally for 1% Max HP per stack and fires increasing Aftertaste bursts as they lose HP.
+ - 1★ Rusty Buckle – All allies bleed for 5% Max HP per stack at the start of each turn. When the party loses HP equal to its total Max HP (scaled +50% per extra stack), it fires 5 Aftertaste hits plus 3 per additional stack, each hit equal to 0.5% of total HP lost.
 - 1★ Threadbare Cloak – Allies start battle with a shield equal to 3% Max HP per stack.
 - 1★ Lucky Button – +3% Crit Rate; missed crits add +3% Crit Rate next turn.
  - 1★ Bent Dagger – +3% ATK; when a foe dies, allies gain +1% ATK for the rest of combat.

--- a/.codex/planning/bd48a561-relic-plan.md
+++ b/.codex/planning/bd48a561-relic-plan.md
@@ -10,7 +10,7 @@ Parent: [Web Game Plan](8a7d9c1e-web-game-plan.md)
 - *Critical Boost* grants +0.5% Crit Rate and +5% Crit Damage per stack but vanishes when the unit is hit.
 
 ## 1★ Relics
- - [ ] **Rusty Buckle** – At the start of combat, the ally with the lowest Max HP gains a self-inflicted bleed for 1% of their Max HP plus 1% per stack. Every 10% HP lost triggers 5 hits of Aftertaste to all foes, each hit equal to 0.5% of the total HP lost. Each additional copy adds 3 hits.
+ - [ ] **Rusty Buckle** – At the start of each turn, all allies bleed for 5% of their Max HP per stack. After the party loses HP equal to its total Max HP (threshold rises by 50% per additional stack), unleash 5 hits of Aftertaste at random foes, plus 3 hits per extra stack. Each hit deals 0.5% of the cumulative HP lost.
  - [x] **Threadbare Cloak** – Allies start battle with a shield equal to 3% Max HP; each copy adds another 3%.
  - [x] **Lucky Button** – +3% Crit Rate; missed crits add +3% Crit Rate next turn.
  - [x] **Bent Dagger** – +3% ATK; whenever a foe dies, gain +1% ATK for the rest of combat per stack.

--- a/backend/plugins/relics/rusty_buckle.py
+++ b/backend/plugins/relics/rusty_buckle.py
@@ -10,81 +10,96 @@ from plugins.relics._base import safe_async_task
 
 @dataclass
 class RustyBuckle(RelicBase):
-    """Bleeds lowest-HP ally and triggers Aftertaste as HP drops."""
+    """Bleeds all allies and triggers Aftertaste as party HP drops."""
 
     id: str = "rusty_buckle"
     name: str = "Rusty Buckle"
     stars: int = 1
     effects: dict[str, float] = field(default_factory=dict)
     about: str = (
-        "Bleeds the weakest ally and unleashes growing Aftertaste blasts as they suffer."
+        "All allies bleed for 5% Max HP per stack at the start of each turn and unleash Aftertaste as the party suffers."
     )
 
     def apply(self, party) -> None:
-        """Bleed weakest ally and ping foes as their HP drops."""
+        """Bleed all allies and ping foes as party HP drops."""
         super().apply(party)
 
         stacks = party.relics.count(self.id)
-        state: dict[str, object] = {"foes": [], "ally": None, "triggers": 0}
+        state: dict[str, object] = {
+            "foes": [],
+            "party_max_hp": sum(ally.max_hp for ally in party.members),
+            "hp_lost": 0,
+            "triggers": 0,
+        }
 
-        def _battle_start(entity) -> None:
+        def _turn_start(entity) -> None:
             from plugins.foes._base import FoeBase
 
             if isinstance(entity, FoeBase):
-                state["foes"].append(entity)
+                if entity not in state["foes"]:
+                    state["foes"].append(entity)
                 return
 
-            if state["ally"] is None and party.members:
-                ally = min(party.members, key=lambda m: m.max_hp)
-                # Increase initial bleed to 5% per stack (was 1%)
-                bleed = int(ally.max_hp * 0.05 * stacks)
-                dmg = min(bleed, max(ally.hp - 1, 0))
+            if entity in party.members:
+                bleed = int(entity.max_hp * 0.05 * stacks)
+                dmg = min(bleed, max(entity.hp - 1, 0))
 
-                # Emit relic effect event for initial bleed
-                BUS.emit("relic_effect", "rusty_buckle", ally, "initial_bleed", dmg, {
-                    "target_selection": "lowest_max_hp",
-                    "bleed_percentage": 5 * stacks,
-                    "stacks": stacks
-                })
+                BUS.emit(
+                    "relic_effect",
+                    "rusty_buckle",
+                    entity,
+                    "turn_bleed",
+                    dmg,
+                    {
+                        "target_selection": "each_turn",
+                        "bleed_percentage": 5 * stacks,
+                        "stacks": stacks,
+                    },
+                )
 
-                safe_async_task(ally.apply_damage(dmg, attacker=ally))
-                state["ally"] = ally
-                state["triggers"] = 0
+                safe_async_task(entity.apply_damage(dmg, attacker=entity))
 
         def _damage(target, attacker, amount) -> None:
-            ally = state.get("ally")
-            if target is not ally:
+            if target not in party.members:
                 return
-            max_hp = ally.max_hp
+            state["hp_lost"] += amount
+            party_max_hp = state["party_max_hp"]
             triggers = state["triggers"]
-            lost_frac = 1 - (ally.hp / max_hp)
-            while lost_frac >= 0.1 * (triggers + 1):
+            threshold = party_max_hp * (1 + 0.5 * (stacks - 1))
+            while state["hp_lost"] >= threshold * (triggers + 1):
                 triggers += 1
                 state["triggers"] = triggers
-                total_lost = max_hp * 0.1 * triggers
-                dmg = int(total_lost * 0.005)
+                lost_pct = state["hp_lost"] / party_max_hp
+                dmg = int(party_max_hp * lost_pct * 0.005)
                 hits = 5 + 3 * (stacks - 1)
 
-                # Emit relic effect event for aftertaste trigger
-                BUS.emit("relic_effect", "rusty_buckle", ally, "aftertaste_trigger", dmg, {
-                    "trigger_count": triggers,
-                    "hp_lost_percentage": lost_frac * 100,
-                    "aftertaste_hits": hits,
-                    "damage_per_hit": dmg
-                })
+                BUS.emit(
+                    "relic_effect",
+                    "rusty_buckle",
+                    target,
+                    "aftertaste_trigger",
+                    dmg,
+                    {
+                        "trigger_count": triggers,
+                        "hp_lost_percentage": lost_pct * 100,
+                        "aftertaste_hits": hits,
+                        "damage_per_hit": dmg,
+                    },
+                )
 
                 for _ in range(hits):
                     if state["foes"]:
                         foe = random.choice(state["foes"])
-                        safe_async_task(Aftertaste(base_pot=dmg).apply(ally, foe))
+                        safe_async_task(Aftertaste(base_pot=dmg).apply(target, foe))
 
-        BUS.subscribe("battle_start", _battle_start)
+        BUS.subscribe("turn_start", _turn_start)
         BUS.subscribe("damage_taken", _damage)
 
     def describe(self, stacks: int) -> str:
         bleed = 5 * stacks
         hits = 5 + 3 * (stacks - 1)
+        req = int((1 + 0.5 * (stacks - 1)) * 100)
         return (
-            f"Lowest-HP ally bleeds for {bleed}% Max HP at start. "
-            f"Each 10% HP lost triggers {hits} Aftertaste hits at random foes."
+            f"All allies bleed for {bleed}% Max HP at the start of each turn. "
+            f"Each {req}% party HP lost triggers {hits} Aftertaste hits at random foes."
         )

--- a/backend/tests/test_rusty_buckle.py
+++ b/backend/tests/test_rusty_buckle.py
@@ -1,0 +1,89 @@
+import pytest
+
+from autofighter.party import Party
+import autofighter.stats as stats
+from plugins.effects.aftertaste import Aftertaste
+from plugins.event_bus import EventBus
+from plugins.foes._base import FoeBase
+from plugins.players._base import PlayerBase
+from plugins.relics.rusty_buckle import RustyBuckle
+
+
+@pytest.fixture
+def bus(monkeypatch):
+    bus = EventBus()
+    monkeypatch.setattr(stats, "BUS", bus)
+    import plugins.relics.rusty_buckle as rb
+    monkeypatch.setattr(rb, "BUS", bus)
+    stats.set_battle_active(True)
+    yield bus
+    stats.set_battle_active(False)
+
+
+def test_all_allies_bleed_each_turn(bus):
+    party = Party(
+        members=[PlayerBase(max_hp=1000, hp=1000), PlayerBase(max_hp=800, hp=800)],
+        relics=["rusty_buckle"],
+    )
+    relic = RustyBuckle()
+    relic.apply(party)
+    foe = FoeBase()
+    bus.emit("turn_start", foe)
+    for member in party.members:
+        bus.emit("turn_start", member)
+    assert party.members[0].hp == 950
+    assert party.members[1].hp == 760
+    for member in party.members:
+        bus.emit("turn_start", member)
+    assert party.members[0].hp == 900
+    assert party.members[1].hp == 720
+
+
+def test_aftertaste_triggers_on_cumulative_loss(monkeypatch, bus):
+    party = Party(
+        members=[PlayerBase(max_hp=1000, hp=1000), PlayerBase(max_hp=1000, hp=1000)],
+        relics=["rusty_buckle"],
+    )
+    relic = RustyBuckle()
+    relic.apply(party)
+    foe = FoeBase()
+    bus.emit("turn_start", foe)
+    for member in party.members:
+        bus.emit("turn_start", member)
+
+    hits = 0
+
+    async def fake_apply(self, attacker, target):
+        nonlocal hits
+        hits += 1
+        return []
+
+    monkeypatch.setattr(Aftertaste, "apply", fake_apply)
+    bus.emit("damage_taken", party.members[0], None, 1900)
+    assert hits == 5
+
+
+def test_stacks_increase_threshold(monkeypatch, bus):
+    party = Party(
+        members=[PlayerBase(max_hp=1000, hp=1000), PlayerBase(max_hp=1000, hp=1000)],
+        relics=["rusty_buckle", "rusty_buckle"],
+    )
+    relic = RustyBuckle()
+    relic.apply(party)
+    foe = FoeBase()
+    bus.emit("turn_start", foe)
+    for member in party.members:
+        bus.emit("turn_start", member)
+
+    hits = 0
+
+    async def fake_apply(self, attacker, target):
+        nonlocal hits
+        hits += 1
+        return []
+
+    monkeypatch.setattr(Aftertaste, "apply", fake_apply)
+    bus.emit("damage_taken", party.members[0], None, 2899)
+    assert hits == 0
+    bus.emit("damage_taken", party.members[0], None, 1)
+    assert hits == 5


### PR DESCRIPTION
## Summary
- Bleed all allies for 5% max HP each turn and track party-wide HP loss for Rusty Buckle
- Trigger Aftertaste based on cumulative HP loss and update relic documentation
- Add tests covering turn-based bleed, Aftertaste thresholds, and stacking behavior

## Testing
- `uv run ruff check backend/plugins/relics/rusty_buckle.py backend/tests/test_rusty_buckle.py --fix`
- `uv run ruff check . --fix` *(fails: unused variables and whitespace in .codex/prototypes)*
- `./run-tests.sh` *(multiple backend test failures: performance assertions, missing modules, and async setup issues)*

------
https://chatgpt.com/codex/tasks/task_b_68c0b0d0ceb0832c90baef8f3b386bdf