### PR TITLE
fix: ensure unique pull result keys

### DIFF
--- a/frontend/src/lib/components/PullResultsOverlay.svelte
+++ b/frontend/src/lib/components/PullResultsOverlay.svelte
@@ -89,16 +89,16 @@
 <div class="layout">
   {#if isBatch}
     <div class="stack" aria-hidden={stack.length === 0}>
-      {#each stack as r, i (r.id)}
-        <div class="card" style={`--i: ${i}`} out:send={{ key: r.id }}>
+      {#each stack as r, i (`${r.id}-${i}`)}
+        <div class="card" style={`--i: ${i}`} out:send={{ key: `${r.id}-${i}` }}>
           <CurioChoice entry={r} disabled={true} />
         </div>
       {/each}
     </div>
   {/if}
   <div class="choices">
-    {#each visible as r (r.id)}
-      <div class="card" in:receive={{ key: r.id }}>
+    {#each visible as r, i (`${r.id}-${i}`)}
+      <div class="card" in:receive={{ key: `${r.id}-${i}` }}>
         <CurioChoice entry={r} disabled={true} />
       </div>
     {/each}


### PR DESCRIPTION
## Summary
- ensure pull results overlay uses composite keys for each blocks and crossfade transitions

## Testing
- `bun run lint`
- `bun test tests/pullresultsoverlay.test.js`
- `./run-tests.sh` *(fails: ModuleNotFoundError: No module named 'autofighter.events')*

------
https://chatgpt.com/codex/tasks/task_b_68c137df5ce0832c80376ee52688df2b