### PR TITLE
[FEAT] Revamp settings layout

### DIFF
--- a/frontend/src/lib/components/DotSelector.svelte
+++ b/frontend/src/lib/components/DotSelector.svelte
@@ -10,6 +10,15 @@
 </script>
 
 <div class="dot-selector">
+  <button
+    type="button"
+    class="mute"
+    class:selected={value === 0}
+    aria-label="Mute"
+    on:click={() => select(0)}
+  >
+    ✕
+  </button>
   {#each Array(10) as _, i}
     <button
       type="button"
@@ -33,8 +42,16 @@
     background: rgba(255, 255, 255, 0.3);
     cursor: pointer;
     transition: background 0.2s;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+  .dot-selector button.mute {
+    font-size: 0.5rem;
+    color: rgba(255, 255, 255, 0.9);
   }
   .dot-selector button.selected {
     background: #fff;
+    color: #000;
   }
 </style>

--- a/frontend/tests/dot-selector.test.js
+++ b/frontend/tests/dot-selector.test.js
@@ -1,0 +1,14 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+describe('DotSelector component', () => {
+  test('includes a mute button for 0% volume', () => {
+    const content = readFileSync(
+      join(import.meta.dir, '../src/lib/components/DotSelector.svelte'),
+      'utf8'
+    );
+    expect(content).toMatch(/aria-label="Mute"/);
+    expect(content).toMatch(/select\(0\)/);
+  });
+});


### PR DESCRIPTION
## Summary
- add mute button to DotSelector for 0% volume
- test DotSelector mute functionality

## Testing
- `bun run lint`
- `bun test tests/audio-settings.test.js tests/tooltip.test.js tests/dot-selector.test.js`


------
https://chatgpt.com/codex/tasks/task_b_68c59b8120fc832c84d9300c4ff1022b