### PR TITLE
[FIX] Ensure Swift Footwork refunds first action

### DIFF
--- a/backend/plugins/cards/swift_footwork.py
+++ b/backend/plugins/cards/swift_footwork.py
@@ -24,9 +24,14 @@ class SwiftFootwork(CardBase):
             used.clear()
 
         def _action_used(actor, *_args) -> None:
-            pid = id(actor)
-            if actor not in party.members or pid in used:
+            if actor not in party.members:
                 return
+
+            pid = id(actor)
+            if pid in used:
+                return
+
+            actor.action_points += 1
             used.add(pid)
             BUS.emit("card_effect", self.id, actor, "free_action", 0, {})
 

--- a/backend/tests/test_card_rewards.py
+++ b/backend/tests/test_card_rewards.py
@@ -202,6 +202,7 @@ async def test_iron_guard_defense_buff():
 @pytest.mark.asyncio
 async def test_swift_footwork_first_action(monkeypatch):
     member = Stats()
+    member.action_points = 1
     party = Party(members=[member])
     award_card(party, "swift_footwork")
     await cards_module.apply_cards(party)
@@ -215,9 +216,16 @@ async def test_swift_footwork_first_action(monkeypatch):
 
     BUS.subscribe("card_effect", _listener)
     BUS.emit("battle_start")
+    member.action_points -= 1
     BUS.emit("action_used", member, None, 10)
+    await asyncio.sleep(0.05)
+    assert member.action_points == 1
+    member.action_points -= 1
+    BUS.emit("action_used", member, None, 10)
+    await asyncio.sleep(0.05)
     BUS.unsubscribe("card_effect", _listener)
-    assert "free_action" in events
+    assert member.action_points == 0
+    assert events.count("free_action") == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- refund first action's action point for Swift Footwork card
- test Swift Footwork refunds only the first action

## Testing
- `ruff check .`
- `run-tests.sh` *(fails: test suite contains existing failing tests)*
- `uv run pytest tests/test_card_rewards.py::test_swift_footwork_first_action -q`


------
https://chatgpt.com/codex/tasks/task_b_68c0ea9653cc832c9b8cb5d544e4b5db