### PR TITLE
[FIX] preserve party member mutability during threaded copies

### DIFF
--- a/backend/autofighter/rooms/battle.py
+++ b/backend/autofighter/rooms/battle.py
@@ -188,8 +188,10 @@ class BattleRoom(Room):
             _scale_stats(f, self.node, self.strength)
         foe = foes[0]
 
-        members = await asyncio.gather(
-            *(asyncio.to_thread(copy.deepcopy, m) for m in party.members)
+        members = list(
+            await asyncio.gather(
+                *(asyncio.to_thread(copy.deepcopy, m) for m in party.members)
+            )
         )
         combat_party = Party(
             members=members,


### PR DESCRIPTION
## Summary
- ensure deep-copied party members remain mutable by converting gathered tuple to list

## Testing
- `uv tool run ruff check backend --fix`
- `./run-tests.sh` *(fails: ModuleNotFoundError: No module named 'llms'; ImportError: No module named 'battle_logging'; AssertionError in DOT tests)*

------
https://chatgpt.com/codex/tasks/task_b_68c76e5eb6ac832c9e93c9e66081627c