### PR TITLE
fix: avoid unnecessary jellyfish resummon

### DIFF
--- a/backend/plugins/passives/becca_menagerie_bond.py
+++ b/backend/plugins/passives/becca_menagerie_bond.py
@@ -157,11 +157,10 @@ class BeccaMenagerieBond:
         current_summons = SummonManager.get_summons(target_id)
         jellyfish_summons = [s for s in current_summons if s.summon_source == self.id]
 
-        # If we have viable jellyfish and we're not changing type, skip summoning
-        if (not decision['should_resummon'] and
-            jellyfish_type == self._last_summon.get(entity_id) and
-            jellyfish_summons):
-            return False
+        # If a healthy jellyfish exists and no type change is requested, skip summoning
+        if jellyfish_summons and not decision["should_resummon"]:
+            if jellyfish_type is None or jellyfish_type == self._last_summon.get(entity_id):
+                return False
 
         # Pay HP cost using proper damage system
         target.hp -= hp_cost


### PR DESCRIPTION
## Summary
- prevent summoning a new jellyfish when one is already healthy and no type change is specified

## Testing
- `ruff check . --fix`
- `./run-tests.sh` *(fails: backend tests/test_app.py, backend tests/test_app_without_llm_deps.py, backend tests/test_character_editor.py, backend tests/test_damage_type_persistence.py, backend tests/test_gacha.py, backend tests/test_new_upgrade_system.py, backend tests/test_players_user.py)*

------
https://chatgpt.com/codex/tasks/task_b_68c14f6a3898832ca6b22b25bb804139