### PR TITLE
[FIX] Await extra turn events

### DIFF
--- a/backend/autofighter/rooms/battle.py
+++ b/backend/autofighter/rooms/battle.py
@@ -780,7 +780,7 @@ class BattleRoom(Room):
                     acting_foe.action_points = acting_foe.actions_per_turn
                     for _ in range(max(0, acting_foe.action_points - 1)):
                         try:
-                            BUS.emit("extra_turn", acting_foe)
+                            await BUS.emit_async("extra_turn", acting_foe)
                         except Exception:
                             pass
                 safety = 0


### PR DESCRIPTION
## Summary
- keep heavy extra turn subscribers off the synchronous battle path

## Testing
- `./run-tests.sh` *(fails: numerous import errors and assertion failures; run terminated)*
- `uv tool run ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_b_68c77126def0832c896fc0e58a8eeb67