### PR TITLE
feat: queue combat logs to background thread

### DIFF
--- a/backend/.codex/implementation/logging.md
+++ b/backend/.codex/implementation/logging.md
@@ -17,6 +17,12 @@ loop. Battle errors and unhandled exceptions call this helper automatically, but
 it can also be imported and awaited manually during debugging to guarantee that
 all log messages reach disk.
 
+## High-Frequency Combat Logs
+
+Combat loops enqueue messages via the `queue_log` helper in `rooms.battle`. A
+background worker thread processes this queue and forwards entries to the
+standard logger, ensuring combat iterations avoid synchronous I/O.
+
 ## Battle Modules
 
 ```python


### PR DESCRIPTION
## Summary
- queue high-frequency combat logs to a background thread
- document queue_log helper for combat logging

## Testing
- `./run-tests.sh` *(fails: timeout and missing modules)*
- `ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_b_68c77f6d2a10832c91b72a3f7c4a219f