### PR TITLE
[FIX] Guard PullsMenu localStorage access

### DIFF
--- a/frontend/.codex/implementation/pulls-menu.md
+++ b/frontend/.codex/implementation/pulls-menu.md
@@ -5,5 +5,7 @@ current pity and ticket counts and provides buttons for one, five, or ten
 pulls. Each button disables when the player lacks enough tickets. After a
 successful pull it opens `PullResultsOverlay.svelte`, which queues the
 returned items and reveals them one at a time. The menu remembers the last
-selected banner in `localStorage` and restores it on reload. If that banner is
-no longer available, the first available banner is selected instead.
+selected banner via `localStorage` when available, gracefully skipping
+persistence if storage access is blocked. On reload, the banner is restored if
+possible; if that banner is no longer available, the first available banner is
+selected instead.

--- a/frontend/src/lib/components/PullsMenu.svelte
+++ b/frontend/src/lib/components/PullsMenu.svelte
@@ -9,11 +9,25 @@
   
   const dispatch = createEventDispatcher();
   export let reducedMotion = false;
-  
+
   // State management
+  function safeLocalStorageGet(key) {
+    try {
+      return localStorage.getItem(key);
+    } catch {
+      return null;
+    }
+  }
+
+  function safeLocalStorageSet(key, value) {
+    try {
+      localStorage.setItem(key, value);
+    } catch {}
+  }
+
   let activeTab = 'standard';
   if (browser) {
-    const saved = localStorage.getItem('pulls-active-banner');
+    const saved = safeLocalStorageGet('pulls-active-banner');
     if (saved) {
       activeTab = saved;
     }
@@ -91,7 +105,7 @@
   function switchTab(tabId) {
     activeTab = tabId;
     if (browser) {
-      localStorage.setItem('pulls-active-banner', activeTab);
+      safeLocalStorageSet('pulls-active-banner', activeTab);
     }
   }
 
@@ -99,7 +113,7 @@
     if (banners.length > 0 && !banners.find(b => b.id === activeTab)) {
       activeTab = banners[0].id;
       if (browser) {
-        localStorage.setItem('pulls-active-banner', activeTab);
+        safeLocalStorageSet('pulls-active-banner', activeTab);
       }
     }
   }

--- a/frontend/tests/pullsmenu.test.js
+++ b/frontend/tests/pullsmenu.test.js
@@ -23,8 +23,8 @@ describe('PullsMenu component', () => {
       join(import.meta.dir, '../src/lib/components/PullsMenu.svelte'),
       'utf8'
     );
-    expect(content).toContain("localStorage.getItem('pulls-active-banner')");
-    expect(content).toContain("localStorage.setItem('pulls-active-banner', activeTab)");
+    expect(content).toContain("safeLocalStorageGet('pulls-active-banner')");
+    expect(content).toContain("safeLocalStorageSet('pulls-active-banner', activeTab)");
   });
 
   test('validates active banner after pull or reload', () => {


### PR DESCRIPTION
## Summary
- prevent runtime crashes when localStorage is unavailable
- document banner persistence fallback
- adjust tests for safe localStorage helpers

## Testing
- `bun run lint`
- `bun test tests/pullsmenu.test.js`


------
https://chatgpt.com/codex/tasks/task_b_68c5b00f6958832c88477b8016b9fd69