### PR TITLE
[REF] offload battle setup to threads

### DIFF
--- a/backend/autofighter/rooms/battle.py
+++ b/backend/autofighter/rooms/battle.py
@@ -187,15 +187,19 @@ class BattleRoom(Room):
         for f in foes:
             _scale_stats(f, self.node, self.strength)
         foe = foes[0]
+
+        members = await asyncio.gather(
+            *(asyncio.to_thread(copy.deepcopy, m) for m in party.members)
+        )
         combat_party = Party(
-            members=[copy.deepcopy(m) for m in party.members],
+            members=members,
             gold=party.gold,
             relics=party.relics,
             cards=party.cards,
             rdr=party.rdr,
         )
         await apply_cards(combat_party)
-        apply_relics(combat_party)
+        await asyncio.to_thread(apply_relics, combat_party)
         party.rdr = combat_party.rdr
 
         foe_effects = []


### PR DESCRIPTION
## Summary
- offload party member deep copies to a worker thread
- run relic application in a thread to keep the event loop responsive

## Testing
- `./run-tests.sh` *(fails: asset placeholders > card placeholder exists; floor-transition.test.js error; backend tests timed out)*
- `uv tool run ruff check backend --fix`


------
https://chatgpt.com/codex/tasks/task_b_68c74b583e50832ca9408404847233dc