### PR TITLE
[BUGFIX] add safe shutdown and request_shutdown

### DIFF
--- a/backend/.codex/implementation/error-handling.md
+++ b/backend/.codex/implementation/error-handling.md
@@ -1,0 +1,17 @@
+# Error Handling and Shutdown
+
+`request_shutdown()` provides a safe shutdown path for the backend. The
+coroutine cancels active tasks, flushes queued log records, shuts down the Quart
+application, and stops the running event loop.
+
+Battle errors and unhandled exceptions invoke this helper automatically so the
+server exits instead of continuing in a bad state. When debugging, you can
+trigger the same behavior manually:
+
+```python
+from app import request_shutdown
+await request_shutdown()
+```
+
+Using this helper ensures buffered logs are written to disk before the process
+terminates.

--- a/backend/.codex/implementation/logging.md
+++ b/backend/.codex/implementation/logging.md
@@ -10,6 +10,13 @@ log = logging.getLogger(__name__)
 
 Use `log.debug`, `log.info`, and so on instead of `print`. Records propagate through the queued buffer and are written to `backend/logs/backend.log` roughly every 15 seconds.
 
+## Safe Shutdown
+
+`request_shutdown()` flushes buffered log handlers before stopping the event
+loop. Battle errors and unhandled exceptions call this helper automatically, but
+it can also be imported and awaited manually during debugging to guarantee that
+all log messages reach disk.
+
 ## Battle Modules
 
 ```python

--- a/backend/README.md
+++ b/backend/README.md
@@ -46,6 +46,17 @@ The backend uses a queued, buffered logging pipeline:
 - Records land in a rotating log file at `logs/backend.log`.
 - A `RichHandler` remains attached for colorful console output.
 
+## Safe Shutdown
+
+`request_shutdown()` cancels running tasks, flushes buffered logs, and stops the event loop.
+Battle errors and unhandled exceptions call it automatically. During debugging,
+you can invoke it manually:
+
+```python
+from app import request_shutdown
+await request_shutdown()
+```
+
 ## Performance and Memory Metrics
 
 `GET /performance/metrics` exposes the sizes of the in-memory battle tracking structures (`battle_tasks`, `battle_snapshots`, and `battle_locks`) along with current process memory usage (via `psutil` if installed or `tracemalloc` otherwise). Operators can trigger manual cleanup of completed battles with `POST /performance/gc`, which purges stale state and runs garbage collection.

--- a/backend/game.py
+++ b/backend/game.py
@@ -484,6 +484,9 @@ async def _run_battle(
                 await asyncio.to_thread(save_party, run_id, party)
             except Exception:
                 pass
+            from app import request_shutdown
+
+            await request_shutdown()
             return
         state["battle"] = False
         try:

--- a/backend/tests/test_battle_shutdown_on_error.py
+++ b/backend/tests/test_battle_shutdown_on_error.py
@@ -1,0 +1,51 @@
+import asyncio
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+from autofighter.rooms import BattleRoom
+
+
+@pytest.fixture()
+def app_with_shutdown(tmp_path, monkeypatch):
+    db_path = tmp_path / "save.db"
+    monkeypatch.setenv("AF_DB_PATH", str(db_path))
+    monkeypatch.setenv("AF_DB_KEY", "testkey")
+    monkeypatch.syspath_prepend(Path(__file__).resolve().parents[1])
+    spec = importlib.util.spec_from_file_location(
+        "app", Path(__file__).resolve().parents[1] / "app.py",
+    )
+    app_module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(app_module)
+    app_module.app.testing = True
+    return app_module
+
+
+@pytest.mark.asyncio
+async def test_battle_error_triggers_shutdown(app_with_shutdown, monkeypatch):
+    app_module = app_with_shutdown
+    app = app_module.app
+    client = app.test_client()
+
+    async def boom(self, party, data, progress, foe=None):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(BattleRoom, "resolve", boom)
+
+    loop = asyncio.get_running_loop()
+
+    def stop() -> None:
+        raise SystemExit
+
+    monkeypatch.setattr(loop, "stop", stop)
+
+    start_resp = await client.post("/run/start", json={"party": ["player"]})
+    run_id = (await start_resp.get_json())["run_id"]
+
+    await client.post(f"/rooms/{run_id}/battle")
+    task = app_module.battle_tasks[run_id]
+
+    with pytest.raises(SystemExit):
+        await task

--- a/backend/tests/test_error_handler.py
+++ b/backend/tests/test_error_handler.py
@@ -21,18 +21,27 @@ def app_client(tmp_path, monkeypatch):
     spec.loader.exec_module(app_module)
     app_module.app.testing = True
 
+    called = {"flag": False}
+
+    async def fake_shutdown() -> None:
+        called["flag"] = True
+
+    monkeypatch.setattr(app_module, "request_shutdown", fake_shutdown)
+
     @app_module.app.route("/explode")
     async def explode() -> None:
         raise RuntimeError("boom")
 
-    return app_module.app.test_client()
+    return app_module.app.test_client(), called
 
 
 @pytest.mark.asyncio
 async def test_error_handler_returns_traceback(app_client):
-    response = await app_client.get("/explode")
+    client, called = app_client
+    response = await client.get("/explode")
     assert response.status_code == 500
     data = await response.get_json()
     assert "traceback" in data
     assert "RuntimeError" in data["traceback"]
     assert response.headers["Access-Control-Allow-Origin"] == "*"
+    assert called["flag"] is True


### PR DESCRIPTION
## Summary
- add `request_shutdown` coroutine to stop Quart loop and flush logs
- invoke shutdown from battle errors and global error handler
- document safe shutdown behavior and add regression tests

## Testing
- `uv sync`
- `uv tool run ruff check backend --fix`
- `./run-tests.sh` *(fails: ModuleNotFoundError: No module named 'battle_logging')*


------
https://chatgpt.com/codex/tasks/task_b_68c71d07855c832cb57c731d92af3c95