### PR TITLE
[FEAT] enhance sturdy vest hot

### DIFF
--- a/backend/plugins/cards/sturdy_vest.py
+++ b/backend/plugins/cards/sturdy_vest.py
@@ -1,9 +1,13 @@
+import asyncio
 from dataclasses import dataclass
 from dataclasses import field
+import logging
 
 from autofighter.effects import EffectManager
 from autofighter.stats import BUS
 from plugins.cards._base import CardBase
+
+log = logging.getLogger(__name__)
 
 
 @dataclass
@@ -17,52 +21,77 @@ class SturdyVest(CardBase):
     async def apply(self, party) -> None:  # type: ignore[override]
         await super().apply(party)
 
-        # Track which members have the HoT active to avoid stacking
-        active_hots = set()
+        # Track active HoTs and remaining turns per member
+        active_hots: dict[int, tuple[object, int]] = {}
 
-        def _check_low_hp():
+        async def _check_low_hp(apply_tick: bool = False) -> None:
+            # Apply existing HoTs at the start of each turn
+            if apply_tick:
+                for member_id, (member, turns_left) in list(active_hots.items()):
+                    hot_amount = int(getattr(member, "max_hp", 1) * 0.03)
+
+                    async def apply_hot() -> None:
+                        try:
+                            await member.apply_healing(
+                                hot_amount,
+                                source_type="hot",
+                                source_name="sturdy_vest",
+                            )
+                        except Exception as exc:  # pragma: no cover - logging only
+                            log.warning("Error applying Sturdy Vest HoT: %s", exc)
+
+                    try:
+                        loop = asyncio.get_running_loop()
+                    except RuntimeError:
+                        asyncio.run(apply_hot())
+                    else:
+                        loop.create_task(apply_hot())
+
+                    turns_left -= 1
+                    if turns_left <= 0:
+                        del active_hots[member_id]
+                    else:
+                        active_hots[member_id] = (member, turns_left)
+
+            # Check for new HoT activations
             for member in party.members:
                 member_id = id(member)
-                current_hp = getattr(member, 'hp', 0)
-                max_hp = getattr(member, 'max_hp', 1)
+                current_hp = getattr(member, "hp", 0)
+                max_hp = getattr(member, "max_hp", 1)
 
-                # Check if below 35% HP and not already has HoT
                 if current_hp / max_hp < 0.35 and member_id not in active_hots:
-                    # Add to active set
-                    active_hots.add(member_id)
-
-                    # Apply 3% HoT for 2 turns
-                    effect_manager = getattr(member, 'effect_manager', None)
+                    effect_manager = getattr(member, "effect_manager", None)
                     if effect_manager is None:
                         effect_manager = EffectManager(member)
                         member.effect_manager = effect_manager
 
-                    # Create HoT effect (3% of max HP per turn for 2 turns)
+                    active_hots[member_id] = (member, 2)
                     hot_amount = int(max_hp * 0.03)
-                    import asyncio
-                    import logging
-                    log = logging.getLogger(__name__)
 
-                    async def apply_hot():
-                        try:
-                            await member.apply_healing(hot_amount, source_type="hot", source_name="sturdy_vest")
-                        except Exception as e:
-                            log.warning("Error applying Sturdy Vest HoT: %s", e)
-                        finally:
-                            # Remove from active set after 2 turns (simplified)
-                            if member_id in active_hots:
-                                active_hots.remove(member_id)
+                    log.debug(
+                        "Sturdy Vest activated HoT for %s: %d HP/turn for 2 turns",
+                        member.id,
+                        hot_amount,
+                    )
+                    BUS.emit(
+                        "card_effect",
+                        self.id,
+                        member,
+                        "hot_activation",
+                        hot_amount,
+                        {
+                            "hot_amount": hot_amount,
+                            "duration": 2,
+                            "trigger_threshold": 0.35,
+                        },
+                    )
 
-                    # Schedule HoT for next 2 turns
-                    asyncio.create_task(apply_hot())
+        async def _on_turn_start(*_) -> None:
+            await _check_low_hp(apply_tick=True)
 
-                    log.debug("Sturdy Vest activated HoT for %s: %d HP/turn for 2 turns", member.id, hot_amount)
-                    BUS.emit("card_effect", self.id, member, "hot_activation", hot_amount, {
-                        "hot_amount": hot_amount,
-                        "duration": 2,
-                        "trigger_threshold": 0.35
-                    })
+        async def _on_damage_taken(*_) -> None:
+            await _check_low_hp()
 
         # Check HP at the start of each turn and after damage taken
-        BUS.subscribe("turn_start", _check_low_hp)
-        BUS.subscribe("damage_taken", lambda target, attacker, damage: _check_low_hp())
+        BUS.subscribe("turn_start", _on_turn_start)
+        BUS.subscribe("damage_taken", _on_damage_taken)

--- a/backend/tests/test_sturdy_vest.py
+++ b/backend/tests/test_sturdy_vest.py
@@ -1,0 +1,47 @@
+import asyncio
+import sys
+import types
+
+from autofighter.cards import apply_cards
+from autofighter.cards import award_card
+from autofighter.party import Party
+from autofighter.stats import BUS
+from plugins.players._base import PlayerBase
+
+
+def setup_event_loop():
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    return loop
+
+
+def test_sturdy_vest_grants_two_turn_hot():
+    sys.modules.setdefault(
+        "llms.torch_checker", types.SimpleNamespace(is_torch_available=lambda: False)
+    )
+
+    loop = setup_event_loop()
+    party = Party()
+    member = PlayerBase()
+    member.id = "member"
+    member.set_base_stat("max_hp", 100)
+    member.hp = 100
+    party.members.append(member)
+    award_card(party, "sturdy_vest")
+    loop.run_until_complete(apply_cards(party))
+
+    member.hp = 30
+    loop.run_until_complete(BUS.emit_async("damage_taken", member, None, 0))
+
+    loop.run_until_complete(BUS.emit_async("turn_start"))
+    loop.run_until_complete(asyncio.sleep(0))
+    assert member.hp == 33
+
+    loop.run_until_complete(BUS.emit_async("turn_start"))
+    loop.run_until_complete(asyncio.sleep(0))
+    assert member.hp == 36
+
+    loop.run_until_complete(BUS.emit_async("turn_start"))
+    loop.run_until_complete(asyncio.sleep(0))
+    assert member.hp == 39
+


### PR DESCRIPTION
## Summary
- ensure sturdy vest healing coroutines run on a valid event loop
- track and apply HoT ticks across two turns per trigger
- add regression test for sturdy vest HoT behavior

## Testing
- `ruff check backend/plugins/cards/sturdy_vest.py backend/tests/test_sturdy_vest.py --fix`
- `pytest backend/tests/test_sturdy_vest.py`
- `./run-tests.sh` *(fails: expect to contain "Show Action Values")*


------
https://chatgpt.com/codex/tasks/task_b_68c59e3eb948832c9b64fec5110e6f13