### PR TITLE
[FEAT] Add conditional crit bonus to Farsight Scope

### DIFF
--- a/backend/tests/test_farsight_scope.py
+++ b/backend/tests/test_farsight_scope.py
@@ -1,0 +1,38 @@
+import asyncio
+
+import pytest
+
+from autofighter.cards import apply_cards
+from autofighter.cards import award_card
+from autofighter.party import Party
+from autofighter.stats import BUS
+from autofighter.stats import Stats
+
+
+def setup_event_loop():
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    return loop
+
+
+def test_farsight_scope_crit_bonus_applied_and_removed():
+    loop = setup_event_loop()
+    party = Party()
+    ally = Stats()
+    enemy = Stats()
+    ally.set_base_stat("atk", 100)
+    enemy.set_base_stat("max_hp", 1000)
+    enemy.hp = 1000
+    party.members.append(ally)
+    award_card(party, "farsight_scope")
+    loop.run_until_complete(apply_cards(party))
+
+    base_crit = ally.crit_rate
+
+    enemy.hp = 400  # Below 50%
+    BUS.emit("before_attack", ally, enemy)
+    assert ally.crit_rate == pytest.approx(base_crit + 0.06, abs=1e-6)
+
+    BUS.emit("action_used", ally, enemy, ally.atk)
+    assert ally.crit_rate == pytest.approx(base_crit, abs=1e-6)
+


### PR DESCRIPTION
## Summary
- add temporary +6% crit rate vs low-HP foes for Farsight Scope card
- test Farsight Scope crit bonus application and cleanup

## Testing
- `uv run pytest tests/test_farsight_scope.py`
- `ruff check backend/plugins/cards/farsight_scope.py backend/tests/test_farsight_scope.py --fix`


------
https://chatgpt.com/codex/tasks/task_b_68c0ea8d0d00832c971b24a200900061