### PR TITLE
fix: reset snapshot counter on poll restart

### DIFF
--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -488,6 +488,7 @@
 
   function startBattlePoll() {
     stopBattlePoll(); // Clear any existing timer
+    missingSnapTicks = 0;
     try {
       if (typeof window !== 'undefined' && (window.afRewardOpen === true || window.afReviewOpen === true)) return;
     } catch {}


### PR DESCRIPTION
## Summary
- reset `missingSnapTicks` when starting a new battle poll to avoid stale reconnect errors

## Testing
- `uv run ruff check . --fix`
- `./run-tests.sh` (fail: missing modules and other test failures)


------
https://chatgpt.com/codex/tasks/task_b_68c7134c1c08832c991eeae222ebef94