### PR TITLE
[REFACTOR] modularize settings menu tabs

### DIFF
--- a/frontend/.codex/implementation/settings-menu.md
+++ b/frontend/.codex/implementation/settings-menu.md
@@ -1,7 +1,7 @@
 # Settings Menu
 
-The settings overlay now uses a tabbed layout with icon-only buttons
-for each category:
+The settings overlay uses a tabbed layout with icon-only buttons for
+each category:
 
 - **Audio**: `Volume2` icon.
 - **System**: `Cog` icon.
@@ -9,7 +9,17 @@ for each category:
   available.
 - **Gameplay**: `Gamepad` icon.
 
-`SettingsMenu.svelte` receives `backendFlavor` from the page and
+Each tab's content lives in its own component:
+
+- `AudioSettings.svelte`
+- `SystemSettings.svelte`
+- `LLMSettings.svelte`
+- `GameplaySettings.svelte`
+
+These components share grid and tooltip styling via
+`settings-shared.css`, while `SettingsMenu.svelte` handles tab
+selection, LRM configuration, and dispatches `save` and `endRun`
+events. `SettingsMenu.svelte` receives `backendFlavor` from the page and
 checks it for `"llm"` to decide whether the LLM tab should appear. When
 the flavor string omits `"llm"`, the component skips `getLrmConfig()`
 and hides the model selector and test button.

--- a/frontend/src/lib/components/AudioSettings.svelte
+++ b/frontend/src/lib/components/AudioSettings.svelte
@@ -1,0 +1,27 @@
+<script>
+  import { Volume2, Music, Mic } from 'lucide-svelte';
+  export let sfxVolume = 5;
+  export let musicVolume = 5;
+  export let voiceVolume = 5;
+  export let scheduleSave;
+</script>
+
+<div class="panel">
+  <div class="control" title="Adjust sound effect volume.">
+    <Volume2 />
+    <label>SFX Volume</label>
+    <input type="range" min="0" max="100" bind:value={sfxVolume} on:input={scheduleSave} />
+  </div>
+  <div class="control" title="Adjust background music volume.">
+    <Music />
+    <label>Music Volume</label>
+    <input type="range" min="0" max="100" bind:value={musicVolume} on:input={scheduleSave} />
+  </div>
+  <div class="control" title="Adjust voice volume.">
+    <Mic />
+    <label>Voice Volume</label>
+    <input type="range" min="0" max="100" bind:value={voiceVolume} on:input={scheduleSave} />
+  </div>
+</div>
+
+<style src="./settings-shared.css"></style>

--- a/frontend/src/lib/components/GameplaySettings.svelte
+++ b/frontend/src/lib/components/GameplaySettings.svelte
@@ -1,0 +1,25 @@
+<script>
+  import { Power } from 'lucide-svelte';
+  export let showActionValues = false;
+  export let scheduleSave;
+  export let handleEndRun;
+  export let endingRun = false;
+  export let endRunStatus = '';
+</script>
+
+<div class="panel">
+  <div class="control" title="Display numeric action values in the turn order.">
+    <label>Show Action Values</label>
+    <input type="checkbox" bind:checked={showActionValues} on:change={scheduleSave} />
+  </div>
+  <div class="control" title="End the current run.">
+    <Power />
+    <label>End Run</label>
+    <button on:click={handleEndRun} disabled={endingRun}>{endingRun ? 'Ending…' : 'End'}</button>
+    {#if endRunStatus}
+      <span class="status" data-testid="endrun-status">{endRunStatus}</span>
+    {/if}
+  </div>
+</div>
+
+<style src="./settings-shared.css"></style>

--- a/frontend/src/lib/components/LLMSettings.svelte
+++ b/frontend/src/lib/components/LLMSettings.svelte
@@ -1,0 +1,27 @@
+<script>
+  export let lrmModel = '';
+  export let lrmOptions = [];
+  export let handleModelChange;
+  export let handleTestModel;
+  export let testReply = '';
+</script>
+
+<div class="panel">
+  <div class="control" title="Select language reasoning model.">
+    <label>LRM Model</label>
+    <select bind:value={lrmModel} on:change={handleModelChange}>
+      {#each lrmOptions as opt}
+        <option value={opt}>{opt}</option>
+      {/each}
+    </select>
+  </div>
+  <div class="control" title="Send a sample prompt to the selected model.">
+    <label>Test Model</label>
+    <button on:click={handleTestModel}>Test</button>
+  </div>
+  {#if testReply}
+    <p class="status" data-testid="lrm-test-reply">{testReply}</p>
+  {/if}
+</div>
+
+<style src="./settings-shared.css"></style>

--- a/frontend/src/lib/components/SystemSettings.svelte
+++ b/frontend/src/lib/components/SystemSettings.svelte
@@ -1,0 +1,58 @@
+<script>
+  import { Trash2, Download, Upload } from 'lucide-svelte';
+  export let framerate = 60;
+  export let reducedMotion = false;
+  export let handleWipe;
+  export let wipeStatus = '';
+  export let handleBackup;
+  export let handleImport;
+  export let scheduleSave;
+  export let healthStatus = 'unknown';
+  export let healthPing = null;
+  export let refreshHealth;
+</script>
+
+<div class="panel">
+  <div class="control" title="Backend health and network latency.">
+    <label>Backend Health</label>
+    <span class="badge" data-status={healthStatus}>
+      {healthStatus === 'healthy' ? 'Healthy' : healthStatus === 'degraded' ? 'Degraded' : healthStatus === 'error' ? 'Error' : 'Unknown'}
+    </span>
+    {#if healthPing !== null}
+      <span class="ping">{Math.round(healthPing)}ms</span>
+    {/if}
+    <button on:click={() => refreshHealth(true)}>Refresh</button>
+  </div>
+  <div class="control" title="Limit server polling frequency.">
+    <label>Framerate</label>
+    <select bind:value={framerate} on:change={scheduleSave}>
+      <option value={30}>30</option>
+      <option value={60}>60</option>
+      <option value={120}>120</option>
+    </select>
+  </div>
+  <div class="control" title="Slow down battle animations.">
+    <label>Reduced Motion</label>
+    <input type="checkbox" bind:checked={reducedMotion} on:change={scheduleSave} />
+  </div>
+  <div class="control" title="Clear all save data.">
+    <Trash2 />
+    <label>Wipe Save Data</label>
+    <button on:click={handleWipe}>Wipe</button>
+  </div>
+  {#if wipeStatus}
+    <p class="status" data-testid="wipe-status">{wipeStatus}</p>
+  {/if}
+  <div class="control" title="Download encrypted backup of save data.">
+    <Download />
+    <label>Backup Save Data</label>
+    <button on:click={handleBackup}>Backup</button>
+  </div>
+  <div class="control" title="Import an encrypted save backup.">
+    <Upload />
+    <label>Import Save Data</label>
+    <input type="file" accept=".afsave" on:change={handleImport} />
+  </div>
+</div>
+
+<style src="./settings-shared.css"></style>

--- a/frontend/src/lib/components/settings-shared.css
+++ b/frontend/src/lib/components/settings-shared.css
@@ -1,0 +1,58 @@
+.panel {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.control {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.control[title] {
+  cursor: help;
+}
+
+label {
+  flex: 1;
+  font-size: 0.85rem;
+}
+
+input[type='range'] {
+  flex: 2;
+}
+
+select {
+  flex: 2;
+  background: #0a0a0a;
+  color: #fff;
+  border: 1px solid #fff;
+}
+
+button {
+  border: 2px solid #fff;
+  background: #0a0a0a;
+  color: #fff;
+  padding: 0.3rem 0.6rem;
+}
+
+.status {
+  margin: 0;
+  font-size: 0.8rem;
+}
+
+.badge {
+  border: 1px solid rgba(255,255,255,0.6);
+  padding: 0.1rem 0.4rem;
+  border-radius: 2px;
+  font-size: 0.75rem;
+}
+.badge[data-status='healthy'] { color: #00ff88; border-color: #00ff88; }
+.badge[data-status='degraded'] { color: #ffaa00; border-color: #ffaa00; }
+.badge[data-status='error'] { color: #ff4444; border-color: #ff4444; }
+
+.ping {
+  font-size: 0.75rem;
+  opacity: 0.9;
+}


### PR DESCRIPTION
## Summary
- split SettingsMenu into AudioSettings, SystemSettings, LLMSettings, and GameplaySettings components
- add shared styling module for settings panels
- document new settings components and structure

## Testing
- `bun run lint:fix`
- `uv tool run ruff check backend --fix`
- `./run-tests.sh` *(fails: llms.loader._IMPORT_ERROR missing, etc.)*

------
https://chatgpt.com/codex/tasks/task_b_68c5181c8850832cb6eaa0f2026ddf70