### PR TITLE
Fix Honed Point bonus damage apply_damage call

### DIFF
--- a/backend/plugins/cards/honed_point.py
+++ b/backend/plugins/cards/honed_point.py
@@ -22,7 +22,7 @@ class HonedPoint(CardBase):
 
         marked_enemies: dict[int, set[int]] = {}
 
-        def _on_damage_dealt(attacker, target, damage, damage_type, source, source_action, action_name):
+        def _on_damage_dealt(attacker, target, damage, _damage_type, source, source_action, action_name):
             if attacker in party.members and action_name == "attack":
                 attacker_id = id(attacker)
                 target_id = id(target)
@@ -39,7 +39,6 @@ class HonedPoint(CardBase):
                             target.apply_damage(
                                 bonus_damage,
                                 attacker,
-                                source_type=damage_type,
                                 action_name="honed_point_bonus",
                             )
                         )


### PR DESCRIPTION
## Summary
- remove unsupported `source_type` argument in Honed Point bonus damage handler
- mark unused damage type parameter

## Testing
- `ruff check backend --fix`
- `./run-tests.sh` *(fails: frontend tests missing assets; backend tests timed out)*

------
https://chatgpt.com/codex/tasks/task_b_68c0f05cae04832c8431355fac75e3cf