### PR TITLE
[FIX] scale Threadbare Cloak shield

### DIFF
--- a/backend/plugins/relics/threadbare_cloak.py
+++ b/backend/plugins/relics/threadbare_cloak.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from dataclasses import field
 
+from autofighter.stats import BUS
 from plugins.relics._base import RelicBase
 from plugins.relics._base import safe_async_task
 
@@ -30,6 +31,11 @@ class ThreadbareCloak(RelicBase):
             safe_async_task(member.apply_healing(shield))
 
         party._threadbare_cloak_stacks = stacks
+
+        def _reset(*_: object) -> None:
+            party._threadbare_cloak_stacks = 0
+
+        BUS.subscribe("battle_end", _reset)
 
     def describe(self, stacks: int) -> str:
         pct = 3 * stacks

--- a/backend/tests/test_relic_effects.py
+++ b/backend/tests/test_relic_effects.py
@@ -211,6 +211,23 @@ def test_threadbare_cloak_shield_scales_with_stacks():
     assert a.hp == 100 + int(100 * 0.03 * 2)
 
 
+def test_threadbare_cloak_applies_each_battle():
+    event_bus_module.bus._subs.clear()
+    party = Party()
+    a = PlayerBase()
+    a.hp = a.max_hp = 100
+    party.members.append(a)
+
+    award_relic(party, "threadbare_cloak")
+    apply_relics(party)
+    assert a.hp == 100 + int(100 * 0.03)
+
+    BUS.emit("battle_end", a)
+    a.hp = a.max_hp = 100
+    apply_relics(party)
+    assert a.hp == 100 + int(100 * 0.03)
+
+
 def test_lucky_button_missed_crit():
     event_bus_module.bus._subs.clear()
     party = Party()


### PR DESCRIPTION
## Summary
- reset Threadbare Cloak stack state after each battle
- add regression test for shield reapplication across battles

## Testing
- `uv run ruff check backend/plugins/relics/threadbare_cloak.py backend/tests/test_relic_effects.py --fix`
- `./run-tests.sh` *(fails: KeyError: 'foes' in test_battle_snapshot_consistency::test_foe_element_stable_across_snapshots)*

------
https://chatgpt.com/codex/tasks/task_b_68c0efef2e58832c886ff4863f70ed45