### PR TITLE
Remove duplicate reward sidebar in BattleReview

### DIFF
--- a/frontend/src/lib/components/BattleReview.svelte
+++ b/frontend/src/lib/components/BattleReview.svelte
@@ -427,12 +427,6 @@
     padding: 2px 4px;
   }
   .effects-block { display: flex; flex-direction: column; align-items: stretch; min-width: 8rem; }
-  .rewards {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 0.5rem;
-  }
   .effects-out { margin-top: 0.35rem; max-width: 320px; }
   .effects-section { margin-top: 0.25rem; }
   .effects-title { font-size: 0.72rem; color: #aaa; margin-bottom: 0.1rem; text-align: center; }
@@ -867,24 +861,6 @@
 
 <div class="layout review">
   
-  <div class="side rewards">
-    {#if cards.length}
-      <div class="reward-grid">
-        {#each cards.slice(0,3) as card, i (card.id)}
-          <RewardCard entry={card} type="card" on:select={handleSelect} />
-        {/each}
-      </div>
-    {/if}
-    {#if relics.length}
-      <div class="reward-grid">
-        {#each relics.slice(0,3) as relic, i (relic.id)}
-          <CurioChoice entry={relic} on:select={handleSelect} />
-        {/each}
-      </div>
-    {/if}
-  </div>
-  
-
   <!-- Top-level summary and raw events toggle -->
   <div class="side" style="grid-column: 1 / -1;">
     <div class="header">


### PR DESCRIPTION
## Summary
- remove leftover reward sidebar in BattleReview now that ReviewOverlay handles rewards

## Testing
- `bun run lint`
- `bun test` *(fails: expected party persistence and inventory selectors)*

------
https://chatgpt.com/codex/tasks/task_b_68c81a40fd04832c88165ccd77bd92cb