### PR TITLE
Guardian Charm stacks now scale defense boost

### DIFF
--- a/backend/plugins/relics/guardian_charm.py
+++ b/backend/plugins/relics/guardian_charm.py
@@ -22,16 +22,28 @@ class GuardianCharm(RelicBase):
         if not party.members:
             return
         member = min(party.members, key=lambda m: m.hp)
+        stacks = party.relics.count(self.id)
+        defense_pct = 20 * stacks
 
         # Emit relic effect event for defense boost
-        BUS.emit("relic_effect", "guardian_charm", member, "defense_boost", 20, {
-            "target_selection": "lowest_hp",
-            "defense_percentage": 20,
-            "target_hp": member.hp,
-            "target_max_hp": member.max_hp
-        })
+        BUS.emit(
+            "relic_effect",
+            "guardian_charm",
+            member,
+            "defense_boost",
+            defense_pct,
+            {
+                "target_selection": "lowest_hp",
+                "defense_percentage": defense_pct,
+                "target_hp": member.hp,
+                "target_max_hp": member.max_hp,
+                "stacks": stacks,
+            },
+        )
 
-        mod = create_stat_buff(member, name=self.id, defense_mult=1.2, turns=9999)
+        mod = create_stat_buff(
+            member, name=self.id, defense_mult=1 + 0.2 * stacks, turns=9999
+        )
         member.effect_manager.add_modifier(mod)
 
     def describe(self, stacks: int) -> str:

--- a/backend/tests/test_relic_effects.py
+++ b/backend/tests/test_relic_effects.py
@@ -109,6 +109,20 @@ def test_guardian_charm_targets_lowest_hp():
     assert high.defense == 50
 
 
+def test_guardian_charm_stacks():
+    party = Party()
+    low = PlayerBase()
+    high = PlayerBase()
+    low.hp = low.max_hp = 50
+    high.hp = high.max_hp = 100
+    party.members.extend([low, high])
+    award_relic(party, "guardian_charm")
+    award_relic(party, "guardian_charm")
+    apply_relics(party)
+    assert low.defense == int(50 * (1 + 0.2 * 2))
+    assert high.defense == 50
+
+
 def test_herbal_charm_heals_each_turn():
     event_bus_module.bus._subs.clear()
     party = Party()


### PR DESCRIPTION
## Summary
- compute Guardian Charm stack count and scale defense multiplier
- emit stack-aware percentage in relic effect payload
- add unit test for multi-stack defense scaling

## Testing
- `ruff check backend/plugins/relics/guardian_charm.py backend/tests/test_relic_effects.py --fix`
- `./run-tests.sh` *(fails: frontend missing modules, several backend tests timed out)*

------
https://chatgpt.com/codex/tasks/task_b_68c0ead81ed0832ca47e166b39fe415b