### PR TITLE
Add per-target bonus damage for Honed Point card

### DIFF
--- a/backend/plugins/cards/honed_point.py
+++ b/backend/plugins/cards/honed_point.py
@@ -1,8 +1,12 @@
+import asyncio
 from dataclasses import dataclass
 from dataclasses import field
+import logging
 
 from autofighter.stats import BUS
 from plugins.cards._base import CardBase
+
+log = logging.getLogger(__name__)
 
 
 @dataclass
@@ -11,42 +15,53 @@ class HonedPoint(CardBase):
     name: str = "Honed Point"
     stars: int = 1
     effects: dict[str, float] = field(default_factory=lambda: {"atk": 0.04})
-    about: str = "+4% ATK; First attack vs an unmarked enemy gains +10% armor penetration for that hit"
+    about: str = "+4% ATK; First attack vs an unmarked enemy deals +10% bonus damage"
 
     async def apply(self, party) -> None:  # type: ignore[override]
         await super().apply(party)
 
-        # Track which enemies have been marked (attacked) by which party members
-        marked_enemies = {}
+        marked_enemies: dict[int, set[int]] = {}
 
         def _on_damage_dealt(attacker, target, damage, damage_type, source, source_action, action_name):
-            # Check if attacker is one of our party members and this is an attack
             if attacker in party.members and action_name == "attack":
                 attacker_id = id(attacker)
                 target_id = id(target)
 
-                # Check if this is the first attack against this enemy by this attacker
                 if attacker_id not in marked_enemies:
                     marked_enemies[attacker_id] = set()
 
                 if target_id not in marked_enemies[attacker_id]:
-                    # Mark this enemy and apply armor penetration bonus
                     marked_enemies[attacker_id].add(target_id)
 
-                    # Apply +10% armor penetration for this hit (theoretical implementation)
-                    armor_pen_bonus = 10
-                    import logging
-                    log = logging.getLogger(__name__)
-                    log.debug("Honed Point armor penetration: +%d%% armor pen vs unmarked enemy", armor_pen_bonus)
-                    BUS.emit("card_effect", self.id, attacker, "armor_penetration", armor_pen_bonus, {
-                        "armor_pen_bonus": armor_pen_bonus,
-                        "trigger_event": "first_attack_unmarked"
-                    })
+                    bonus_damage = int(damage * 0.10)
+                    if bonus_damage > 0:
+                        asyncio.create_task(
+                            target.apply_damage(
+                                bonus_damage,
+                                attacker,
+                                source_type=damage_type,
+                                action_name="honed_point_bonus",
+                            )
+                        )
+                        log.debug(
+                            "Honed Point bonus damage: +%d vs unmarked enemy", bonus_damage
+                        )
+                        BUS.emit(
+                            "card_effect",
+                            self.id,
+                            attacker,
+                            "bonus_damage",
+                            bonus_damage,
+                            {
+                                "bonus_damage": bonus_damage,
+                                "trigger_event": "first_attack_unmarked",
+                            },
+                        )
 
         def _on_battle_start(target):
-            # Reset marked enemies for new battle
             if target in party.members:
                 marked_enemies.clear()
 
         BUS.subscribe("damage_dealt", _on_damage_dealt)
         BUS.subscribe("battle_start", _on_battle_start)
+

--- a/backend/tests/test_honed_point.py
+++ b/backend/tests/test_honed_point.py
@@ -1,0 +1,48 @@
+import asyncio
+
+from autofighter.cards import apply_cards
+from autofighter.cards import award_card
+from autofighter.party import Party
+from autofighter.stats import Stats
+from plugins import event_bus as event_bus_module
+
+
+def setup_event_loop():
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    return loop
+
+
+def test_honed_point_bonus_damage_once():
+    event_bus_module.bus._subs.clear()
+    loop = setup_event_loop()
+    party = Party()
+    attacker = Stats()
+    target = Stats()
+
+    attacker._base_atk = 100
+    target._base_defense = 0
+    target.mitigation = 1
+    target._base_vitality = 1
+
+    party.members.append(attacker)
+    award_card(party, "honed_point")
+    loop.run_until_complete(apply_cards(party))
+
+    initial_hp = target.hp
+    dmg = loop.run_until_complete(
+        target.apply_damage(attacker.atk, attacker=attacker, action_name="attack")
+    )
+    loop.run_until_complete(asyncio.sleep(0))
+
+    expected_first = dmg + int(dmg * 0.10)
+    assert target.hp == initial_hp - expected_first
+
+    hp_after_first = target.hp
+    dmg2 = loop.run_until_complete(
+        target.apply_damage(attacker.atk, attacker=attacker, action_name="attack")
+    )
+    loop.run_until_complete(asyncio.sleep(0))
+
+    assert target.hp == hp_after_first - dmg2
+


### PR DESCRIPTION
## Summary
- apply 10% bonus damage on the first attack against an unmarked foe for the Honed Point card
- add regression test ensuring bonus triggers once per attacker-target pair

## Testing
- `ruff check backend --fix`
- `./run-tests.sh` *(fails: frontend tests missing assets; backend tests timed out)*

------
https://chatgpt.com/codex/tasks/task_b_68c0ea8ec484832c991b3cea1469f9b2