### PR TITLE
[FIX] prevent battle restart when awaiting next room

### DIFF
--- a/backend/.codex/implementation/battle-snapshots.md
+++ b/backend/.codex/implementation/battle-snapshots.md
@@ -41,6 +41,9 @@ poll for results:
   and each run receives an error snapshot noting that a concurrent battle was
   detected.
 
+- Repeated calls to `battle_room` while `awaiting_next` is `true` return the
+  existing snapshot rather than launching another battle.
+
 These snapshots are stored in `game.battle_snapshots` and polled by the
 frontend during combat.
 

--- a/backend/services/room_service.py
+++ b/backend/services/room_service.py
@@ -44,14 +44,10 @@ def _collect_summons(entities: list) -> dict[str, list[dict[str, Any]]]:
 async def battle_room(run_id: str, data: dict[str, Any]) -> dict[str, Any]:
     action = data.get("action", "")
 
-    # Flag to track if this is a restart scenario (snapshot requested but none exists)
-    is_restart_scenario = False
-
     if action == "snapshot":
         snap = battle_snapshots.get(run_id)
         if snap is not None:
             return snap
-        is_restart_scenario = True
         action = ""
         data = {k: v for k, v in data.items() if k != "action"}
 
@@ -126,13 +122,13 @@ async def battle_room(run_id: str, data: dict[str, Any]) -> dict[str, Any]:
     node = rooms[state["current"]]
     if node.room_type not in {"battle-weak", "battle-normal"}:
         raise ValueError("invalid room")
-    # Only check awaiting flags if this is NOT a restart scenario
-    if not is_restart_scenario and (
-        state.get("awaiting_card")
-        or state.get("awaiting_relic")
-        or state.get("awaiting_loot")
-        or state.get("awaiting_next")
-    ):
+    # Check awaiting flags before attempting to launch a new battle
+    awaiting_card = state.get("awaiting_card")
+    awaiting_relic = state.get("awaiting_relic")
+    awaiting_loot = state.get("awaiting_loot")
+    awaiting_next = state.get("awaiting_next")
+
+    if awaiting_next:
         snap = battle_snapshots.get(run_id)
         if snap is not None:
             return snap
@@ -149,22 +145,26 @@ async def battle_room(run_id: str, data: dict[str, Any]) -> dict[str, Any]:
             "enrage": {"active": False, "stacks": 0},
             "rdr": party.rdr,
         }
-        if state.get("awaiting_next"):
-            next_type = (
-                rooms[state["current"] + 1].room_type
-                if state["current"] + 1 < len(rooms)
-                else None
-            )
-            payload.update(
-                {
-                    "awaiting_next": True,
-                    "current_index": state.get("current", 0),
-                    "current_room": node.room_type,
-                }
-            )
-            if next_type is not None:
-                payload["next_room"] = next_type
+        next_type = (
+            rooms[state["current"] + 1].room_type
+            if state["current"] + 1 < len(rooms)
+            else None
+        )
+        payload.update(
+            {
+                "awaiting_next": True,
+                "current_index": state.get("current", 0),
+                "current_room": node.room_type,
+            }
+        )
+        if next_type is not None:
+            payload["next_room"] = next_type
         return payload
+
+    if awaiting_card or awaiting_relic or awaiting_loot:
+        snap = battle_snapshots.get(run_id)
+        if snap is not None:
+            return snap
     if run_id in battle_tasks and not battle_tasks[run_id].done():
         snap = battle_snapshots.get(run_id, {"result": "battle"})
         return snap

--- a/backend/services/room_service.py
+++ b/backend/services/room_service.py
@@ -126,29 +126,18 @@ async def battle_room(run_id: str, data: dict[str, Any]) -> dict[str, Any]:
     node = rooms[state["current"]]
     if node.room_type not in {"battle-weak", "battle-normal"}:
         raise ValueError("invalid room")
-    if state.get("awaiting_next"):
-        next_type = (
-            rooms[state["current"] + 1].room_type
-            if state["current"] + 1 < len(rooms)
-            else None
-        )
-        payload: dict[str, Any] = {
-            "result": "battle",
-            "awaiting_next": True,
-            "current_index": state.get("current", 0),
-            "current_room": node.room_type,
-        }
-        if next_type is not None:
-            payload["next_room"] = next_type
-        return payload
-
     # Only check awaiting flags if this is NOT a restart scenario
-    if not is_restart_scenario and (state.get("awaiting_card") or state.get("awaiting_relic") or state.get("awaiting_loot")):
+    if not is_restart_scenario and (
+        state.get("awaiting_card")
+        or state.get("awaiting_relic")
+        or state.get("awaiting_loot")
+        or state.get("awaiting_next")
+    ):
         snap = battle_snapshots.get(run_id)
         if snap is not None:
             return snap
         party_data = [_serialize(m) for m in party.members]
-        return {
+        payload: dict[str, Any] = {
             "result": "battle",
             "party": party_data,
             "foes": [],
@@ -160,6 +149,22 @@ async def battle_room(run_id: str, data: dict[str, Any]) -> dict[str, Any]:
             "enrage": {"active": False, "stacks": 0},
             "rdr": party.rdr,
         }
+        if state.get("awaiting_next"):
+            next_type = (
+                rooms[state["current"] + 1].room_type
+                if state["current"] + 1 < len(rooms)
+                else None
+            )
+            payload.update(
+                {
+                    "awaiting_next": True,
+                    "current_index": state.get("current", 0),
+                    "current_room": node.room_type,
+                }
+            )
+            if next_type is not None:
+                payload["next_room"] = next_type
+        return payload
     if run_id in battle_tasks and not battle_tasks[run_id].done():
         snap = battle_snapshots.get(run_id, {"result": "battle"})
         return snap

--- a/backend/tests/test_battle_room_awaiting_next.py
+++ b/backend/tests/test_battle_room_awaiting_next.py
@@ -1,0 +1,52 @@
+import asyncio
+import importlib.util
+from pathlib import Path
+import sys
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from game import battle_snapshots
+from game import battle_tasks
+from game import load_map
+from game import save_map
+from services.room_service import battle_room
+from services.run_service import start_run
+
+
+@pytest.fixture()
+def app_module(tmp_path, monkeypatch):
+    db_path = tmp_path / "save.db"
+    monkeypatch.setenv("AF_DB_PATH", str(db_path))
+    monkeypatch.setenv("AF_DB_KEY", "testkey")
+    monkeypatch.syspath_prepend(Path(__file__).resolve().parents[1])
+    spec = importlib.util.spec_from_file_location(
+        "app", Path(__file__).resolve().parents[1] / "app.py",
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.mark.asyncio
+async def test_battle_room_awaiting_next_returns_snapshot(app_module):
+    run_info = await start_run(["player"])
+    run_id = run_info["run_id"]
+
+    state, rooms = await asyncio.to_thread(load_map, run_id)
+    state["awaiting_next"] = True
+    await asyncio.to_thread(save_map, run_id, state)
+
+    battle_snapshots[run_id] = {"result": "battle", "awaiting_next": True}
+
+    assert run_id not in battle_tasks
+
+    snap1 = await battle_room(run_id, {})
+    assert snap1 is battle_snapshots[run_id]
+    assert run_id not in battle_tasks
+
+    snap2 = await battle_room(run_id, {})
+    assert snap2 is snap1
+    assert run_id not in battle_tasks

--- a/backend/tests/test_battle_room_reward_restart.py
+++ b/backend/tests/test_battle_room_reward_restart.py
@@ -1,0 +1,47 @@
+import asyncio
+import importlib.util
+from pathlib import Path
+import sys
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from game import battle_snapshots
+from game import battle_tasks
+from game import load_map
+from game import save_map
+from services.room_service import battle_room
+from services.run_service import start_run
+
+
+@pytest.fixture()
+def app_module(tmp_path, monkeypatch):
+    db_path = tmp_path / "save.db"
+    monkeypatch.setenv("AF_DB_PATH", str(db_path))
+    monkeypatch.setenv("AF_DB_KEY", "testkey")
+    spec = importlib.util.spec_from_file_location(
+        "app", Path(__file__).resolve().parents[1] / "app.py",
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.mark.asyncio
+async def test_missing_snapshot_restarts_battle(app_module):
+    run_info = await start_run(["player"])
+    run_id = run_info["run_id"]
+
+    state, rooms = await asyncio.to_thread(load_map, run_id)
+    state["awaiting_card"] = True
+    await asyncio.to_thread(save_map, run_id, state)
+
+    assert run_id not in battle_snapshots
+    assert run_id not in battle_tasks
+
+    snap = await battle_room(run_id, {})
+    assert snap["result"] == "battle"
+    assert run_id in battle_snapshots
+    assert run_id in battle_tasks


### PR DESCRIPTION
## Summary
- handle `awaiting_next` when checking for pending rewards to avoid restarting battles
- document that battle_room reuses snapshots during awaiting_next
- add regression test ensuring repeated battle_room calls during awaiting_next don't spawn new tasks

## Testing
- `uv run pytest backend/tests/test_battle_room_awaiting_next.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68c5cafd9028832cbae26cefc1338bbe