### PR TITLE
Boost Mindful Tassel debuff potency

### DIFF
--- a/backend/plugins/cards/mindful_tassel.py
+++ b/backend/plugins/cards/mindful_tassel.py
@@ -1,5 +1,7 @@
 from dataclasses import dataclass
 from dataclasses import field
+import logging
+import math
 
 from autofighter.stats import BUS
 from plugins.cards._base import CardBase
@@ -16,34 +18,74 @@ class MindfulTassel(CardBase):
     async def apply(self, party) -> None:  # type: ignore[override]
         await super().apply(party)
 
-        first_debuff_used = {}
+        bonus_used = False
 
-        def _on_effect_applied(target, effect_name, duration, source):
-            # Check if source is one of our party members and this is a debuff
-            if source in party.members:
-                source_id = id(source)
-                effect_lower = effect_name.lower()
-                is_debuff = any(keyword in effect_lower for keyword in
-                               ['bleed', 'poison', 'burn', 'freeze', 'stun', 'silence', 'slow', 'weakness', 'curse'])
+        def _on_effect_applied(effect_name, entity, details=None):
+            nonlocal bonus_used
 
-                if is_debuff and source_id not in first_debuff_used:
-                    # Mark first debuff as used for this member
-                    first_debuff_used[source_id] = True
+            if bonus_used or not details:
+                return
 
-                    # Increase potency by 5% (theoretical implementation)
-                    import logging
-                    log = logging.getLogger(__name__)
-                    log.debug("Mindful Tassel first debuff potency: +5% potency to %s", effect_name)
-                    BUS.emit("card_effect", self.id, source, "debuff_potency_boost", 5, {
-                        "potency_boost": 5,
-                        "effect_name": effect_name,
-                        "trigger_event": "first_debuff"
-                    })
+            effect_id = details.get("effect_id")
+            effect_type = details.get("effect_type")
+            if effect_id is None or effect_type not in {"dot", "stat_modifier"}:
+                return
 
-        def _on_battle_start(target):
-            # Reset first debuff usage for new battle
-            if target in party.members:
-                first_debuff_used.clear()
+            if effect_type == "stat_modifier":
+                deltas = details.get("deltas") or {}
+                multipliers = details.get("multipliers") or {}
+                if not any(v < 0 for v in deltas.values()) and not any(
+                    v < 1 for v in multipliers.values()
+                ):
+                    return
+
+            mgr = getattr(entity, "effect_manager", None)
+            if mgr is None:
+                return
+
+            if effect_type == "dot":
+                pool = mgr.dots
+            else:
+                pool = mgr.mods
+
+            eff = next((e for e in pool if getattr(e, "id", None) == effect_id), None)
+            if eff is None:
+                return
+
+            source = getattr(eff, "source", None)
+            if source not in party.members:
+                return
+
+            bonus_used = True
+
+            if hasattr(eff, "damage"):
+                eff.damage = int(eff.damage * 1.05)
+
+            if hasattr(eff, "turns") and eff.turns > 0:
+                eff.turns = max(eff.turns, math.ceil(eff.turns * 1.05))
+
+            log = logging.getLogger(__name__)
+            log.debug(
+                "Mindful Tassel first debuff potency: +5% potency to %s",
+                effect_name,
+            )
+            BUS.emit(
+                "card_effect",
+                self.id,
+                source,
+                "debuff_potency_boost",
+                5,
+                {
+                    "potency_boost": 5,
+                    "effect_name": effect_name,
+                    "trigger_event": "first_debuff",
+                },
+            )
+
+        def _on_battle_start(entity):
+            nonlocal bonus_used
+            if entity in party.members:
+                bonus_used = False
 
         BUS.subscribe("effect_applied", _on_effect_applied)
         BUS.subscribe("battle_start", _on_battle_start)


### PR DESCRIPTION
## Summary
- Enhance Mindful Tassel so the first debuff inflicted each battle gains +5% damage and duration
- Reset the bonus at battle start and add coverage test for the potency bump
- Detect qualifying debuffs via effect metadata rather than name keywords

## Testing
- `uvx ruff check backend/plugins/cards/mindful_tassel.py backend/tests/test_card_effects.py --fix`
- `./run-tests.sh` *(fails: ModuleNotFoundError: No module named 'llms', plus numerous unrelated test failures)*

------
https://chatgpt.com/codex/tasks/task_b_68c0ea902950832cb8daf9e0c7be4ee2