### PR TITLE
Ensure battle resolves report ended flag

### DIFF
--- a/backend/autofighter/rooms/battle.py
+++ b/backend/autofighter/rooms/battle.py
@@ -28,8 +28,8 @@ from autofighter.summons.base import Summon
 from autofighter.summons.manager import SummonManager
 from plugins.damage_types import ALL_DAMAGE_TYPES
 
-from ..party import Party
 from ..action_queue import ActionQueue
+from ..party import Party
 from ..passives import PassiveRegistry
 from ..stats import BUS
 from ..stats import Stats
@@ -1097,6 +1097,7 @@ class BattleRoom(Room):
             "enrage": {"active": enrage_active, "stacks": enrage_stacks, "turns": enrage_stacks},
             "rdr": party.rdr,
             "action_queue": _queue_snapshot(),
+            "ended": True,
         }
 
 

--- a/backend/tests/test_battle_end_on_all_foes_dead.py
+++ b/backend/tests/test_battle_end_on_all_foes_dead.py
@@ -1,0 +1,20 @@
+import pytest
+
+from autofighter.mapgen import MapNode
+from autofighter.party import Party
+from autofighter.rooms.battle import BattleRoom
+from autofighter.stats import Stats
+from plugins.players.player import Player
+
+
+@pytest.mark.asyncio
+async def test_battle_end_on_all_foes_dead():
+    player = Player()
+    party = Party(members=[player])
+    node = MapNode(0, "battle-normal", 1, 0, 1, 0)
+    room = BattleRoom(node=node)
+    foe = Stats()
+    foe.id = "dummy"
+    foe.hp = 1
+    result = await room.resolve(party, {}, foe=foe)
+    assert result["ended"] is True


### PR DESCRIPTION
## Summary
- include `ended` flag in `BattleRoom.resolve` victory snapshots
- test battle end when all foes are defeated

## Testing
- `uv tool run ruff check backend --fix`
- `PYTHONPATH=. uv run pytest tests/test_battle_end_on_all_foes_dead.py -q`
- `./run-tests.sh` *(fails: tests/assets.test.js, tests/battlepolling.test.js, tests/floor-transition.test.js, tests/pullsmenu.test.js; timed out: backend tests/test_app.py, backend tests/test_app_without_llm_deps.py, backend tests/test_character_editor.py, backend tests/test_damage_by_action_tracking.py, backend tests/test_damage_type_persistence.py, backend tests/test_gacha.py, backend tests/test_new_upgrade_system.py, backend tests/test_players_user.py)*

------
https://chatgpt.com/codex/tasks/task_b_68c47f0449cc832c9bb85ab81507dfe9