### PR TITLE
[FEATURE] Add Guardian Shard mitigation bonus

### DIFF
--- a/backend/plugins/cards/guardian_shard.py
+++ b/backend/plugins/cards/guardian_shard.py
@@ -28,8 +28,15 @@ class GuardianShard(CardBase):
             if target in party.members:
                 battle_deaths += 1
 
-        def _on_battle_end():
+        def _on_battle_end(target):
             nonlocal mitigation_bonus_pending, active_members
+
+            if (
+                target is not None
+                and target is not party
+                and target not in party.members
+            ):
+                return
 
             # Remove any active mitigation buffs
             for member in active_members:

--- a/backend/tests/test_guardian_shard.py
+++ b/backend/tests/test_guardian_shard.py
@@ -27,7 +27,7 @@ def test_guardian_shard_applies_bonus_after_no_deaths():
     BUS.emit("battle_start", ally1)
     BUS.emit("battle_start", ally2)
     loop.run_until_complete(asyncio.sleep(0))
-    BUS.emit("battle_end")
+    BUS.emit("battle_end", ally1)
     loop.run_until_complete(asyncio.sleep(0))
 
     pre = ally1.mitigation
@@ -36,7 +36,7 @@ def test_guardian_shard_applies_bonus_after_no_deaths():
     loop.run_until_complete(asyncio.sleep(0))
     assert ally1.mitigation == pytest.approx(pre + 1)
 
-    BUS.emit("battle_end")
+    BUS.emit("battle_end", ally1)
     loop.run_until_complete(asyncio.sleep(0))
     assert ally1.mitigation == pytest.approx(pre)
 
@@ -54,7 +54,7 @@ def test_guardian_shard_no_bonus_after_death():
     BUS.emit("battle_start", ally2)
     BUS.emit("death", ally1)
     loop.run_until_complete(asyncio.sleep(0))
-    BUS.emit("battle_end")
+    BUS.emit("battle_end", ally1)
     loop.run_until_complete(asyncio.sleep(0))
 
     pre = ally1.mitigation


### PR DESCRIPTION
## Summary
- apply temporary +1 mitigation buff at battle start if previous fight had no ally deaths
- remove Guardian Shard mitigation buff at battle end
- test Guardian Shard mitigation bonus only applies after a death-free battle
- guard against unrelated `battle_end` events removing mitigation bonus

## Testing
- `ruff check backend/plugins/cards/guardian_shard.py backend/tests/test_guardian_shard.py --fix`
- `./run-tests.sh` *(fails: missing frontend modules; several backend tests timed out)*

------
https://chatgpt.com/codex/tasks/task_b_68c0f03b0a38832ca8035ac14087f8fa