### PR TITLE
[FIX] Lower ticket drop rate

### DIFF
--- a/ABOUTGAME.md
+++ b/ABOUTGAME.md
@@ -94,7 +94,7 @@ All LLM operations are asynchronous and won't block the game interface. Models a
 
 ### Loot and Rare Drop Rate
 
-Battles award gold, relic choices, upgrade items, and occasionally pull tickets. Gold equals a base value of 5/20/200 for normal, boss, and floor-boss rooms, multiplied by the loop, a random range, and the party's rare drop rate (`rdr`). Relics drop with `10% x rdr` odds in normal fights or `50% x rdr` in boss rooms. Upgrade items use the foe's element, cap at 4★, and their quantity scales with `rdr`-fractions have a matching chance to grant an extra item. Each battle also rolls a `10% x rdr` chance for a pull ticket. `rdr` improves drop quantity and odds and can even upgrade relic or card star ranks with lucky rolls at extreme values: climbing from 3★ to 4★ requires 1000% `rdr`, while 5★ demands a colossal 1,000,000%.
+Battles award gold, relic choices, upgrade items, and occasionally pull tickets. Gold equals a base value of 5/20/200 for normal, boss, and floor-boss rooms, multiplied by the loop, a random range, and the party's rare drop rate (`rdr`). Relics drop with `10% x rdr` odds in normal fights or `50% x rdr` in boss rooms. Upgrade items use the foe's element, cap at 4★, and their quantity scales with `rdr`-fractions have a matching chance to grant an extra item. Each battle also rolls a `0.05% x rdr` chance for a pull ticket. `rdr` improves drop quantity and odds and can even upgrade relic or card star ranks with lucky rolls at extreme values: climbing from 3★ to 4★ requires 1000% `rdr`, while 5★ demands a colossal 1,000,000%.
 
 Each foe defeated during a battle temporarily grants +55% `rdr` for that room, raising gold payouts and damage-type item drops.
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -92,7 +92,7 @@ floor bosses) multiplied by the loop, a random range, and the party's rare drop
 rate (`rdr`). Relic drops roll `10% × rdr` in normal fights or `50% × rdr` in
 boss and floor-boss rooms. Upgrade items use the foe's element at random, cap at
 4★, and their quantity scales with `rdr` with fractional amounts having a
-matching chance to yield an extra item. Each fight also rolls a `10% × rdr`
+matching chance to yield an extra item. Each fight also rolls a `0.05% × rdr`
 chance to award a pull ticket. `rdr` boosts drop quantity and odds and, at
 extreme values, can roll to upgrade relic and card star ranks (3★→4★ at 1000%
 `rdr`, 4★→5★ at 1,000,000%) though success is never guaranteed.

--- a/backend/autofighter/rooms/battle.py
+++ b/backend/autofighter/rooms/battle.py
@@ -1170,7 +1170,7 @@ class BattleRoom(Room):
             {"id": random.choice(ELEMENTS), "stars": _pick_item_stars(self)}
             for _ in range(item_count)
         ]
-        ticket_chance = 0.1 * temp_rdr
+        ticket_chance = 0.0005 * temp_rdr
         if random.random() < ticket_chance:
             items.append({"id": "ticket", "stars": 0})
         loot = {

--- a/backend/tests/test_battle_loot_items.py
+++ b/backend/tests/test_battle_loot_items.py
@@ -38,6 +38,7 @@ async def test_battle_loot_items_update_inventory(app_with_db, monkeypatch):
             "card_choices": [],
             "relic_choices": [],
             "items": [
+                # include a ticket despite the 0.05% × rdr base drop rate for determinism
                 {"id": "fire", "stars": 1},
                 {"id": "ticket", "stars": 0},
             ],

--- a/backend/tests/test_loot_summary.py
+++ b/backend/tests/test_loot_summary.py
@@ -14,7 +14,8 @@ async def test_battle_returns_loot_summary(monkeypatch):
     member = Stats()
     member.id = "p1"
     party = Party(members=[member])
-    monkeypatch.setattr(rooms_module.random, "random", lambda: 0.5)
+    monkeypatch.setattr(rooms_module.random, "random", lambda: 0.999)
+    # high roll to avoid rare ticket drop (0.05% × rdr)
     monkeypatch.setattr(rooms_module.random, "choice", lambda seq: seq[0])
     monkeypatch.setattr(rooms_module, "card_choices", lambda *a, **k: [])
     result = await room.resolve(party, {})
@@ -37,7 +38,8 @@ async def test_floor_boss_high_star_items(monkeypatch):
     member = Stats()
     member.id = "p1"
     party = Party(members=[member])
-    monkeypatch.setattr(rooms_module.random, "random", lambda: 0.5)
+    monkeypatch.setattr(rooms_module.random, "random", lambda: 0.999)
+    # high roll to avoid rare ticket drop (0.05% × rdr)
     monkeypatch.setattr(rooms_module.random, "choice", lambda seq: seq[0])
     monkeypatch.setattr(rooms_module, "card_choices", lambda *a, **k: [])
     result = await room.resolve(party, {})

--- a/backend/tests/test_rdr.py
+++ b/backend/tests/test_rdr.py
@@ -39,7 +39,8 @@ async def test_rdr_scales_items_and_tickets(monkeypatch):
     monkeypatch.setattr(rooms_module, "card_choices", lambda *a, **k: [])
     monkeypatch.setattr(rooms_module, "relic_choices", lambda *a, **k: [])
     monkeypatch.setattr(rooms_module.random, "choice", lambda seq: seq[0])
-    monkeypatch.setattr(rooms_module.random, "random", lambda: 0.15)
+    monkeypatch.setattr(rooms_module.random, "random", lambda: 0.00075)
+    # low roll so only high RDR triggers the 0.05% × rdr ticket chance
     result_low = await room.resolve(low, {})
     result_high = await room.resolve(high, {})
     low_upgrades = [i for i in result_low["loot"]["items"] if i["id"] != "ticket"]


### PR DESCRIPTION
## Summary
- reduce base pull ticket drop rate by 200x
- document the new 0.05% × rdr odds
- align tests with the rarer ticket drops

## Testing
- `uv tool run ruff check . --fix`
- `./run-tests.sh` *(fails: ModuleNotFoundError: No module named 'llms'; ImportError: No module named 'battle_logging')*

------
https://chatgpt.com/codex/tasks/task_b_68c5ad771248832c923f143a79f6e46a