### PR TITLE
[ENH] Delay battle start and highlight active action

### DIFF
--- a/backend/autofighter/rooms/battle.py
+++ b/backend/autofighter/rooms/battle.py
@@ -394,6 +394,10 @@ class BattleRoom(Room):
                     "active_id": None,
                 }
             )
+            try:
+                await asyncio.sleep(3)
+            except Exception:
+                pass
         # Helper to pace actions: dynamic pacing based on combatant count
         async def _pace(start_time: float) -> None:
             try:

--- a/frontend/src/lib/battle/ActionQueue.svelte
+++ b/frontend/src/lib/battle/ActionQueue.svelte
@@ -87,7 +87,20 @@
     border: 2px solid var(--element-color);
     border-radius: 8px;
     overflow: hidden;
-    }
+  }
+  .entry.active {
+    border-width: 4px;
+    box-shadow: 0 0 8px 2px color-mix(in oklab, var(--element-color) 80%, white);
+  }
+  .entry.active::before {
+    content: '';
+    position: absolute;
+    left: -0.75rem;
+    top: 50%;
+    transform: translateY(-50%);
+    border: 8px solid transparent;
+    border-right-color: var(--element-color);
+  }
   .entry.bonus {
     opacity: 0.6;
   }

--- a/frontend/tests/actionqueue.test.js
+++ b/frontend/tests/actionqueue.test.js
@@ -9,6 +9,7 @@ import { join } from 'path';
       expect(content).toContain('showActionValues');
       expect(content).toContain('animate:flip');
       expect(content).toContain('class:bonus');
+      expect(content).toContain('.entry.active');
     });
   });
 


### PR DESCRIPTION
## Summary
- pause three seconds after initial battle snapshot
- add active fighter indicator with glow/arrow in action queue
- test for active indicator in ActionQueue component

## Testing
- `./run-tests.sh` *(failed: backend tests/test_app.py timed out, backend tests/test_app_without_llm_deps.py timed out, backend tests/test_character_editor.py timed out, backend tests/test_damage_by_action_tracking.py timed out, backend tests/test_damage_type_persistence.py timed out, backend tests/test_gacha.py timed out, backend tests/test_new_upgrade_system.py timed out, backend tests/test_players_user.py timed out; frontend tests/assets.test.js failed, frontend tests/floor-transition.test.js failed, frontend tests/pullsmenu.test.js failed)*

------
https://chatgpt.com/codex/tasks/task_b_68c50af8e3e4832c97350907fead4034