### PR TITLE
[DOCS] Document Carly and Luna connection

### DIFF
--- a/.codex/lore/notes/character-connections.md
+++ b/.codex/lore/notes/character-connections.md
@@ -1,0 +1,4 @@
+# Character Connections
+
+- **Carly** was built by **Luna**.
+- **Lady Darkness** recognizes **Luna** through the relic **Essence of 6858**, not through Carly. See the relic's code: [Essence of 6858](../../../backend/plugins/relics/fallback_essence.py).


### PR DESCRIPTION
## Summary
- note that Carly was built by Luna
- clarify Lady Darkness recognizes Luna through the relic Essence of 6858

## Testing
- `uv tool run ruff check . --fix`
- `./run-tests.sh` *(fails: ModuleNotFoundError: No module named 'battle_logging')*


------
https://chatgpt.com/codex/tasks/task_b_68c77ab0f194832c93a633f24d8ef949