### PR TITLE
Add cost damage helper for relic self-damage

### DIFF
--- a/backend/autofighter/stats.py
+++ b/backend/autofighter/stats.py
@@ -668,6 +668,22 @@ class Stats:
             BUS.emit_batched("damage_dealt", attacker, self, original_amount, "attack", None, None, action_name)
         return original_amount
 
+    async def apply_cost_damage(self, amount: int) -> int:
+        """Apply self-inflicted damage that ignores mitigation and shields."""
+        from autofighter.stats import is_battle_active  # local import for clarity
+
+        if not is_battle_active():
+            return 0
+        if getattr(self, "hp", 0) <= 0:
+            return 0
+        amount = max(int(amount), 0)
+        self.last_damage_taken = amount
+        self.damage_taken += amount
+        if amount > 0:
+            self.hp = max(self.hp - amount, 1)
+        BUS.emit_batched("damage_taken", self, None, amount)
+        return amount
+
     async def apply_healing(self, amount: int, healer: Optional["Stats"] = None, source_type: str = "heal", source_name: Optional[str] = None) -> int:
         def _ensure(obj: "Stats") -> DamageTypeBase:
             dt = getattr(obj, "damage_type", Generic())

--- a/backend/plugins/relics/greed_engine.py
+++ b/backend/plugins/relics/greed_engine.py
@@ -51,7 +51,7 @@ class GreedEngine(RelicBase):
                         "max_hp": member.max_hp
                     })
 
-                    safe_async_task(member.apply_damage(dmg))
+                    safe_async_task(member.apply_cost_damage(dmg))
 
             BUS.subscribe("gold_earned", _gold)
             BUS.subscribe("turn_start", _drain)

--- a/backend/plugins/relics/omega_core.py
+++ b/backend/plugins/relics/omega_core.py
@@ -82,7 +82,7 @@ class OmegaCore(RelicBase):
                     "delay": delay
                 })
 
-                safe_async_task(member.apply_damage(dmg))
+                safe_async_task(member.apply_cost_damage(dmg))
 
         def _battle_end(entity) -> None:
             from plugins.foes._base import FoeBase

--- a/backend/plugins/relics/rusty_buckle.py
+++ b/backend/plugins/relics/rusty_buckle.py
@@ -58,7 +58,7 @@ class RustyBuckle(RelicBase):
                     },
                 )
 
-                safe_async_task(entity.apply_damage(dmg, attacker=entity))
+                safe_async_task(entity.apply_cost_damage(dmg))
 
         def _damage(target, attacker, _original) -> None:
             if target not in party.members:

--- a/backend/tests/test_cost_damage.py
+++ b/backend/tests/test_cost_damage.py
@@ -1,0 +1,55 @@
+import pytest
+
+import autofighter.stats as stats
+from plugins.event_bus import EventBus
+
+
+@pytest.fixture
+def bus(monkeypatch):
+    bus = EventBus()
+    bus._prefer_async = False
+    monkeypatch.setattr(stats, "BUS", bus)
+    return bus
+
+
+@pytest.fixture(autouse=True)
+def battle_active():
+    stats.set_battle_active(True)
+    yield
+    stats.set_battle_active(False)
+
+
+@pytest.mark.asyncio
+async def test_cost_damage_ignores_defense_and_shields(bus):
+    s = stats.Stats()
+    s._base_defense = 100000
+    s.mitigation = 0.1
+    s.shields = 200
+    start_hp = s.hp
+    await s.apply_cost_damage(150)
+    assert s.hp == start_hp - 150
+    assert s.shields == 200
+    assert s.damage_taken == 150
+
+
+@pytest.mark.asyncio
+async def test_cost_damage_clamps_to_one_hp(bus):
+    s = stats.Stats()
+    s.hp = 50
+    await s.apply_cost_damage(1000)
+    assert s.hp == 1
+    assert s.damage_taken == 1000
+
+
+@pytest.mark.asyncio
+async def test_normal_attack_respects_defense_and_shields(bus):
+    s = stats.Stats()
+    s._base_defense = 100000
+    s.mitigation = 0.1
+    s.shields = 200
+    start_hp = s.hp
+    attacker = stats.Stats()
+    await s.apply_damage(150, attacker=attacker)
+    assert s.hp == start_hp
+    assert s.shields == 199
+    assert s.damage_taken == 1


### PR DESCRIPTION
## Summary
- add async `apply_cost_damage` to `Stats` that bypasses mitigation and shields while emitting damage events
- update Greed Engine, Omega Core, and Rusty Buckle relics to use cost damage helper
- cover cost damage behavior with new tests

## Testing
- `uv run ruff check backend/tests/test_cost_damage.py --fix`
- `./run-tests.sh` *(fails: e.g., `tests/test_passives.py::test_room_heal_event_and_enrage` assertion)*

------
https://chatgpt.com/codex/tasks/task_b_68c515001290832c951163443bd49ef2