### PR TITLE
[FIX] handle foe battle_end events

### DIFF
--- a/backend/plugins/cards/guardian_shard.py
+++ b/backend/plugins/cards/guardian_shard.py
@@ -31,10 +31,12 @@ class GuardianShard(CardBase):
         def _on_battle_end(target):
             nonlocal mitigation_bonus_pending, active_members
 
+            if target is None:
+                return
             if (
-                target is not None
-                and target is not party
+                target is not party
                 and target not in party.members
+                and getattr(target, "plugin_type", None) != "foe"
             ):
                 return
 

--- a/backend/tests/test_guardian_shard.py
+++ b/backend/tests/test_guardian_shard.py
@@ -6,6 +6,7 @@ from autofighter.cards import apply_cards
 from autofighter.cards import award_card
 from autofighter.party import Party
 from autofighter.stats import BUS
+from plugins.foes._base import FoeBase
 from plugins.players._base import PlayerBase
 
 
@@ -27,7 +28,7 @@ def test_guardian_shard_applies_bonus_after_no_deaths():
     BUS.emit("battle_start", ally1)
     BUS.emit("battle_start", ally2)
     loop.run_until_complete(asyncio.sleep(0))
-    BUS.emit("battle_end", ally1)
+    BUS.emit("battle_end", FoeBase())
     loop.run_until_complete(asyncio.sleep(0))
 
     pre = ally1.mitigation
@@ -36,7 +37,7 @@ def test_guardian_shard_applies_bonus_after_no_deaths():
     loop.run_until_complete(asyncio.sleep(0))
     assert ally1.mitigation == pytest.approx(pre + 1)
 
-    BUS.emit("battle_end", ally1)
+    BUS.emit("battle_end", FoeBase())
     loop.run_until_complete(asyncio.sleep(0))
     assert ally1.mitigation == pytest.approx(pre)
 
@@ -54,7 +55,7 @@ def test_guardian_shard_no_bonus_after_death():
     BUS.emit("battle_start", ally2)
     BUS.emit("death", ally1)
     loop.run_until_complete(asyncio.sleep(0))
-    BUS.emit("battle_end", ally1)
+    BUS.emit("battle_end", FoeBase())
     loop.run_until_complete(asyncio.sleep(0))
 
     pre = ally1.mitigation


### PR DESCRIPTION
## Summary
- handle foe-targeted `battle_end` events in Guardian Shard
- test Guardian Shard bonus with foe-targeted events

## Testing
- `ruff check backend/plugins/cards/guardian_shard.py backend/tests/test_guardian_shard.py --fix`
- `./run-tests.sh` *(fails: AttributeError in wind ultimate tests)*

------
https://chatgpt.com/codex/tasks/task_b_68c0f35ce4dc832c86023788e5e21ed5