### PR TITLE
Fix Steel Bangles damage reduction and add tests

### DIFF
--- a/backend/plugins/cards/steel_bangles.py
+++ b/backend/plugins/cards/steel_bangles.py
@@ -43,15 +43,30 @@ class SteelBangles(CardBase):
                 attacker_id = id(attacker)
                 if attacker_id in damage_reduced_targets:
                     reduction = damage_reduced_targets.pop(attacker_id)
-                    damage_reduction = int(damage * reduction)
+                    reduced_damage = int(damage * (1 - reduction))
+                    damage_reduction = damage - reduced_damage
+
                     import logging
                     log = logging.getLogger(__name__)
-                    log.debug("Steel Bangles reducing attack damage by %d", damage_reduction)
-                    # Note: Actual damage reduction would need to be implemented in the damage system
-                    BUS.emit("card_effect", self.id, attacker, "damage_reduced", damage_reduction, {
-                        "damage_reduction": damage_reduction,
-                        "original_damage": damage
-                    })
+                    log.debug(
+                        "Steel Bangles reducing attack damage from %d to %d",
+                        damage,
+                        reduced_damage,
+                    )
+                    BUS.emit(
+                        "card_effect",
+                        self.id,
+                        attacker,
+                        "damage_reduced",
+                        damage_reduction,
+                        {
+                            "damage_reduction": damage_reduction,
+                            "original_damage": damage,
+                        },
+                    )
+                    return reduced_damage
+
+            return damage
 
         BUS.subscribe("damage_dealt", _on_damage_dealt)
         BUS.subscribe("before_damage", _on_before_damage)

--- a/backend/tests/test_steel_bangles.py
+++ b/backend/tests/test_steel_bangles.py
@@ -1,0 +1,37 @@
+import asyncio
+
+import pytest
+
+from autofighter.cards import apply_cards
+from autofighter.cards import award_card
+from autofighter.party import Party
+from autofighter.stats import BUS
+from autofighter.stats import Stats
+import plugins.cards.steel_bangles as steel_bangles_module
+import plugins.event_bus as event_bus_module
+
+
+@pytest.mark.asyncio
+async def test_steel_bangles_reduces_damage_once(monkeypatch) -> None:
+    event_bus_module.bus._subs.clear()
+    defender = Stats()
+    attacker = Stats()
+    party = Party([defender])
+    award_card(party, "steel_bangles")
+    await apply_cards(party)
+    await asyncio.sleep(0)
+
+    # Force damage reduction to trigger
+    monkeypatch.setattr(steel_bangles_module.random, "random", lambda: 0.0)
+    BUS.emit("damage_dealt", defender, attacker, 100, "attack", None, None, "attack")
+    await asyncio.sleep(0.1)
+
+    # Retrieve the original before_damage callback
+    obj_ref, _wrapper = event_bus_module.bus._subs["before_damage"][0]
+    callback = obj_ref() if callable(obj_ref) else obj_ref
+
+    # First attack is reduced
+    assert callback(defender, attacker, 100) == 97
+    # Subsequent attacks are unaffected
+    assert callback(defender, attacker, 100) == 100
+


### PR DESCRIPTION
## Summary
- apply incoming damage reduction for Steel Bangles instead of logging
- test Steel Bangles damage reduction only applies once

## Testing
- `uvx ruff check backend/plugins/cards/steel_bangles.py backend/tests/test_steel_bangles.py --fix`
- `uv run pytest tests/test_steel_bangles.py`
- `./run-tests.sh` *(fails: KeyError 'foes' in test_battle_snapshot_consistency, ModuleNotFoundError 'battle_logging', TypeError Stats.__init__ in test_frozen_wound)*

------
https://chatgpt.com/codex/tasks/task_b_68c0ea92a8c4832c9b0c85db404a018c