### PR TITLE
[FEAT] Revamp settings layout

### DIFF
--- a/.codex/instructions/options-menu.md
+++ b/.codex/instructions/options-menu.md
@@ -1,62 +1,65 @@
 # Options Menu
 
-The Options submenu lets players adjust audio levels, system behaviour, and gameplay automation. Controls appear under **Audio**, **System**, and **Gameplay** headings.
+The Options submenu lets players adjust audio levels, system behaviour, and gameplay automation. Controls appear under **Audio**, **System**, and **Gameplay** headings and use a two-column grid with labels and icons on the left and interactive controls on the right. Rows highlight on hover for clarity.
 
 ## Controls
 
 - **Sound Effects Volume**
-  - Slider adjusting sound effect levels.
+  - Ten-dot selector adjusting sound effect levels in 10% increments.
+  - Component: `DotSelector`
   - Lucide icon: `volume-2`
   - Label: `SFX Volume`
   - Tooltip: `Adjust sound effect volume.`
 
 - **Music Volume**
-  - Slider adjusting background music levels.
+  - Ten-dot selector adjusting background music levels.
+  - Component: `DotSelector`
   - Lucide icon: `music`
   - Label: `Music Volume`
   - Tooltip: `Adjust background music volume.`
 
 - **Voice Volume**
-  - Slider adjusting voice levels.
+  - Ten-dot selector adjusting voice levels.
+  - Component: `DotSelector`
   - Lucide icon: `mic`
   - Label: `Voice Volume`
   - Tooltip: `Adjust voice volume.`
 
+- **Backend Health**
+  - Badge shows backend status with latency ping.
+  - Lucide icon: `activity`
+  - Tooltip: `Backend health and network latency.`
+
 - **Framerate**
   - Select box limiting server polling frequency.
-  - Label: `Framerate`
+  - Lucide icon: `gauge`
   - Tooltip: `Limit server polling frequency.`
 - **Reduced Motion**
   - Toggle that slows animation effects for accessibility.
-  - Label: `Reduced Motion`
+  - Lucide icon: `move`
   - Tooltip: `Slow down battle animations.`
 - **Show Action Values**
   - Toggle that reveals numeric action values in the turn order UI.
-  - Label: `Show Action Values`
-  - Tooltip: `Display numeric action values in battle.`
+  - Tooltip component: `Tooltip` with text `Display numeric action values in the turn order.`
 
 - **Animation Speed**
   - Slider that scales the global `TURN_PACING` for all actions.
-  - Label: `Animation Speed`
   - Tooltip: `Adjust battle animation pacing.`
 
 - **Wipe Save Data**
   - Button that clears all save records after confirmation.
   - Lucide icon: `trash-2`
-  - Label: `Wipe Save Data`
   - Tooltip: `Clear all save data.`
   - Behavior: also clears all frontend client storage (localStorage, sessionStorage, IndexedDB), deletes CacheStorage entries, unregisters service workers, and then forces a full page reload so stale roster or party data cannot persist.
 
 - **Backup Save Data**
   - Button that downloads an encrypted snapshot of save tables.
   - Lucide icon: `download`
-  - Label: `Backup Save Data`
   - Tooltip: `Download encrypted save backup.`
 
 - **Import Save Data**
   - File picker that uploads an encrypted backup and restores it if valid.
   - Lucide icon: `upload`
-  - Label: `Import Save Data`
   - Tooltip: `Import encrypted save backup.`
 
 - **Autocraft**
@@ -68,11 +71,11 @@ The Options submenu lets players adjust audio levels, system behaviour, and game
 - **End Current Run**
   - Button that terminates the active run.
   - Lucide icon: `power`
-  - Label: `End Current Run`
-  - Tooltip: `End the current run.`
+  - Tooltip component: `Tooltip` with text `End the current run.`
 
 ## Guidelines
 
-- Each control must include its Lucide icon, visible label, and hover tooltip.
+- Each control uses the shared grid layout and hover transitions from `settings-shared.css`.
+- Controls must include Lucide icons where specified and accessible tooltips via `title` or `Tooltip` component.
 - Changes take effect immediately and should persist between sessions.
 - For turn order debugging, enable [Action Value Display](action-value-display.md).

--- a/frontend/.codex/implementation/settings-menu.md
+++ b/frontend/.codex/implementation/settings-menu.md
@@ -1,12 +1,10 @@
 # Settings Menu
 
-The settings overlay uses a tabbed layout with icon-only buttons for
-each category:
+The settings overlay uses a tabbed layout with icon-only buttons for each category:
 
 - **Audio**: `Volume2` icon.
 - **System**: `Cog` icon.
-- **LLM**: `Brain` icon, shown only when language model controls are
-  available.
+- **LLM**: `Brain` icon, shown only when language model controls are available.
 - **Gameplay**: `Gamepad` icon.
 
 Each tab's content lives in its own component:
@@ -16,14 +14,10 @@ Each tab's content lives in its own component:
 - `LLMSettings.svelte`
 - `GameplaySettings.svelte`
 
-These components share grid and tooltip styling via
-`settings-shared.css`, while `SettingsMenu.svelte` handles tab
-selection, LRM configuration, and dispatches `save` and `endRun`
-events. `SettingsMenu.svelte` receives `backendFlavor` from the page and
-checks it for `"llm"` to decide whether the LLM tab should appear. When
-the flavor string omits `"llm"`, the component skips `getLrmConfig()`
-and hides the model selector and test button.
+All tabs share a two-column grid defined in `settings-shared.css`. Labels and Lucide icons occupy the left column while interactive controls sit on the right, and rows fade on hover. The stylesheet also provides tooltip styling consumed by `Tooltip.svelte`.
 
-The Gameplay tab's **End Run** button now attempts to end the current run by
-ID and falls back to clearing all runs when the ID is missing or the targeted
-request fails.
+Audio volume controls use the `DotSelector` component to render ten selectable levels (0–100%). Gameplay controls that need explanations wrap their labels in the `Tooltip` component for accessible hover and focus hints. System settings include icons for backend health (`activity`), framerate (`gauge`), reduced motion (`move`), wipe (`trash-2`), backup (`download`), and import (`upload`).
+
+`SettingsMenu.svelte` handles tab selection, LRM configuration, and dispatches `save` and `endRun` events. `SettingsMenu.svelte` receives `backendFlavor` from the page and checks it for `"llm"` to decide whether the LLM tab should appear. When the flavor string omits `"llm"`, the component skips `getLrmConfig()` and hides the model selector and test button.
+
+The Gameplay tab's **End Run** button now attempts to end the current run by ID and falls back to clearing all runs when the ID is missing or the targeted request fails.

--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -14,6 +14,7 @@
         "@sveltejs/adapter-static": "^3.0.9",
         "@sveltejs/kit": "^2.22.0",
         "@sveltejs/vite-plugin-svelte": "^6.0.0",
+        "@testing-library/svelte": "^5.2.8",
         "eslint": "^9.34.0",
         "globals": "^16.3.0",
         "jsdom": "^26.1.0",
@@ -27,6 +28,12 @@
     "@ampproject/remapping": ["@ampproject/remapping@2.3.0", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw=="],
 
     "@asamuzakjp/css-color": ["@asamuzakjp/css-color@3.2.0", "", { "dependencies": { "@csstools/css-calc": "^2.1.3", "@csstools/css-color-parser": "^3.0.9", "@csstools/css-parser-algorithms": "^3.0.4", "@csstools/css-tokenizer": "^3.0.3", "lru-cache": "^10.4.3" } }, "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw=="],
+
+    "@babel/code-frame": ["@babel/code-frame@7.27.1", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.27.1", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg=="],
+
+    "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.27.1", "", {}, "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow=="],
+
+    "@babel/runtime": ["@babel/runtime@7.28.4", "", {}, "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ=="],
 
     "@csstools/color-helpers": ["@csstools/color-helpers@5.1.0", "", {}, "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA=="],
 
@@ -178,6 +185,12 @@
 
     "@sveltejs/vite-plugin-svelte-inspector": ["@sveltejs/vite-plugin-svelte-inspector@5.0.0", "", { "dependencies": { "debug": "^4.4.1" }, "peerDependencies": { "@sveltejs/vite-plugin-svelte": "^6.0.0-next.0", "svelte": "^5.0.0", "vite": "^6.3.0 || ^7.0.0" } }, "sha512-iwQ8Z4ET6ZFSt/gC+tVfcsSBHwsqc6RumSaiLUkAurW3BCpJam65cmHw0oOlDMTO0u+PZi9hilBRYN+LZNHTUQ=="],
 
+    "@testing-library/dom": ["@testing-library/dom@10.4.1", "", { "dependencies": { "@babel/code-frame": "^7.10.4", "@babel/runtime": "^7.12.5", "@types/aria-query": "^5.0.1", "aria-query": "5.3.0", "dom-accessibility-api": "^0.5.9", "lz-string": "^1.5.0", "picocolors": "1.1.1", "pretty-format": "^27.0.2" } }, "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg=="],
+
+    "@testing-library/svelte": ["@testing-library/svelte@5.2.8", "", { "dependencies": { "@testing-library/dom": "9.x.x || 10.x.x" }, "peerDependencies": { "svelte": "^3 || ^4 || ^5 || ^5.0.0-next.0", "vite": "*", "vitest": "*" }, "optionalPeers": ["vite", "vitest"] }, "sha512-ucQOtGsJhtawOEtUmbR4rRh53e6RbM1KUluJIXRmh6D4UzxR847iIqqjRtg9mHNFmGQ8Vkam9yVcR5d1mhIHKA=="],
+
+    "@types/aria-query": ["@types/aria-query@5.0.4", "", {}, "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw=="],
+
     "@types/cookie": ["@types/cookie@0.6.0", "", {}, "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA=="],
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
@@ -193,6 +206,8 @@
     "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
     "ajv": ["ajv@6.12.6", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g=="],
+
+    "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
@@ -242,7 +257,11 @@
 
     "deepmerge": ["deepmerge@4.3.1", "", {}, "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A=="],
 
+    "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
+
     "devalue": ["devalue@5.1.1", "", {}, "sha512-maua5KUiapvEwiEAe+XnlZ3Rh0GD+qI1J/nb9vrJc3muPXvcF/8gXYTWF76+5DAqHyDUtOIImEuo0YKE9mshVw=="],
+
+    "dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
 
     "entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
@@ -328,6 +347,8 @@
 
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
+    "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
+
     "js-yaml": ["js-yaml@4.1.0", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA=="],
 
     "jsdom": ["jsdom@26.1.0", "", { "dependencies": { "cssstyle": "^4.2.1", "data-urls": "^5.0.0", "decimal.js": "^10.5.0", "html-encoding-sniffer": "^4.0.0", "http-proxy-agent": "^7.0.2", "https-proxy-agent": "^7.0.6", "is-potential-custom-element-name": "^1.0.1", "nwsapi": "^2.2.16", "parse5": "^7.2.1", "rrweb-cssom": "^0.8.0", "saxes": "^6.0.0", "symbol-tree": "^3.2.4", "tough-cookie": "^5.1.1", "w3c-xmlserializer": "^5.0.0", "webidl-conversions": "^7.0.0", "whatwg-encoding": "^3.1.1", "whatwg-mimetype": "^4.0.0", "whatwg-url": "^14.1.1", "ws": "^8.18.0", "xml-name-validator": "^5.0.0" }, "peerDependencies": { "canvas": "^3.0.0" }, "optionalPeers": ["canvas"] }, "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg=="],
@@ -357,6 +378,8 @@
     "lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
     "lucide-svelte": ["lucide-svelte@0.539.0", "", { "peerDependencies": { "svelte": "^3 || ^4 || ^5.0.0-next.42" } }, "sha512-p4k3GOje/9Si1eIkg1W1OQUhozeja5Ka5shjVpfyP5X2ye+B7sfyMnX3d5D2et+MYJwUFGrMna5MIYgq6bLfqw=="],
+
+    "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
 
     "magic-string": ["magic-string@0.30.17", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0" } }, "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA=="],
 
@@ -400,7 +423,11 @@
 
     "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
 
+    "pretty-format": ["pretty-format@27.5.1", "", { "dependencies": { "ansi-regex": "^5.0.1", "ansi-styles": "^5.0.0", "react-is": "^17.0.1" } }, "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ=="],
+
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
+
+    "react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
 
     "readdirp": ["readdirp@3.6.0", "", { "dependencies": { "picomatch": "^2.2.1" } }, "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA=="],
 
@@ -492,9 +519,13 @@
 
     "@humanfs/node/@humanwhocodes/retry": ["@humanwhocodes/retry@0.3.1", "", {}, "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA=="],
 
+    "@testing-library/dom/aria-query": ["aria-query@5.3.0", "", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A=="],
+
     "anymatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
     "chokidar/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
+
+    "pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
 
     "readdirp/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
   }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,6 +16,7 @@
     "@sveltejs/adapter-static": "^3.0.9",
     "@sveltejs/kit": "^2.22.0",
     "@sveltejs/vite-plugin-svelte": "^6.0.0",
+    "@testing-library/svelte": "^5.2.8",
     "eslint": "^9.34.0",
     "globals": "^16.3.0",
     "jsdom": "^26.1.0",

--- a/frontend/src/lib/components/AudioSettings.svelte
+++ b/frontend/src/lib/components/AudioSettings.svelte
@@ -1,26 +1,24 @@
 <script>
   import { Volume2, Music, Mic } from 'lucide-svelte';
-  export let sfxVolume = 5;
-  export let musicVolume = 5;
-  export let voiceVolume = 5;
+  import DotSelector from './DotSelector.svelte';
+  export let sfxVolume = 50;
+  export let musicVolume = 50;
+  export let voiceVolume = 50;
   export let scheduleSave;
 </script>
 
 <div class="settings-panel">
   <div class="control" title="Adjust sound effect volume.">
-    <Volume2 />
-    <label>SFX Volume</label>
-    <input type="range" min="0" max="100" bind:value={sfxVolume} on:input={scheduleSave} />
+    <span class="label"><Volume2 /> SFX Volume</span>
+    <DotSelector bind:value={sfxVolume} on:change={scheduleSave} />
   </div>
   <div class="control" title="Adjust background music volume.">
-    <Music />
-    <label>Music Volume</label>
-    <input type="range" min="0" max="100" bind:value={musicVolume} on:input={scheduleSave} />
+    <span class="label"><Music /> Music Volume</span>
+    <DotSelector bind:value={musicVolume} on:change={scheduleSave} />
   </div>
   <div class="control" title="Adjust voice volume.">
-    <Mic />
-    <label>Voice Volume</label>
-    <input type="range" min="0" max="100" bind:value={voiceVolume} on:input={scheduleSave} />
+    <span class="label"><Mic /> Voice Volume</span>
+    <DotSelector bind:value={voiceVolume} on:change={scheduleSave} />
   </div>
 </div>
 

--- a/frontend/src/lib/components/DotSelector.svelte
+++ b/frontend/src/lib/components/DotSelector.svelte
@@ -1,0 +1,40 @@
+<script>
+  import { createEventDispatcher } from 'svelte';
+  export let value = 50;
+  const dispatch = createEventDispatcher();
+
+  const select = (v) => {
+    value = v;
+    dispatch('change', v);
+  };
+</script>
+
+<div class="dot-selector">
+  {#each Array(10) as _, i}
+    <button
+      type="button"
+      class:selected={value >= (i + 1) * 10}
+      aria-label={(i + 1) * 10 + '%'}
+      on:click={() => select((i + 1) * 10)}
+    />
+  {/each}
+</div>
+
+<style>
+  .dot-selector {
+    display: flex;
+    gap: 0.3rem;
+  }
+  .dot-selector button {
+    width: 0.6rem;
+    height: 0.6rem;
+    border-radius: 50%;
+    border: none;
+    background: rgba(255, 255, 255, 0.3);
+    cursor: pointer;
+    transition: background 0.2s;
+  }
+  .dot-selector button.selected {
+    background: #fff;
+  }
+</style>

--- a/frontend/src/lib/components/GameplaySettings.svelte
+++ b/frontend/src/lib/components/GameplaySettings.svelte
@@ -1,5 +1,6 @@
 <script>
   import { Power } from 'lucide-svelte';
+  import Tooltip from './Tooltip.svelte';
   export let showActionValues = false;
   export let scheduleSave;
   export let handleEndRun;
@@ -8,13 +9,16 @@
 </script>
 
 <div class="settings-panel">
-  <div class="control" title="Display numeric action values in the turn order.">
-    <label>Show Action Values</label>
+  <div class="control">
+    <Tooltip text="Display numeric action values in the turn order.">
+      <span class="label">Show Action Values</span>
+    </Tooltip>
     <input type="checkbox" bind:checked={showActionValues} on:change={scheduleSave} />
   </div>
-  <div class="control" title="End the current run.">
-    <Power />
-    <label>End Run</label>
+  <div class="control">
+    <Tooltip text="End the current run.">
+      <span class="label"><Power /> End Run</span>
+    </Tooltip>
     <button on:click={handleEndRun} disabled={endingRun}>{endingRun ? 'Ending…' : 'End'}</button>
     {#if endRunStatus}
       <span class="status" data-testid="endrun-status">{endRunStatus}</span>

--- a/frontend/src/lib/components/LLMSettings.svelte
+++ b/frontend/src/lib/components/LLMSettings.svelte
@@ -8,7 +8,7 @@
 
 <div class="settings-panel">
   <div class="control" title="Select language reasoning model.">
-    <label>LRM Model</label>
+    <span class="label">LRM Model</span>
     <select bind:value={lrmModel} on:change={handleModelChange}>
       {#each lrmOptions as opt}
         <option value={opt}>{opt}</option>
@@ -16,7 +16,7 @@
     </select>
   </div>
   <div class="control" title="Send a sample prompt to the selected model.">
-    <label>Test Model</label>
+    <span class="label">Test Model</span>
     <button on:click={handleTestModel}>Test</button>
   </div>
   {#if testReply}

--- a/frontend/src/lib/components/SystemSettings.svelte
+++ b/frontend/src/lib/components/SystemSettings.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { Trash2, Download, Upload } from 'lucide-svelte';
+  import { Activity, Gauge, Move, Trash2, Download, Upload } from 'lucide-svelte';
   export let framerate = 60;
   export let reducedMotion = false;
   export let handleWipe;
@@ -14,9 +14,15 @@
 
 <div class="settings-panel">
   <div class="control" title="Backend health and network latency.">
-    <label>Backend Health</label>
+    <span class="label"><Activity /> Backend Health</span>
     <span class="badge" data-status={healthStatus}>
-      {healthStatus === 'healthy' ? 'Healthy' : healthStatus === 'degraded' ? 'Degraded' : healthStatus === 'error' ? 'Error' : 'Unknown'}
+      {healthStatus === 'healthy'
+        ? 'Healthy'
+        : healthStatus === 'degraded'
+        ? 'Degraded'
+        : healthStatus === 'error'
+        ? 'Error'
+        : 'Unknown'}
     </span>
     {#if healthPing !== null}
       <span class="ping">{Math.round(healthPing)}ms</span>
@@ -24,7 +30,7 @@
     <button on:click={() => refreshHealth(true)}>Refresh</button>
   </div>
   <div class="control" title="Limit server polling frequency.">
-    <label>Framerate</label>
+    <span class="label"><Gauge /> Framerate</span>
     <select bind:value={framerate} on:change={scheduleSave}>
       <option value={30}>30</option>
       <option value={60}>60</option>
@@ -32,25 +38,22 @@
     </select>
   </div>
   <div class="control" title="Slow down battle animations.">
-    <label>Reduced Motion</label>
+    <span class="label"><Move /> Reduced Motion</span>
     <input type="checkbox" bind:checked={reducedMotion} on:change={scheduleSave} />
   </div>
   <div class="control" title="Clear all save data.">
-    <Trash2 />
-    <label>Wipe Save Data</label>
+    <span class="label"><Trash2 /> Wipe Save Data</span>
     <button on:click={handleWipe}>Wipe</button>
   </div>
   {#if wipeStatus}
     <p class="status" data-testid="wipe-status">{wipeStatus}</p>
   {/if}
   <div class="control" title="Download encrypted backup of save data.">
-    <Download />
-    <label>Backup Save Data</label>
+    <span class="label"><Download /> Backup Save Data</span>
     <button on:click={handleBackup}>Backup</button>
   </div>
   <div class="control" title="Import an encrypted save backup.">
-    <Upload />
-    <label>Import Save Data</label>
+    <span class="label"><Upload /> Import Save Data</span>
     <input type="file" accept=".afsave" on:change={handleImport} />
   </div>
 </div>

--- a/frontend/src/lib/components/Tooltip.svelte
+++ b/frontend/src/lib/components/Tooltip.svelte
@@ -1,0 +1,17 @@
+<script>
+  export let text = '';
+  let show = false;
+</script>
+
+<div
+  class="tooltip-wrapper"
+  on:mouseenter={() => (show = true)}
+  on:mouseleave={() => (show = false)}
+  on:focusin={() => (show = true)}
+  on:focusout={() => (show = false)}
+>
+  <slot />
+  <span class="tooltip" role="tooltip" class:visible={show}>{text}</span>
+</div>
+
+<style src="./settings-shared.css"></style>

--- a/frontend/src/lib/components/settings-shared.css
+++ b/frontend/src/lib/components/settings-shared.css
@@ -5,26 +5,30 @@
 }
 
 .settings-panel .control {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.2rem 0.3rem;
+  border-radius: 4px;
+  transition: background-color 0.2s;
+}
+
+.settings-panel .control:hover {
+  background-color: rgba(255, 255, 255, 0.05);
+}
+
+.settings-panel .label {
   display: flex;
   align-items: center;
   gap: 0.4rem;
-}
-
-.settings-panel .control[title] {
-  cursor: help;
-}
-
-.settings-panel label {
-  flex: 1;
   font-size: 0.85rem;
 }
 
-.settings-panel input[type='range'] {
-  flex: 2;
-}
-
-.settings-panel select {
-  flex: 2;
+.settings-panel select,
+.settings-panel input[type='checkbox'],
+.settings-panel input[type='file'] {
+  justify-self: start;
 }
 
 .settings-panel button {
@@ -34,6 +38,7 @@
 .settings-panel .status {
   margin: 0;
   font-size: 0.8rem;
+  grid-column: 1 / -1;
 }
 
 .settings-panel .badge {
@@ -49,4 +54,30 @@
 .settings-panel .ping {
   font-size: 0.75rem;
   opacity: 0.9;
+}
+
+.tooltip-wrapper {
+  position: relative;
+  display: inline-block;
+}
+
+.tooltip {
+  position: absolute;
+  background: rgba(0,0,0,0.8);
+  color: #fff;
+  padding: 0.2rem 0.4rem;
+  border-radius: 4px;
+  font-size: 0.75rem;
+  top: 100%;
+  left: 0;
+  transform: translateY(0.2rem);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s;
+  white-space: nowrap;
+  z-index: 10;
+}
+
+.tooltip.visible {
+  opacity: 1;
 }

--- a/frontend/tests/audio-settings.test.js
+++ b/frontend/tests/audio-settings.test.js
@@ -1,0 +1,10 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+describe('AudioSettings component', () => {
+  test('replaces sliders with DotSelector', () => {
+    const content = readFileSync(join(import.meta.dir, '../src/lib/components/AudioSettings.svelte'), 'utf8');
+    expect((content.match(/DotSelector/g) || []).length).toBeGreaterThanOrEqual(3);
+  });
+});

--- a/frontend/tests/tooltip.test.js
+++ b/frontend/tests/tooltip.test.js
@@ -1,0 +1,12 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+describe('Tooltip component', () => {
+  test('provides accessible markup and events', () => {
+    const content = readFileSync(join(import.meta.dir, '../src/lib/components/Tooltip.svelte'), 'utf8');
+    expect(content).toContain('role="tooltip"');
+    expect(content).toContain('on:mouseenter');
+    expect(content).toContain('on:focusin');
+  });
+});


### PR DESCRIPTION
## Summary
- adopt two-column grid for settings panels with hover transitions
- add DotSelector and Tooltip components; migrate audio sliders and gameplay tooltips
- enhance System settings with icons and update docs/tests

## Testing
- `bun run lint`
- `bun test` *(fails: vi.mock is not a function, Svelte runes outside tests)*
- `bun test tests/audio-settings.test.js tests/tooltip.test.js`


------
https://chatgpt.com/codex/tasks/task_b_68c520cbabd8832c8a4391c29512a783