### PR TITLE
[BUGFIX] avoid backend shutdown on HTTP errors

### DIFF
--- a/backend/tests/test_error_handler.py
+++ b/backend/tests/test_error_handler.py
@@ -45,3 +45,13 @@ async def test_error_handler_returns_traceback(app_client):
     assert "RuntimeError" in data["traceback"]
     assert response.headers["Access-Control-Allow-Origin"] == "*"
     assert called["flag"] is True
+
+
+@pytest.mark.asyncio
+async def test_http_exception_does_not_shutdown(app_client):
+    client, called = app_client
+    response = await client.get("/missing")
+    assert response.status_code == 404
+    data = await response.get_json()
+    assert "traceback" not in data
+    assert called["flag"] is False


### PR DESCRIPTION
## Summary
- only call `request_shutdown` for non-HTTP exceptions
- add regression test covering HTTP errors

## Testing
- `uv tool run ruff check backend --fix`
- `uv run pytest backend/tests/test_error_handler.py -q`
- `./run-tests.sh` *(fails: ModuleNotFoundError: No module named 'battle_logging')*


------
https://chatgpt.com/codex/tasks/task_b_68c727f862bc832caf34f38d257682e8