### PR TITLE
[FEAT] handle Luna ultimate charge

### DIFF
--- a/backend/plugins/damage_types/generic.py
+++ b/backend/plugins/damage_types/generic.py
@@ -21,9 +21,7 @@ class Generic(DamageTypeBase):
         if not getattr(actor, "use_ultimate", lambda: False)():
             return False
 
-
         from autofighter.stats import BUS  # Import here to avoid circular imports
-        from plugins.passives.luna_lunar_reservoir import LunaLunarReservoir as _LLR_old
 
         registry = PassiveRegistry()
         target_pool = (
@@ -34,6 +32,8 @@ class Generic(DamageTypeBase):
         if not target_pool:
             return True
         target = target_pool[0]
+
+        await registry.trigger("ultimate_used", actor, party=allies, foes=enemies)
 
         base = actor.atk // 64
         remainder = actor.atk % 64
@@ -60,11 +60,6 @@ class Generic(DamageTypeBase):
                 foes=enemies,
             )
             await asyncio.sleep(0.002)
-        from plugins.passives.luna_lunar_reservoir import LunaLunarReservoir
-
-        if LunaLunarReservoir is not _LLR_old:
-            _LLR_old.add_charge(actor, amount=64)
-        LunaLunarReservoir.add_charge(actor, amount=64)
         return True
 
     @classmethod

--- a/backend/plugins/passives/luna_lunar_reservoir.py
+++ b/backend/plugins/passives/luna_lunar_reservoir.py
@@ -14,23 +14,32 @@ class LunaLunarReservoir:
     plugin_type = "passive"
     id = "luna_lunar_reservoir"
     name = "Lunar Reservoir"
-    trigger = "action_taken"  # Triggers when Luna takes any action
+    trigger = ["action_taken", "ultimate_used"]  # Respond to actions and ultimates
     max_stacks = 200  # Show charge level 0-200
     stack_display = "number"
 
     # Class-level tracking of charge points for each entity
     _charge_points: ClassVar[dict[int, int]] = {}
 
-    async def apply(self, target: "Stats") -> None:
-        """Apply charge mechanics for Luna."""
+    async def apply(self, target: "Stats", event: str = "action_taken", **_: object) -> None:
+        """Apply charge mechanics for Luna.
+
+        Args:
+            target: Entity gaining charge.
+            event: Triggering event name.
+        """
         entity_id = id(target)
 
         # Initialize charge if not present
         if entity_id not in self._charge_points:
             self._charge_points[entity_id] = 0
 
-        # Grant 1 charge point per action
-        self._charge_points[entity_id] += 1
+        # Grant charge based on event type
+        if event == "ultimate_used":
+            self._charge_points[entity_id] += 64
+        else:
+            self._charge_points[entity_id] += 1
+
         current_charge = self._charge_points[entity_id]
 
         # Determine attack count based on charge level

--- a/backend/tests/test_generic_ultimate.py
+++ b/backend/tests/test_generic_ultimate.py
@@ -1,9 +1,9 @@
 import pytest
 
+from autofighter.passives import PassiveRegistry
 from autofighter.stats import BUS
 from autofighter.stats import Stats
 from plugins.damage_types.generic import Generic
-from plugins.passives.luna_lunar_reservoir import LunaLunarReservoir
 
 
 class Actor(Stats):
@@ -18,7 +18,9 @@ class Actor(Stats):
 
 @pytest.mark.asyncio
 async def test_generic_ultimate_hits_and_passive_triggers():
-    LunaLunarReservoir._charge_points.clear()
+    registry = PassiveRegistry()
+    llr = registry._registry["luna_lunar_reservoir"]
+    llr._charge_points.clear()
 
     actor = Actor(damage_type=Generic(), passives=["luna_lunar_reservoir"])
     actor.id = "luna"
@@ -47,4 +49,4 @@ async def test_generic_ultimate_hits_and_passive_triggers():
 
     assert result is True
     assert hits["count"] == 64
-    assert LunaLunarReservoir.get_charge(actor) >= 64
+    assert llr.get_charge(actor) >= 64


### PR DESCRIPTION
## Summary
- support ultimate-based charge gains in Luna's Lunar Reservoir passive
- trigger passive events for ultimates in Generic damage type and drop manual charge hook
- test ultimate charge increase without direct passive import

## Testing
- `uv tool run ruff check backend --fix`
- `./run-tests.sh` *(fails: async def functions are not natively supported)*

------
https://chatgpt.com/codex/tasks/task_b_68c8342c202c832caeaa3e87be0e662b