### PR TITLE
[FIX] ensure thread-safe scheduling for vitality cards

### DIFF
--- a/backend/plugins/cards/enduring_charm.py
+++ b/backend/plugins/cards/enduring_charm.py
@@ -1,5 +1,7 @@
+import asyncio
 from dataclasses import dataclass
 from dataclasses import field
+import logging
 
 from autofighter.effects import EffectManager
 from autofighter.effects import create_stat_buff
@@ -18,54 +20,52 @@ class EnduringCharm(CardBase):
     async def apply(self, party) -> None:  # type: ignore[override]
         await super().apply(party)
 
-        # Track which members have the vitality boost active to avoid stacking
+        loop = asyncio.get_running_loop()
+
         active_boosts = set()
 
-        def _check_low_hp():
+        def _check_low_hp() -> None:
             for member in party.members:
                 member_id = id(member)
-                current_hp = getattr(member, 'hp', 0)
-                max_hp = getattr(member, 'max_hp', 1)
+                current_hp = getattr(member, "hp", 0)
+                max_hp = getattr(member, "max_hp", 1)
 
-                # Check if below 30% HP and not already has boost
                 if current_hp / max_hp < 0.30 and member_id not in active_boosts:
-                    # Add to active set
                     active_boosts.add(member_id)
 
-                    # Apply +3% vitality for 2 turns
-                    effect_manager = getattr(member, 'effect_manager', None)
+                    effect_manager = getattr(member, "effect_manager", None)
                     if effect_manager is None:
                         effect_manager = EffectManager(member)
                         member.effect_manager = effect_manager
 
-                    # Create vitality buff
                     vit_mod = create_stat_buff(
                         member,
                         name=f"{self.id}_low_hp_vit",
                         turns=2,
-                        vitality_mult=1.03  # +3% vitality
+                        vitality_mult=1.03,
                     )
                     effect_manager.add_modifier(vit_mod)
 
-                    import logging
                     log = logging.getLogger(__name__)
-                    log.debug("Enduring Charm activated vitality boost for %s: +3% vitality for 2 turns", member.id)
-                    BUS.emit("card_effect", self.id, member, "vitality_boost", 3, {
-                        "vitality_boost": 3,
-                        "duration": 2,
-                        "trigger_threshold": 0.30
-                    })
+                    log.debug(
+                        "Enduring Charm activated vitality boost for %s: +3% vitality for 2 turns",
+                        member.id,
+                    )
+                    BUS.emit(
+                        "card_effect",
+                        self.id,
+                        member,
+                        "vitality_boost",
+                        3,
+                        {"vitality_boost": 3, "duration": 2, "trigger_threshold": 0.30},
+                    )
 
-                    # Remove from active set after some time (simplified)
-                    def _remove_boost():
+                    def _remove_boost() -> None:
                         if member_id in active_boosts:
                             active_boosts.remove(member_id)
 
-                    # Schedule removal (in real implementation, this would be handled by effect expiration)
-                    import asyncio
-                    asyncio.get_event_loop().call_later(20, _remove_boost)  # Remove after 20 seconds
+                    loop.call_soon_threadsafe(lambda: loop.call_later(20, _remove_boost))
 
-        # Check HP at the start of each turn and after damage taken
         BUS.subscribe("turn_start", _check_low_hp)
 
         def _on_damage_taken(target, attacker, damage):

--- a/backend/plugins/cards/vital_core.py
+++ b/backend/plugins/cards/vital_core.py
@@ -1,5 +1,7 @@
+import asyncio
 from dataclasses import dataclass
 from dataclasses import field
+import logging
 
 from autofighter.effects import EffectManager
 from autofighter.effects import create_stat_buff
@@ -18,53 +20,61 @@ class VitalCore(CardBase):
     async def apply(self, party) -> None:  # type: ignore[override]
         await super().apply(party)
 
+        loop = asyncio.get_running_loop()
+
         # Track which members have the vitality boost active to avoid stacking
         active_boosts = set()
 
-        def _check_low_hp():
+        def _check_low_hp() -> None:
             for member in party.members:
                 member_id = id(member)
-                current_hp = getattr(member, 'hp', 0)
-                max_hp = getattr(member, 'max_hp', 1)
+                current_hp = getattr(member, "hp", 0)
+                max_hp = getattr(member, "max_hp", 1)
 
-                # Check if below 30% HP and not already has boost
                 if current_hp / max_hp < 0.30 and member_id not in active_boosts:
-                    # Add to active set
                     active_boosts.add(member_id)
 
-                    # Apply +3% vitality for 2 turns
-                    effect_manager = getattr(member, 'effect_manager', None)
+                    effect_manager = getattr(member, "effect_manager", None)
                     if effect_manager is None:
                         effect_manager = EffectManager(member)
                         member.effect_manager = effect_manager
 
-                    # Create vitality buff
                     vit_mod = create_stat_buff(
                         member,
                         name=f"{self.id}_low_hp_vit",
                         turns=2,
-                        vitality_mult=1.03  # +3% vitality
+                        vitality_mult=1.03,
                     )
                     effect_manager.add_modifier(vit_mod)
 
-                    import logging
                     log = logging.getLogger(__name__)
-                    log.debug("Vital Core activated vitality boost for %s: +3% vitality for 2 turns", member.id)
-                    BUS.emit("card_effect", self.id, member, "vitality_boost", 3, {
-                        "vitality_boost": 3,
-                        "duration": 2,
-                        "trigger_threshold": 0.30
-                    })
+                    log.debug(
+                        "Vital Core activated vitality boost for %s: +3% vitality for 2 turns",
+                        member.id,
+                    )
+                    BUS.emit(
+                        "card_effect",
+                        self.id,
+                        member,
+                        "vitality_boost",
+                        3,
+                        {"vitality_boost": 3, "duration": 2, "trigger_threshold": 0.30},
+                    )
 
-                    # Remove from active set after some time (simplified)
-                    def _remove_boost():
+                    def _remove_boost() -> None:
                         if member_id in active_boosts:
                             active_boosts.remove(member_id)
 
-                    # Schedule removal (in real implementation, this would be handled by effect expiration)
-                    import asyncio
-                    asyncio.get_event_loop().call_later(20, _remove_boost)  # Remove after 20 seconds
+                    loop.call_soon_threadsafe(lambda: loop.call_later(20, _remove_boost))
 
-        # Check HP at the start of each turn and after damage taken
+        def _on_damage_taken(target, attacker, damage):
+            _check_low_hp()
+
+        def _cleanup(*_: object) -> None:
+            BUS.unsubscribe("turn_start", _check_low_hp)
+            BUS.unsubscribe("damage_taken", _on_damage_taken)
+            BUS.unsubscribe("battle_end", _cleanup)
+
         BUS.subscribe("turn_start", _check_low_hp)
-        BUS.subscribe("damage_taken", lambda target, attacker, damage: _check_low_hp())
+        BUS.subscribe("damage_taken", _on_damage_taken)
+        BUS.subscribe("battle_end", _cleanup)


### PR DESCRIPTION
## Summary
- use the running loop to schedule thread-safe timers in Vital Core and Enduring Charm
- add battle-end cleanup for Vital Core low HP checks

## Testing
- `ruff check . --fix`
- `./run-tests.sh` *(fails: backend tests/test_app.py, backend tests/test_app_without_llm_deps.py, backend tests/test_character_editor.py, backend tests/test_damage_by_action_tracking.py, backend tests/test_damage_type_persistence.py, backend tests/test_gacha.py, backend tests/test_new_upgrade_system.py, backend tests/test_players_user.py, frontend tests/assets.test.js, frontend tests/floor-transition.test.js, frontend tests/pullsmenu.test.js)*

------
https://chatgpt.com/codex/tasks/task_b_68c50ad50f64832cb172266fa7658f00