### PR TITLE
Trigger damage_taken passives for cost damage

### DIFF
--- a/backend/autofighter/stats.py
+++ b/backend/autofighter/stats.py
@@ -681,6 +681,13 @@ class Stats:
         self.damage_taken += amount
         if amount > 0:
             self.hp = max(self.hp - amount, 1)
+            try:
+                from autofighter.passives import PassiveRegistry
+
+                registry = PassiveRegistry()
+                await registry.trigger_damage_taken(self, None, amount)
+            except Exception as e:  # pragma: no cover - defensive
+                log.warning("Error triggering damage_taken passives: %s", e)
         BUS.emit_batched("damage_taken", self, None, amount)
         return amount
 

--- a/backend/tests/test_cost_damage.py
+++ b/backend/tests/test_cost_damage.py
@@ -1,5 +1,6 @@
 import pytest
 
+from autofighter.passives import PassiveRegistry
 import autofighter.stats as stats
 from plugins.event_bus import EventBus
 
@@ -53,3 +54,16 @@ async def test_normal_attack_respects_defense_and_shields(bus):
     assert s.hp == start_hp
     assert s.shields == 199
     assert s.damage_taken == 1
+
+
+@pytest.mark.asyncio
+async def test_cost_damage_triggers_damage_taken_passives(bus, monkeypatch):
+    s = stats.Stats()
+    called: dict[str, tuple] = {}
+
+    async def fake_trigger(self, target, attacker, amount):
+        called["args"] = (target, attacker, amount)
+
+    monkeypatch.setattr(PassiveRegistry, "trigger_damage_taken", fake_trigger)
+    await s.apply_cost_damage(42)
+    assert called["args"] == (s, None, 42)


### PR DESCRIPTION
## Summary
- trigger `PassiveRegistry.trigger_damage_taken` when applying cost damage so passives respond
- cover cost damage passive triggering with a new test

## Testing
- `uv run ruff check backend/autofighter/stats.py backend/tests/test_cost_damage.py --fix`
- `./run-tests.sh` *(fails: `tests/test_wind_ultimate_dot_transfer.py::test_wind_ultimate_transfers_from_foes`, `tests/test_wind_ultimate_dot_transfer.py::test_wind_foe_ultimate_transfers_from_allies`)*

------
https://chatgpt.com/codex/tasks/task_b_68c519f08b28832c91fa661fc8cd47ce