### PR TITLE
fix: prevent duplicate reward automation

### DIFF
--- a/frontend/src/lib/components/RewardOverlay.svelte
+++ b/frontend/src/lib/components/RewardOverlay.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { createEventDispatcher, onMount } from 'svelte';
+  import { createEventDispatcher, onDestroy } from 'svelte';
   import RewardCard from './RewardCard.svelte';
   import CurioChoice from './CurioChoice.svelte';
 
@@ -15,16 +15,6 @@
   const dispatch = createEventDispatcher();
 
   // Render immediately; CSS animations handle reveal on mount
-  onMount(() => {
-    if (fullIdleMode) {
-      if (cards.length > 0) {
-        dispatch('select', { type: 'card', id: cards[0].id });
-      } else if (relics.length > 0) {
-        dispatch('select', { type: 'relic', id: relics[0].id });
-      }
-      setTimeout(() => dispatch('next'), 0);
-    }
-  });
 
   function titleForItem(item) {
     if (!item) return '';
@@ -62,7 +52,6 @@
     }
   }
   // Cleanup timer on unmount
-  import { onDestroy } from 'svelte';
   onDestroy(() => clearTimeout(autoTimer));
 
   // Show Next Room button when there's loot but no choices


### PR DESCRIPTION
## Summary
- remove overlay auto-dispatch to avoid duplicate reward handling when idle mode is active

## Testing
- `bun run lint`
- `ruff check . --fix`
- `./run-tests.sh` *(fails: missing card placeholder asset; vi.mock is not a function in floor-transition.test.js)*

------
https://chatgpt.com/codex/tasks/task_b_68c7444ab354832c8d8bcbe087ef6dd9