### PR TITLE
[FIX] include summons in action queue snapshots

### DIFF
--- a/backend/.codex/implementation/battle-action-events.md
+++ b/backend/.codex/implementation/battle-action-events.md
@@ -22,5 +22,7 @@ additional effects in their `ultimate` methods or respond to the
 ## Pacing
 
 Each action calls the internal `_pace` helper, which yields for roughly half a
-second based on the time spent executing the move. This per-actor pacing keeps
+second based on the time spent executing the move. After `_turn_end` resolves,
+the loop now pauses an additional **2.2 seconds** before advancing to the next
+actor so turn-end events can finish processing. This per-actor pacing keeps
 combat readable while avoiding full-turn delays.

--- a/backend/.codex/implementation/battle-snapshots.md
+++ b/backend/.codex/implementation/battle-snapshots.md
@@ -19,6 +19,8 @@ poll for results:
   Both maps are keyed by the owning combatant's id and store arrays of
   serialized summons. Each summon snapshot also includes an `owner_id` for
   convenience.
+- Action queue snapshots now include summons so their action gauge values are
+  serialized alongside party and foe combatants.
 - Progress snapshots now include `active_id`, the id of the combatant whose
   action produced the snapshot, so user interfaces can highlight the active
   fighter for both party and foe turns.

--- a/backend/autofighter/rooms/battle.py
+++ b/backend/autofighter/rooms/battle.py
@@ -219,10 +219,7 @@ class BattleRoom(Room):
 
         # Initialize a visual action queue for UI snapshots (mid-left action bar)
         try:
-            q_entities = [
-                e for e in list(combat_party.members) + list(foes)
-                if not isinstance(e, Summon)
-            ]
+            q_entities = list(combat_party.members) + list(foes)
             _visual_queue = ActionQueue(q_entities)
         except Exception:
             _visual_queue = None
@@ -270,6 +267,8 @@ class BattleRoom(Room):
         ) -> dict[str, list[dict[str, Any]]]:
             snapshots: dict[str, list[dict[str, Any]]] = {}
             for ent in entities:
+                if isinstance(ent, Summon):
+                    continue
                 sid = getattr(ent, "id", str(id(ent)))
                 for summon in SummonManager.get_summons(sid):
                     snap = _serialize(summon)
@@ -279,11 +278,7 @@ class BattleRoom(Room):
 
         def _queue_snapshot() -> list[dict[str, Any]]:
             ordered = sorted(
-                [
-                    c
-                    for c in combat_party.members + foes
-                    if not isinstance(c, Summon)
-                ],
+                combat_party.members + foes,
                 key=lambda c: getattr(c, "action_value", 0.0),
             )
             extras: list[dict[str, Any]] = []
@@ -759,8 +754,9 @@ class BattleRoom(Room):
                                 "active_id": member.id,
                             }
                         )
-                    await _turn_end(member)
                     await _pace(action_start)
+                    await _turn_end(member)
+                    await asyncio.sleep(2.2)
                     await asyncio.sleep(0.001)
                     if battle_over:
                         break
@@ -890,8 +886,9 @@ class BattleRoom(Room):
                                     "active_id": acting_foe.id,
                                 }
                             )
-                        await _turn_end(acting_foe)
                         await _pace(action_start)
+                        await _turn_end(acting_foe)
+                        await asyncio.sleep(2.2)
                         await asyncio.sleep(0.001)
                         break
                     dmg = await target.apply_damage(acting_foe.atk, attacker=acting_foe)
@@ -974,8 +971,9 @@ class BattleRoom(Room):
                                 "active_id": acting_foe.id,
                             }
                         )
-                    await _turn_end(acting_foe)
                     await _pace(action_start)
+                    await _turn_end(acting_foe)
+                    await asyncio.sleep(2.2)
                     await asyncio.sleep(0.001)
                     if battle_over:
                         break


### PR DESCRIPTION
## Summary
- include summons in visual action queue and snapshot serialization
- pace turn end before queue advancement with a 2.2s delay after `_turn_end` for party and foe turns
- document per-turn pacing including post-turn delay

## Testing
- `uv run ruff check . --fix`
- `./run-tests.sh` *(fails: tests/test_accelerate_dependency.py::test_accelerate_missing_error, tests/test_accelerate_dependency.py::test_accelerate_not_needed_with_explicit_device, tests/test_accelerate_fix_verification.py::test_accelerate_fix_verification, tests/test_aggro_property.py::test_player_has_aggro_property, tests/test_aggro_property.py::test_foe_has_aggro_property, ...)*

------
https://chatgpt.com/codex/tasks/task_b_68c5f656e150832c9bd2418808b1095f