### PR TITLE
Refactor frontend into modular components

### DIFF
--- a/frontend/src/lib/components/CombatViewer.svelte
+++ b/frontend/src/lib/components/CombatViewer.svelte
@@ -8,7 +8,6 @@
   import MenuPanel from './MenuPanel.svelte';
   import { getCatalogData } from '../systems/uiApi.js';
   import { getElementColor, getCharacterImage } from '../systems/assetLoader.js';
-  import PartyRoster from './PartyRoster.svelte';
   import PlayerPreview from './PlayerPreview.svelte';
   import { Circle } from 'lucide-svelte';
   import Spinner from './Spinner.svelte';
@@ -328,10 +327,6 @@
   function handleClose() {
     dispatch('close');
   }
-
-  function selectCharacter(id) {
-    selectedCharacterId = id;
-  }
 </script>
 
 <MenuPanel>
@@ -342,30 +337,15 @@
     </div>
     
     <div class="viewer-content">
-      <PartyView {party} />
-      <FoeView {foes} />
-      <!-- Left panel: Use PartyRoster styling (read-only) -->
       <div class="character-roster">
-        <div class="roster-section">
-          <h4 class="roster-title">Party</h4>
-          <PartyRoster
-            roster={viewerRoster.filter(r => r.is_player)}
-            selected={[selectedCharacterId].filter(Boolean)}
-            bind:previewId={selectedCharacterId}
-            reducedMotion={true}
-            on:toggle={() => { /* read-only: suppress */ }}
-          />
-        </div>
-        <div class="roster-section">
-          <h4 class="roster-title">Foes</h4>
-          <PartyRoster
-            roster={viewerRoster.filter(r => !r.is_player)}
-            selected={[selectedCharacterId].filter(Boolean)}
-            bind:previewId={selectedCharacterId}
-            reducedMotion={true}
-            on:toggle={() => { /* read-only: suppress */ }}
-          />
-        </div>
+        <PartyView
+          roster={viewerRoster.filter(r => r.is_player)}
+          bind:selectedId={selectedCharacterId}
+        />
+        <FoeView
+          roster={viewerRoster.filter(r => !r.is_player)}
+          bind:selectedId={selectedCharacterId}
+        />
       </div>
 
       <!-- Center panel: Big portrait (use PlayerPreview from Party menu) -->

--- a/frontend/src/lib/components/combat-viewer/FoeView.svelte
+++ b/frontend/src/lib/components/combat-viewer/FoeView.svelte
@@ -1,9 +1,18 @@
 <script>
-  export let foes = [];
+  import PartyRoster from '../PartyRoster.svelte';
+
+  export let roster = [];
+  export let selectedId = null;
 </script>
 
-<div class="foe-view">
-  {#each foes as foe}
-    <div class="foe-member">{foe.name}</div>
-  {/each}
+<div class="roster-section foe-view">
+  <h4 class="roster-title">Foes</h4>
+  <PartyRoster
+    {roster}
+    selected={[selectedId].filter(Boolean)}
+    bind:previewId={selectedId}
+    reducedMotion={true}
+    on:toggle={() => {}}
+  />
 </div>
+

--- a/frontend/src/lib/components/combat-viewer/HpStatus.svelte
+++ b/frontend/src/lib/components/combat-viewer/HpStatus.svelte
@@ -4,6 +4,9 @@
   export let maxHp = 1;
 </script>
 
-<div class="hp-status">
-  {Math.round(hpPercent(hp, maxHp) * 100)}%
+<div class="stat hp-status">
+  <label>HP:</label>
+  <span>
+    {hp}/{maxHp} ({Math.round(hpPercent(hp, maxHp) * 100)}%)
+  </span>
 </div>

--- a/frontend/src/lib/components/combat-viewer/PartyView.svelte
+++ b/frontend/src/lib/components/combat-viewer/PartyView.svelte
@@ -1,9 +1,18 @@
 <script>
-  export let party = [];
+  import PartyRoster from '../PartyRoster.svelte';
+
+  export let roster = [];
+  export let selectedId = null;
 </script>
 
-<div class="party-view">
-  {#each party as member}
-    <div class="party-member">{member.name}</div>
-  {/each}
+<div class="roster-section party-view">
+  <h4 class="roster-title">Party</h4>
+  <PartyRoster
+    {roster}
+    selected={[selectedId].filter(Boolean)}
+    bind:previewId={selectedId}
+    reducedMotion={true}
+    on:toggle={() => {}}
+  />
 </div>
+


### PR DESCRIPTION
## Summary
- Replace duplicated party/foe lists with PartyView and FoeView modules leveraging PartyRoster and shared selection state
- Restore HP stat row with current and maximum values via HpStatus component

## Testing
- `bun run lint`
- `bun test` *(failing: Party persistence, inventory subcomponents, asset placeholders, state polling)*

------
https://chatgpt.com/codex/tasks/task_b_68c813047c64832c986fbdea7bc2e23f