### PR TITLE
[FIX] prevent battle restart when awaiting next room

### DIFF
--- a/backend/services/room_service.py
+++ b/backend/services/room_service.py
@@ -44,14 +44,10 @@ def _collect_summons(entities: list) -> dict[str, list[dict[str, Any]]]:
 async def battle_room(run_id: str, data: dict[str, Any]) -> dict[str, Any]:
     action = data.get("action", "")
 
-    # Flag to track if this is a restart scenario (snapshot requested but none exists)
-    is_restart_scenario = False
-
     if action == "snapshot":
         snap = battle_snapshots.get(run_id)
         if snap is not None:
             return snap
-        is_restart_scenario = True
         action = ""
         data = {k: v for k, v in data.items() if k != "action"}
 
@@ -126,8 +122,8 @@ async def battle_room(run_id: str, data: dict[str, Any]) -> dict[str, Any]:
     node = rooms[state["current"]]
     if node.room_type not in {"battle-weak", "battle-normal"}:
         raise ValueError("invalid room")
-    # Only check awaiting flags if this is NOT a restart scenario
-    if not is_restart_scenario and (
+    # Check awaiting flags before attempting to launch a new battle
+    if (
         state.get("awaiting_card")
         or state.get("awaiting_relic")
         or state.get("awaiting_loot")

--- a/backend/tests/test_battle_room_reward_restart.py
+++ b/backend/tests/test_battle_room_reward_restart.py
@@ -1,0 +1,47 @@
+import asyncio
+import importlib.util
+from pathlib import Path
+import sys
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from game import battle_snapshots
+from game import battle_tasks
+from game import load_map
+from game import save_map
+from services.room_service import battle_room
+from services.run_service import start_run
+
+
+@pytest.fixture()
+def app_module(tmp_path, monkeypatch):
+    db_path = tmp_path / "save.db"
+    monkeypatch.setenv("AF_DB_PATH", str(db_path))
+    monkeypatch.setenv("AF_DB_KEY", "testkey")
+    spec = importlib.util.spec_from_file_location(
+        "app", Path(__file__).resolve().parents[1] / "app.py",
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.mark.asyncio
+async def test_missing_snapshot_restarts_battle(app_module):
+    run_info = await start_run(["player"])
+    run_id = run_info["run_id"]
+
+    state, rooms = await asyncio.to_thread(load_map, run_id)
+    state["awaiting_card"] = True
+    await asyncio.to_thread(save_map, run_id, state)
+
+    assert run_id not in battle_snapshots
+    assert run_id not in battle_tasks
+
+    snap = await battle_room(run_id, {})
+    assert snap["result"] == "battle"
+    assert run_id in battle_snapshots
+    assert run_id in battle_tasks


### PR DESCRIPTION
## Summary
- check awaiting flags before attempting to launch a new battle
- remove unused restart flag from `battle_room`

## Testing
- `ruff check . --fix`
- `uv run pytest backend/tests/test_battle_room_awaiting_next.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68c5eebead48832c84bb1c9f9414b8c9