### PR TITLE
[TASK] Harden post-battle polling

### DIFF
--- a/frontend/.codex/implementation/battle-polling.md
+++ b/frontend/.codex/implementation/battle-polling.md
@@ -18,18 +18,17 @@ Snapshots reporting `result: 'defeat'` are treated as complete even if an
 `ended` flag is missing. The poller stops immediately and the defeat overlay
 is shown.
 
-Network failures now cause `handleRunEnd` when the backend reports the run has
-ended. `pollBattle` watches for thrown errors whose message contains
-"run ended" or whose status code is `404` and stops polling without queuing
-another cycle. This prevents repeated error overlays once a run is gone.
+Unexpected network errors are logged and retried. `handleRunEnd()` now fires
+only when `pollBattle` or `pollState` receive an error with a `404` status or a
+message containing `"run ended"`; other errors allow the poll to continue.
+`handleLootAcknowledge` and `handleNextRoom` call `stopBattlePoll()` before
+acknowledging loot to prevent lingering timers from racing ahead and flagging
+the run as ended.
 
-The general `pollState` routine uses the same detection. Errors mentioning
-"run ended" or returning a 404 now call `handleRunEnd()` and avoid scheduling
-another poll. All pollers (`pollState`, `pollBattle`, and `pollUIState`) also
-check the overlay flags and refrain from starting or rescheduling while either
-overlay is active. Additionally, UI state polling no longer reschedules itself
-when `uiState.mode === 'menu'` to reduce network traffic while in the main
-menu.
+All pollers (`pollState`, `pollBattle`, and `pollUIState`) also check the
+overlay flags and refrain from starting or rescheduling while either overlay is
+active. Additionally, UI state polling no longer reschedules itself when
+`uiState.mode === 'menu'` to reduce network traffic while in the main menu.
 
 Additionally, ending a run from Settings now immediately sets a global
 `window.afHaltSync = true` flag and clears timers to prevent any further

--- a/frontend/.codex/implementation/reward-overlay.md
+++ b/frontend/.codex/implementation/reward-overlay.md
@@ -8,3 +8,7 @@ Assets are resolved by star folder and id through `rewardLoader.js`.
 Ambient effects from `EnrageIndicator.svelte` continue to render while the
 rewards overlay is shown and fade out gracefully, so the transition from
 combat to rewards remains smooth.
+
+`handleLootAcknowledge()` now stops any active battle polling timers before
+calling the backend so lingering snapshot requests cannot mark the run as ended
+mid‑acknowledgement.


### PR DESCRIPTION
## Summary
- prevent snapshot polling errors from ending runs unless status 404 or message says "run ended"
- cancel battle polling before loot acknowledgement to avoid run-end races
- document updated polling and reward handling behavior
- remove completed post-battle polling task file

## Testing
- `uv venv`
- `cd backend && uv sync`
- `cd frontend && bun install`
- `bun run lint`
- `bun test battlepolling.test.js statepolling.test.js`
- `ruff check . --fix`
- `./run-tests.sh` *(fails: ModuleNotFoundError: No module named 'llms', among many other failures)*

------
https://chatgpt.com/codex/tasks/task_b_68c4d7a40400832c9b9b6f28caa090cd