### PR TITLE
fix: restore inventory button semantics

### DIFF
--- a/frontend/src/lib/components/Inventory.svelte
+++ b/frontend/src/lib/components/Inventory.svelte
@@ -231,11 +231,23 @@
     <!-- Left side: Item grid -->
     <div class="item-grid-container">
       {#if activeTab === 'cards'}
-        <CardView cards={sortedCards} select={selectItem} />
+        <CardView
+          cards={sortedCards}
+          select={selectItem}
+          selectedId={selectedItem?.type === 'card' ? selectedItem.id : null}
+        />
       {:else if activeTab === 'relics'}
-        <RelicView relics={sortedRelics} select={selectItem} />
+        <RelicView
+          relics={sortedRelics}
+          select={selectItem}
+          selectedId={selectedItem?.type === 'relic' ? selectedItem.id : null}
+        />
       {:else}
-        <MaterialsPanel materials={materialEntries} select={selectItem} />
+        <MaterialsPanel
+          materials={materialEntries}
+          select={selectItem}
+          selectedId={selectedItem?.type === 'material' ? selectedItem.id : null}
+        />
       {/if}
     </div>
 

--- a/frontend/src/lib/components/inventory/CardView.svelte
+++ b/frontend/src/lib/components/inventory/CardView.svelte
@@ -1,14 +1,58 @@
 <script>
   import CardArt from '../CardArt.svelte';
+
   export let cards = [];
   export let select = () => {};
+  export let selectedId = null;
 </script>
 
-<div class="card-view">
+<div class="cards-grid">
   {#each cards as [entry, qty]}
-    <div class="card-item" on:click={() => select(entry.id, 'card', qty)}>
+    <button
+      type="button"
+      class="card-cell"
+      class:selected={selectedId === entry.id}
+      on:click={() => select(entry.id, 'card', qty)}
+      aria-label={entry.name}
+    >
       <CardArt {entry} type="card" />
-      <span class="qty">{qty}</span>
-    </div>
+      <span class="qty-badge">{qty}</span>
+    </button>
   {/each}
 </div>
+
+<style>
+  .cards-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+    gap: 0.25rem;
+    align-items: start;
+    justify-items: center;
+  }
+
+  .card-cell {
+    position: relative;
+    padding: 0;
+    border: none;
+    background: none;
+    cursor: pointer;
+  }
+
+  .card-cell.selected {
+    outline: 2px solid rgba(120, 180, 255, 0.6);
+    outline-offset: 2px;
+  }
+
+  .qty-badge {
+    position: absolute;
+    top: 6px;
+    right: 10px;
+    background: rgba(0, 0, 0, 0.7);
+    color: #fff;
+    border: 1px solid rgba(255, 255, 255, 0.3);
+    padding: 0 0.35rem;
+    font-size: 0.8rem;
+    line-height: 1.1rem;
+    border-radius: 6px;
+  }
+</style>

--- a/frontend/src/lib/components/inventory/MaterialsPanel.svelte
+++ b/frontend/src/lib/components/inventory/MaterialsPanel.svelte
@@ -1,14 +1,69 @@
 <script>
   import { getMaterialIcon, onIconError } from '../../systems/materialAssetLoader.js';
+
   export let materials = [];
   export let select = () => {};
+  export let selectedId = null;
 </script>
 
 <div class="materials-grid">
   {#each materials as [id, qty]}
-    <div class="material" on:click={() => select(id, 'material', qty)}>
-      <img src={getMaterialIcon(id)} alt={id} on:error={onIconError} />
-      <span class="qty">{qty}</span>
-    </div>
+    <button
+      type="button"
+      class="grid-item"
+      class:selected={selectedId === id}
+      on:click={() => select(id, 'material', qty)}
+      aria-label={id}
+    >
+      <img class="item-icon" src={getMaterialIcon(id)} alt={id} on:error={onIconError} />
+      <span class="item-quantity">×{qty}</span>
+    </button>
   {/each}
 </div>
+
+<style>
+  .materials-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(80px, 1fr));
+    gap: 0.75rem;
+    align-items: start;
+  }
+
+  .grid-item {
+    background: rgba(255, 255, 255, 0.05);
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    padding: 0.5rem;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    position: relative;
+    aspect-ratio: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .grid-item:hover {
+    background: rgba(255, 255, 255, 0.1);
+    border-color: rgba(120, 180, 255, 0.5);
+  }
+
+  .grid-item.selected {
+    background: rgba(120, 180, 255, 0.2);
+    border-color: rgba(120, 180, 255, 0.7);
+    box-shadow: 0 0 8px rgba(120, 180, 255, 0.3);
+  }
+
+  .item-icon {
+    width: 100%;
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .item-quantity {
+    font-size: 0.7rem;
+    color: rgba(255, 255, 255, 0.88);
+  }
+</style>

--- a/frontend/src/lib/components/inventory/RelicView.svelte
+++ b/frontend/src/lib/components/inventory/RelicView.svelte
@@ -1,14 +1,53 @@
 <script>
   import CurioChoice from '../CurioChoice.svelte';
+
   export let relics = [];
   export let select = () => {};
+  export let selectedId = null;
 </script>
 
-<div class="relic-view">
+<div class="relics-grid">
   {#each relics as [entry, qty]}
-    <div class="relic-item" on:click={() => select(entry.id, 'relic', qty)}>
+    <button
+      type="button"
+      class="relic-cell"
+      class:selected={selectedId === entry.id}
+      on:click={() => select(entry.id, 'relic', qty)}
+      aria-label={entry.name}
+    >
       <CurioChoice entry={entry} />
-      <span class="qty">{qty}</span>
-    </div>
+      <span class="relic-qty">{qty}</span>
+    </button>
   {/each}
 </div>
+
+<style>
+  .relics-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+    gap: 1.25rem;
+    align-items: start;
+    justify-items: center;
+  }
+
+  .relic-cell {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.25rem;
+    padding: 0;
+    border: none;
+    background: none;
+    cursor: pointer;
+  }
+
+  .relic-cell.selected {
+    outline: 2px solid rgba(120, 180, 255, 0.6);
+    outline-offset: 4px;
+  }
+
+  .relic-qty {
+    font-size: 0.85rem;
+    opacity: 0.9;
+  }
+</style>


### PR DESCRIPTION
## Summary
- render CardView, RelicView, and MaterialsPanel items as buttons with selection styling
- thread current selection through Inventory.svelte for accessible focus and highlighting

## Testing
- `bun run lint`
- `bun test` *(failing: asset placeholder, party persistence, state polling, inventory subcomponent tests)*

------
https://chatgpt.com/codex/tasks/task_b_68c80f2d00f0832c9db6571b771805d8