### PR TITLE
[FIX] avoid circular import in Generic damage type

### DIFF
--- a/backend/autofighter/effects.py
+++ b/backend/autofighter/effects.py
@@ -7,7 +7,7 @@ from typing import Union
 
 from rich.console import Console
 
-from autofighter.stats import StatEffect
+from autofighter.stat_effect import StatEffect
 from autofighter.stats import Stats
 
 # Diminishing returns configuration for buff scaling

--- a/backend/autofighter/stat_effect.py
+++ b/backend/autofighter/stat_effect.py
@@ -1,0 +1,21 @@
+from dataclasses import dataclass
+from typing import Dict
+from typing import Union
+
+
+@dataclass
+class StatEffect:
+    """Represents a temporary effect that modifies stats."""
+    name: str
+    stat_modifiers: Dict[str, Union[int, float]]
+    duration: int = -1  # -1 for permanent effects (cards/relics), >0 for temporary
+    source: str = "unknown"  # source identifier (card name, relic name, etc.)
+
+    def is_expired(self) -> bool:
+        """Check if this effect has expired."""
+        return self.duration == 0
+
+    def tick(self) -> None:
+        """Reduce duration by 1 if it's a temporary effect."""
+        if self.duration > 0:
+            self.duration -= 1

--- a/backend/autofighter/stats.py
+++ b/backend/autofighter/stats.py
@@ -4,10 +4,10 @@ from dataclasses import field
 import importlib
 import logging
 import random
-from typing import Dict
 from typing import Optional
 from typing import Union
 
+from autofighter.stat_effect import StatEffect
 from plugins.damage_types._base import DamageTypeBase
 from plugins.damage_types.generic import Generic
 from plugins.event_bus import EventBus
@@ -21,24 +21,6 @@ _BATTLE_ACTIVE: bool = False
 
 # Starting value for action gauges.
 GAUGE_START: int = 10_000
-
-
-@dataclass
-class StatEffect:
-    """Represents a temporary effect that modifies stats."""
-    name: str
-    stat_modifiers: Dict[str, Union[int, float]]  # stat_name -> modifier value
-    duration: int = -1  # -1 for permanent effects (cards/relics), >0 for temporary
-    source: str = "unknown"  # source identifier (card name, relic name, etc.)
-
-    def is_expired(self) -> bool:
-        """Check if this effect has expired."""
-        return self.duration == 0
-
-    def tick(self) -> None:
-        """Reduce duration by 1 if it's a temporary effect."""
-        if self.duration > 0:
-            self.duration -= 1
 
 
 class _PassiveList(list):

--- a/backend/autofighter/summons/base.py
+++ b/backend/autofighter/summons/base.py
@@ -21,7 +21,7 @@ from plugins.damage_types._base import DamageTypeBase
 if TYPE_CHECKING:
     from autofighter.effects import HealingOverTime
     from autofighter.effects import StatModifier
-    from autofighter.stats import StatEffect
+    from autofighter.stat_effect import StatEffect
 
 log = logging.getLogger(__name__)
 
@@ -216,7 +216,7 @@ class Summon(Stats):
     @classmethod
     def _scale_stat_effect(cls, effect: "StatEffect", multiplier: float) -> "StatEffect":
         """Create a scaled copy of a StatEffect."""
-        from autofighter.stats import StatEffect
+        from autofighter.stat_effect import StatEffect
 
         scaled_modifiers = {}
         for stat_name, value in effect.stat_modifiers.items():

--- a/backend/plugins/cards/guardian_shard.py
+++ b/backend/plugins/cards/guardian_shard.py
@@ -1,8 +1,8 @@
 from dataclasses import dataclass
 from dataclasses import field
 
+from autofighter.stat_effect import StatEffect
 from autofighter.stats import BUS
-from autofighter.stats import StatEffect
 from plugins.cards._base import CardBase
 
 

--- a/backend/plugins/damage_types/generic.py
+++ b/backend/plugins/damage_types/generic.py
@@ -3,7 +3,6 @@ from dataclasses import dataclass
 
 from autofighter.passives import PassiveRegistry
 from plugins.damage_types._base import DamageTypeBase
-from plugins.passives.luna_lunar_reservoir import LunaLunarReservoir
 
 
 @dataclass
@@ -22,7 +21,9 @@ class Generic(DamageTypeBase):
         if not getattr(actor, "use_ultimate", lambda: False)():
             return False
 
+
         from autofighter.stats import BUS  # Import here to avoid circular imports
+        from plugins.passives.luna_lunar_reservoir import LunaLunarReservoir as _LLR_old
 
         registry = PassiveRegistry()
         target_pool = (
@@ -59,6 +60,10 @@ class Generic(DamageTypeBase):
                 foes=enemies,
             )
             await asyncio.sleep(0.002)
+        from plugins.passives.luna_lunar_reservoir import LunaLunarReservoir
+
+        if LunaLunarReservoir is not _LLR_old:
+            _LLR_old.add_charge(actor, amount=64)
         LunaLunarReservoir.add_charge(actor, amount=64)
         return True
 

--- a/backend/plugins/dots/abyssal_weakness.py
+++ b/backend/plugins/dots/abyssal_weakness.py
@@ -1,5 +1,5 @@
 from autofighter.effects import DamageOverTime
-from autofighter.stats import StatEffect
+from autofighter.stat_effect import StatEffect
 
 
 class AbyssalWeakness(DamageOverTime):

--- a/backend/plugins/foes/_base.py
+++ b/backend/plugins/foes/_base.py
@@ -7,8 +7,8 @@ from dataclasses import fields
 import logging
 
 from autofighter.character import CharacterType
+from autofighter.stat_effect import StatEffect
 from autofighter.stats import BUS
-from autofighter.stats import StatEffect
 from autofighter.stats import Stats
 from plugins.damage_types import random_damage_type
 from plugins.damage_types._base import DamageTypeBase

--- a/backend/plugins/passives/advanced_combat_synergy.py
+++ b/backend/plugins/passives/advanced_combat_synergy.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from typing import ClassVar
 
-from autofighter.stats import StatEffect
+from autofighter.stat_effect import StatEffect
 
 
 @dataclass

--- a/backend/plugins/passives/ally_overload.py
+++ b/backend/plugins/passives/ally_overload.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING
 from typing import Callable
 from typing import ClassVar
 
-from autofighter.stats import StatEffect
+from autofighter.stat_effect import StatEffect
 
 if TYPE_CHECKING:
     from autofighter.stats import Stats

--- a/backend/plugins/passives/attack_up.py
+++ b/backend/plugins/passives/attack_up.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 
-from autofighter.stats import StatEffect
+from autofighter.stat_effect import StatEffect
 
 
 @dataclass

--- a/backend/plugins/passives/becca_menagerie_bond.py
+++ b/backend/plugins/passives/becca_menagerie_bond.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 from typing import ClassVar
 
-from autofighter.stats import StatEffect
+from autofighter.stat_effect import StatEffect
 from autofighter.summons.manager import SummonManager
 from plugins.damage_types import load_damage_type
 

--- a/backend/plugins/passives/bubbles_bubble_burst.py
+++ b/backend/plugins/passives/bubbles_bubble_burst.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING
 from typing import ClassVar
 
 from autofighter.effects import EffectManager
-from autofighter.stats import StatEffect
+from autofighter.stat_effect import StatEffect
 from plugins.damage_types import ALL_DAMAGE_TYPES
 from plugins.damage_types import load_damage_type
 

--- a/backend/plugins/passives/carly_guardians_aegis.py
+++ b/backend/plugins/passives/carly_guardians_aegis.py
@@ -4,7 +4,7 @@ from typing import ClassVar
 from typing import Optional
 from weakref import WeakSet
 
-from autofighter.stats import StatEffect
+from autofighter.stat_effect import StatEffect
 
 if TYPE_CHECKING:
     from autofighter.stats import Stats

--- a/backend/plugins/passives/graygray_counter_maestro.py
+++ b/backend/plugins/passives/graygray_counter_maestro.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING
 from typing import ClassVar
 from typing import Optional
 
-from autofighter.stats import StatEffect
+from autofighter.stat_effect import StatEffect
 
 if TYPE_CHECKING:
     from autofighter.stats import Stats

--- a/backend/plugins/passives/hilander_critical_ferment.py
+++ b/backend/plugins/passives/hilander_critical_ferment.py
@@ -5,8 +5,8 @@ from typing import ClassVar
 from weakref import WeakKeyDictionary
 from weakref import ref
 
+from autofighter.stat_effect import StatEffect
 from autofighter.stats import BUS
-from autofighter.stats import StatEffect
 from plugins.effects.aftertaste import Aftertaste
 from plugins.relics._base import safe_async_task
 

--- a/backend/plugins/passives/ixia_tiny_titan.py
+++ b/backend/plugins/passives/ixia_tiny_titan.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 from typing import ClassVar
 
-from autofighter.stats import StatEffect
+from autofighter.stat_effect import StatEffect
 
 if TYPE_CHECKING:
     from autofighter.stats import Stats

--- a/backend/plugins/passives/kboshi_flux_cycle.py
+++ b/backend/plugins/passives/kboshi_flux_cycle.py
@@ -3,7 +3,7 @@ import random
 from typing import TYPE_CHECKING
 from typing import ClassVar
 
-from autofighter.stats import StatEffect
+from autofighter.stat_effect import StatEffect
 from plugins.damage_types.dark import Dark
 from plugins.damage_types.fire import Fire
 from plugins.damage_types.ice import Ice

--- a/backend/plugins/passives/lady_darkness_eclipsing_veil.py
+++ b/backend/plugins/passives/lady_darkness_eclipsing_veil.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 from typing import ClassVar
 
-from autofighter.stats import StatEffect
+from autofighter.stat_effect import StatEffect
 
 if TYPE_CHECKING:
     from autofighter.stats import Stats

--- a/backend/plugins/passives/lady_echo_resonant_static.py
+++ b/backend/plugins/passives/lady_echo_resonant_static.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING
 from typing import ClassVar
 from typing import Optional
 
-from autofighter.stats import StatEffect
+from autofighter.stat_effect import StatEffect
 
 if TYPE_CHECKING:
     from autofighter.stats import Stats

--- a/backend/plugins/passives/lady_fire_and_ice_duality_engine.py
+++ b/backend/plugins/passives/lady_fire_and_ice_duality_engine.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING
 from typing import ClassVar
 from typing import Iterable
 
-from autofighter.stats import StatEffect
+from autofighter.stat_effect import StatEffect
 
 if TYPE_CHECKING:
     from autofighter.stats import Stats

--- a/backend/plugins/passives/lady_light_radiant_aegis.py
+++ b/backend/plugins/passives/lady_light_radiant_aegis.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 from typing import ClassVar
 
-from autofighter.stats import StatEffect
+from autofighter.stat_effect import StatEffect
 
 if TYPE_CHECKING:
     from autofighter.stats import Stats

--- a/backend/plugins/passives/lady_of_fire_infernal_momentum.py
+++ b/backend/plugins/passives/lady_of_fire_infernal_momentum.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 from typing import Optional
 
-from autofighter.stats import StatEffect
+from autofighter.stat_effect import StatEffect
 
 if TYPE_CHECKING:
     from autofighter.stats import Stats

--- a/backend/plugins/passives/luna_lunar_reservoir.py
+++ b/backend/plugins/passives/luna_lunar_reservoir.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 from typing import ClassVar
 
-from autofighter.stats import StatEffect
+from autofighter.stat_effect import StatEffect
 
 if TYPE_CHECKING:
     from autofighter.stats import Stats

--- a/backend/plugins/passives/mezzy_gluttonous_bulwark.py
+++ b/backend/plugins/passives/mezzy_gluttonous_bulwark.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 from typing import ClassVar
 
-from autofighter.stats import StatEffect
+from autofighter.stat_effect import StatEffect
 
 if TYPE_CHECKING:
     from autofighter.stats import Stats

--- a/backend/plugins/passives/mimic_player_copy.py
+++ b/backend/plugins/passives/mimic_player_copy.py
@@ -2,8 +2,8 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 from typing import ClassVar
 
+from autofighter.stat_effect import StatEffect
 from autofighter.stats import BUS
-from autofighter.stats import StatEffect
 
 if TYPE_CHECKING:
     from autofighter.stats import Stats

--- a/backend/plugins/passives/player_level_up_bonus.py
+++ b/backend/plugins/passives/player_level_up_bonus.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from autofighter.stats import StatEffect
+from autofighter.stat_effect import StatEffect
 
 if TYPE_CHECKING:
     from autofighter.stats import Stats

--- a/backend/tests/test_base_runtime_stats.py
+++ b/backend/tests/test_base_runtime_stats.py
@@ -1,6 +1,6 @@
 """Test the new base stats vs runtime stats system."""
 
-from autofighter.stats import StatEffect
+from autofighter.stat_effect import StatEffect
 from autofighter.stats import Stats
 
 

--- a/backend/tests/test_passive_stacks.py
+++ b/backend/tests/test_passive_stacks.py
@@ -126,7 +126,7 @@ async def test_bubbles_burst_stack_display():
     assert burst_passive["max_stacks"] == 20
 
     # Simulate bubble bursts by manually adding attack buff effects
-    from autofighter.stats import StatEffect
+    from autofighter.stat_effect import StatEffect
 
     # Add a couple of bubble burst attack buffs
     for i in range(3):

--- a/backend/tests/test_stats_integration.py
+++ b/backend/tests/test_stats_integration.py
@@ -10,7 +10,7 @@ import sys
 sys.path.append('.')
 
 from autofighter.effects import create_stat_buff
-from autofighter.stats import StatEffect
+from autofighter.stat_effect import StatEffect
 from autofighter.stats import Stats
 from plugins.players._base import PlayerBase
 

--- a/backend/tests/test_stats_passives.py
+++ b/backend/tests/test_stats_passives.py
@@ -3,7 +3,7 @@ import random
 import pytest
 
 from autofighter.passives import PassiveRegistry
-from autofighter.stats import StatEffect
+from autofighter.stat_effect import StatEffect
 from autofighter.stats import Stats
 
 

--- a/backend/tests/test_summons_system.py
+++ b/backend/tests/test_summons_system.py
@@ -434,7 +434,7 @@ async def test_summon_inheritance_with_effects(monkeypatch):
     summoner._base_vitality = 1.5
 
     # Add a temporary effect that boosts stats
-    from autofighter.stats import StatEffect
+    from autofighter.stat_effect import StatEffect
     boost_effect = StatEffect(
         name="test_boost",
         stat_modifiers={
@@ -484,7 +484,7 @@ async def test_summon_inherits_beneficial_effects(monkeypatch):
     summoner._base_atk = 200
 
     # Add beneficial StatEffect (buff)
-    from autofighter.stats import StatEffect
+    from autofighter.stat_effect import StatEffect
     buff_effect = StatEffect(
         name="test_buff",
         stat_modifiers={
@@ -581,7 +581,7 @@ async def test_summon_does_not_inherit_harmful_effects(monkeypatch):
     summoner.id = "test_summoner"
 
     # Add harmful StatEffect (debuff)
-    from autofighter.stats import StatEffect
+    from autofighter.stat_effect import StatEffect
     debuff_effect = StatEffect(
         name="test_debuff",
         stat_modifiers={
@@ -654,7 +654,7 @@ async def test_summon_inherits_mixed_effects_correctly(monkeypatch):
     summoner.id = "test_summoner"
 
     # Add mixed StatEffect (some beneficial, some harmful modifiers)
-    from autofighter.stats import StatEffect
+    from autofighter.stat_effect import StatEffect
     mixed_effect = StatEffect(
         name="mixed_effect",
         stat_modifiers={


### PR DESCRIPTION
## Summary
- relocate LunaLunarReservoir import into `Generic.ultimate` to prevent circular import and handle plugin reloads
- extract `StatEffect` dataclass into `autofighter.stat_effect` and update all references

## Testing
- `rg "autofighter.stats import StatEffect" -n`
- `uv run pytest -q` *(fails: 116 failed, 151 passed, 1 skipped, 1 error)*

------
https://chatgpt.com/codex/tasks/task_b_68c4fe77e138832c8c874fe2fdb19740