### PR TITLE
[FIX] apply Guiding Compass XP bonus and test

### DIFF
--- a/backend/plugins/cards/guiding_compass.py
+++ b/backend/plugins/cards/guiding_compass.py
@@ -27,11 +27,24 @@ class GuidingCompass(CardBase):
                 extra_xp = 10  # Small extra XP amount
                 for member in party.members:
                     import logging
+
                     log = logging.getLogger(__name__)
-                    log.debug("Guiding Compass first battle bonus: +%d XP to %s", extra_xp, member.id)
-                    BUS.emit("card_effect", self.id, member, "first_battle_xp", extra_xp, {
-                        "bonus_xp": extra_xp,
-                        "trigger_event": "first_battle"
-                    })
+                    log.debug(
+                        "Guiding Compass first battle bonus: +%d XP to %s",
+                        extra_xp,
+                        member.id,
+                    )
+                    member.exp += extra_xp
+                    BUS.emit(
+                        "card_effect",
+                        self.id,
+                        member,
+                        "first_battle_xp",
+                        extra_xp,
+                        {
+                            "bonus_xp": extra_xp,
+                            "trigger_event": "first_battle",
+                        },
+                    )
 
         BUS.subscribe("battle_start", _on_battle_start)

--- a/backend/tests/test_guiding_compass.py
+++ b/backend/tests/test_guiding_compass.py
@@ -1,0 +1,56 @@
+# ruff: noqa: E402
+
+import asyncio
+import sys
+import types
+
+import pytest
+
+torch_checker = types.ModuleType("torch_checker")
+torch_checker.is_torch_available = lambda: False
+llms_module = types.ModuleType("llms")
+llms_module.torch_checker = torch_checker
+sys.modules["llms"] = llms_module
+sys.modules["llms.torch_checker"] = torch_checker
+
+from autofighter.party import Party
+from autofighter.stats import BUS
+from plugins.cards.guiding_compass import GuidingCompass
+import plugins.event_bus as event_bus_module
+from plugins.players._base import PlayerBase
+
+
+@pytest.mark.asyncio
+async def test_guiding_compass_first_battle_xp_only_once() -> None:
+    event_bus_module.bus._subs.clear()
+
+    member1 = PlayerBase()
+    member1.id = "m1"
+    member2 = PlayerBase()
+    member2.id = "m2"
+    party = Party([member1, member2])
+    base_exp = member1.exp
+    card = GuidingCompass()
+    await card.apply(party)
+
+    events: list[tuple[str, str, int]] = []
+
+    def _on_card_effect(card_id, member, effect, amount, extra):
+        if effect == "first_battle_xp":
+            events.append((card_id, member.id, amount))
+
+    BUS.subscribe("card_effect", _on_card_effect)
+
+    BUS.emit("battle_start", member1)
+    await asyncio.sleep(0.05)
+
+    assert member1.exp == base_exp + 10
+    assert member2.exp == base_exp + 10
+    assert len(events) == 2
+
+    BUS.emit("battle_start", member1)
+    await asyncio.sleep(0.05)
+
+    assert member1.exp == base_exp + 10
+    assert member2.exp == base_exp + 10
+    assert len(events) == 2


### PR DESCRIPTION
## Summary
- ensure Guiding Compass grants its extra XP on the party at first battle start
- cover Guiding Compass XP bonus with a new test

## Testing
- `./run-tests.sh` *(fails: test_app.py, test_app_without_llm_deps.py, test_character_editor.py, test_damage_type_persistence.py, test_gacha.py, test_new_upgrade_system.py, test_players_user.py)*

------
https://chatgpt.com/codex/tasks/task_b_68c0ea8e0b18832cb205c9fb472cf93e