### PR TITLE
[FEAT] Persist gacha banner selection

### DIFF
--- a/frontend/.codex/implementation/pulls-menu.md
+++ b/frontend/.codex/implementation/pulls-menu.md
@@ -4,4 +4,6 @@ The `PullsMenu.svelte` component lets players spend gacha tickets. It shows
 current pity and ticket counts and provides buttons for one, five, or ten
 pulls. Each button disables when the player lacks enough tickets. After a
 successful pull it opens `PullResultsOverlay.svelte`, which queues the
-returned items and reveals them one at a time.
+returned items and reveals them one at a time. The menu remembers the last
+selected banner in `localStorage` and restores it on reload. If that banner is
+no longer available, the first available banner is selected instead.

--- a/frontend/src/lib/components/PullsMenu.svelte
+++ b/frontend/src/lib/components/PullsMenu.svelte
@@ -12,6 +12,12 @@
   
   // State management
   let activeTab = 'standard';
+  if (browser) {
+    const saved = localStorage.getItem('pulls-active-banner');
+    if (saved) {
+      activeTab = saved;
+    }
+  }
   let pity = 0;
   let items = {};
   let loading = false;
@@ -30,10 +36,7 @@
       banners = data.banners || [];
       featuredCharacters = data.featured_characters || [];
       
-      // Set default tab to first available banner
-      if (banners.length > 0 && !banners.find(b => b.id === activeTab)) {
-        activeTab = banners[0].id;
-      }
+      ensureActiveTabValid();
     } catch (err) {
       console.error('Failed to load gacha data:', err);
     }
@@ -66,6 +69,7 @@
         banners = fresh?.banners || banners;
         featuredCharacters = fresh?.featured_characters || featuredCharacters;
       } catch {}
+      ensureActiveTabValid();
     } catch (err) {
       // Revert optimistic change on failure
       if (prevTickets >= count) {
@@ -86,6 +90,18 @@
   
   function switchTab(tabId) {
     activeTab = tabId;
+    if (browser) {
+      localStorage.setItem('pulls-active-banner', activeTab);
+    }
+  }
+
+  function ensureActiveTabValid() {
+    if (banners.length > 0 && !banners.find(b => b.id === activeTab)) {
+      activeTab = banners[0].id;
+      if (browser) {
+        localStorage.setItem('pulls-active-banner', activeTab);
+      }
+    }
   }
   
   // Get current banner info

--- a/frontend/tests/pullsmenu.test.js
+++ b/frontend/tests/pullsmenu.test.js
@@ -9,12 +9,30 @@ describe('PullsMenu component', () => {
       'utf8'
     );
     expect(content).toContain('data-testid="pulls-menu"');
-    expect(content).toContain('Pull 1');
-    expect(content).toContain('Pull 5');
-    expect(content).toContain('Pull 10');
+    expect(content).toContain('Pull ×1');
+    expect(content).toContain('Pull ×5');
+    expect(content).toContain('Pull ×10');
     expect(content).toContain('(items.ticket || 0) < 1');
     expect(content).toContain('(items.ticket || 0) < 5');
     expect(content).toContain("openOverlay('pull-results'");
     expect(content).not.toContain('<ul>');
+  });
+
+  test('persists selected banner via localStorage', () => {
+    const content = readFileSync(
+      join(import.meta.dir, '../src/lib/components/PullsMenu.svelte'),
+      'utf8'
+    );
+    expect(content).toContain("localStorage.getItem('pulls-active-banner')");
+    expect(content).toContain("localStorage.setItem('pulls-active-banner', activeTab)");
+  });
+
+  test('validates active banner after pull or reload', () => {
+    const content = readFileSync(
+      join(import.meta.dir, '../src/lib/components/PullsMenu.svelte'),
+      'utf8'
+    );
+    expect(content).toMatch(/async function reloadData[\s\S]*ensureActiveTabValid\(\)/);
+    expect(content).toMatch(/async function pull\([^)]*\)[\s\S]*ensureActiveTabValid\(\)/);
   });
 });


### PR DESCRIPTION
## Summary
- store and restore last gacha banner via localStorage
- ensure banner selection remains valid after pulls and data reloads
- document pulls menu banner persistence and test it

## Testing
- [ ] Backend tests (failed: multiple missing modules)
- [x] Frontend tests `bun test tests/pullsmenu.test.js`
- [x] Lint `bun run lint`
- [ ] Doc sync updates (README and `.codex/implementation` docs; link tasks below)

------
https://chatgpt.com/codex/tasks/task_b_68c5ac8a4a2c832cad79eacdcdcadddb