### PR TITLE
Use async extra_turn emission in BattleRoom

### DIFF
--- a/backend/autofighter/rooms/battle.py
+++ b/backend/autofighter/rooms/battle.py
@@ -373,7 +373,7 @@ class BattleRoom(Room):
             ent.action_points = ent.actions_per_turn
             for _ in range(max(0, ent.action_points - 1)):
                 try:
-                    BUS.emit("extra_turn", ent)
+                    await BUS.emit_async("extra_turn", ent)
                 except Exception:
                     pass
         if progress is not None:
@@ -461,7 +461,7 @@ class BattleRoom(Room):
                     member.action_points = member.actions_per_turn
                     for _ in range(max(0, member.action_points - 1)):
                         try:
-                            BUS.emit("extra_turn", member)
+                            await BUS.emit_async("extra_turn", member)
                         except Exception:
                             pass
                 safety = 0


### PR DESCRIPTION
## Summary
- Await event bus `extra_turn` emissions when initializing action points and refreshing them mid-battle to avoid blocking
- Confirmed existing `_grant_extra_turn` subscriber remains synchronous-safe with async dispatch

## Testing
- `uv run ruff check backend/autofighter/rooms/battle.py --fix`
- `./run-tests.sh` *(fails: ModuleNotFoundError: No module named 'llms')*


------
https://chatgpt.com/codex/tasks/task_b_68c775b0f9e0832c95368838bce76a94