### PR TITLE
[UI] Match settings tabs to stained-glass nav styling

### DIFF
--- a/frontend/.codex/implementation/settings-menu.md
+++ b/frontend/.codex/implementation/settings-menu.md
@@ -16,6 +16,8 @@ Each tab's content lives in its own component:
 
 All tabs share a two-column grid defined in `settings-shared.css`. Labels and Lucide icons occupy the left column while interactive controls sit on the right, and rows fade on hover. The stylesheet also provides tooltip styling consumed by `Tooltip.svelte`.
 
+The tab selector bar reuses the navigation bar’s stained-glass styling via the `stained-glass-bar` class so the tabs visually match other glass elements.
+
 Audio volume controls use the `DotSelector` component to render ten selectable levels (0–100%). Gameplay controls that need explanations wrap their labels in the `Tooltip` component for accessible hover and focus hints. System settings include icons for backend health (`activity`), framerate (`gauge`), reduced motion (`move`), wipe (`trash-2`), backup (`download`), and import (`upload`).
 
 `SettingsMenu.svelte` handles tab selection, LRM configuration, and dispatches `save` and `endRun` events. `SettingsMenu.svelte` receives `backendFlavor` from the page and checks it for `"llm"` to decide whether the LLM tab should appear. When the flavor string omits `"llm"`, the component skips `getLrmConfig()` and hides the model selector and test button.

--- a/frontend/src/lib/components/SettingsMenu.svelte
+++ b/frontend/src/lib/components/SettingsMenu.svelte
@@ -201,7 +201,7 @@
 </script>
 
 <div data-testid="settings-menu" class="tabbed">
-  <div class="tabs">
+  <div class="tabs stained-glass-bar">
     <button class:active={activeTab === 'audio'} on:click={() => (activeTab = 'audio')} title="Audio">
       <Volume2 />
     </button>

--- a/frontend/src/lib/components/settings-shared.css
+++ b/frontend/src/lib/components/settings-shared.css
@@ -126,6 +126,16 @@
   min-height: 360px;
 }
 
+.stained-glass-bar {
+  padding: 0.5rem 0.7rem;
+  border-radius: 0;
+  background: var(--glass-bg);
+  box-shadow: var(--glass-shadow);
+  border: var(--glass-border);
+  backdrop-filter: var(--glass-filter);
+  opacity: 0.99;
+}
+
 .tabs {
   display: flex;
   gap: 0.5rem;
@@ -133,18 +143,24 @@
 }
 
 .tabs button {
-  border: 2px solid #fff;
-  background: #0a0a0a;
-  color: #fff;
-  padding: 0.3rem;
+  background: rgba(255,255,255,0.10);
+  border: none;
+  border-radius: 0;
+  width: 2.9rem;
+  height: 2.9rem;
   display: flex;
   align-items: center;
   justify-content: center;
+  color: #fff;
+  cursor: pointer;
+  transition: background 0.18s, box-shadow 0.18s;
+  box-shadow: 0 1px 4px 0 rgba(0,40,120,0.10);
 }
 
+.tabs button:hover,
 .tabs button.active {
-  background: #fff;
-  color: #0a0a0a;
+  background: rgba(120,180,255,0.22);
+  box-shadow: 0 2px 8px 0 rgba(0,40,120,0.18);
 }
 
 .actions {


### PR DESCRIPTION
## Summary
- reuse stained-glass navigation styling for settings tabs
- style tab buttons like NavBar icon buttons
- document stained-glass tab selector in settings menu docs

## Testing
- `uvx ruff check backend --fix`
- `bun run lint:fix`
- `./run-tests.sh` *(fails: ModuleNotFoundError: No module named 'battle_logging')*

------
https://chatgpt.com/codex/tasks/task_b_68c5ab7c53f4832cace25e7ca1abfc5e