### PR TITLE
[FIX] End runs on legacy rest rooms

### DIFF
--- a/backend/services/room_service.py
+++ b/backend/services/room_service.py
@@ -402,4 +402,6 @@ async def room_action(run_id: str, room_id: str, action_data: dict[str, Any] | N
         return await shop_room(run_id, request_data)
     if room_type == "chat":
         return await chat_room(run_id, request_data)
+    if room_type == "rest":
+        raise LookupError("run ended or room out of range")
     raise ValueError(f"Unsupported room type: {room_type}")


### PR DESCRIPTION
## Summary
- end runs gracefully when encountering legacy rest rooms

## Testing
- `uv run ruff check . --fix`
- `./run-tests.sh` *(fail: backend tests/test_app.py, backend tests/test_app_without_llm_deps.py, backend tests/test_character_editor.py, backend tests/test_damage_by_action_tracking.py, backend tests/test_damage_type_persistence.py, backend tests/test_gacha.py, backend tests/test_new_upgrade_system.py, backend tests/test_players_user.py timed out)*

------
https://chatgpt.com/codex/tasks/task_b_68c743d91f84832c90a80f6b3e767040