### PR TITLE
[FEATURE] Add retaliation damage for Spiked Shield

### DIFF
--- a/backend/tests/test_spiked_shield.py
+++ b/backend/tests/test_spiked_shield.py
@@ -1,0 +1,37 @@
+import asyncio
+
+from autofighter.cards import apply_cards
+from autofighter.cards import award_card
+from autofighter.party import Party
+from autofighter.stats import BUS
+from autofighter.stats import Stats
+from plugins.players._base import PlayerBase
+
+
+def setup_event_loop():
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    return loop
+
+
+def test_spiked_shield_retaliates_damage(monkeypatch):
+    loop = setup_event_loop()
+    party = Party()
+    defender = PlayerBase()
+    attacker = PlayerBase()
+    defender.atk = 100
+    attacker.hp = attacker.max_hp = 1000
+    party.members.append(defender)
+    award_card(party, "spiked_shield")
+    loop.run_until_complete(apply_cards(party))
+
+    async def fake_apply_damage(self, amount, attacker=None, *, trigger_on_hit=True, action_name=None):
+        self.hp -= amount
+        return amount
+
+    monkeypatch.setattr(Stats, "apply_damage", fake_apply_damage, raising=False)
+
+    BUS.emit("mitigation_triggered", defender, 100, 50, attacker)
+    loop.run_until_complete(asyncio.sleep(0))
+
+    assert attacker.hp == 1000 - int(defender.atk * 0.03)


### PR DESCRIPTION
## Summary
- make Spiked Shield deal retaliation damage to the attacker when mitigation triggers
- log and emit card effect event for actual retaliation damage dealt
- add unit test to verify Spiked Shield retaliation damage on mitigation

## Testing
- `uv tool run ruff check backend --fix`
- `./run-tests.sh` *(fails: backend tests/test_app.py, backend tests/test_app_without_llm_deps.py, backend tests/test_character_editor.py, backend tests/test_damage_type_persistence.py, backend tests/test_gacha.py, backend tests/test_new_upgrade_system.py, backend tests/test_players_user.py, frontend tests/* multiple ENOENT and module errors)*

------
https://chatgpt.com/codex/tasks/task_b_68c0ea949a64832c8efb861c34862c2c