### PR TITLE
[FIX] capture HoT member data for sturdy vest

### DIFF
--- a/backend/plugins/cards/sturdy_vest.py
+++ b/backend/plugins/cards/sturdy_vest.py
@@ -30,7 +30,10 @@ class SturdyVest(CardBase):
                 for member_id, (member, turns_left) in list(active_hots.items()):
                     hot_amount = int(getattr(member, "max_hp", 1) * 0.03)
 
-                    async def apply_hot() -> None:
+                    async def apply_hot(
+                        member: object = member,
+                        hot_amount: int = hot_amount,
+                    ) -> None:
                         try:
                             await member.apply_healing(
                                 hot_amount,


### PR DESCRIPTION
## Summary
- freeze member and heal values when scheduling Sturdy Vest HoT ticks

## Testing
- `uv run ruff check backend/plugins/cards/sturdy_vest.py backend/tests/test_sturdy_vest.py --fix`
- `uv run pytest tests/test_sturdy_vest.py`
- `./run-tests.sh` *(fails: expect(received).toContain("Show Action Values"))*

------
https://chatgpt.com/codex/tasks/task_b_68c5a2fbdbfc832cae375f7108a09d02