### PR TITLE
Fix battle engine shared state preservation

### DIFF
--- a/backend/autofighter/rooms/battle/engine.py
+++ b/backend/autofighter/rooms/battle/engine.py
@@ -76,8 +76,10 @@ async def run_battle(
     visual_queue = setup_data.visual_queue
     battle_logger = setup_data.battle_logger
 
-    battle_snapshots = battle_snapshots or {}
-    battle_tasks = battle_tasks or {}
+    if battle_snapshots is None:
+        battle_snapshots = {}
+    if battle_tasks is None:
+        battle_tasks = {}
 
     for foe_obj in foes:
         await BUS.emit_async("battle_start", foe_obj)


### PR DESCRIPTION
## Summary
- delegate `BattleRoom.resolve` to a new async engine helper and keep patched enrage thresholds
- implement `run_battle` to drive the combat loop, event emissions, rewards, and post-battle cleanup with display tweaks
- expose enrage constants via the rooms package and add an async regression test for the new engine
- preserve shared battle snapshot and task dictionaries when provided to the async engine

## Testing
- PYTHONPATH=backend:. uv run pytest backend/tests/test_battle_engine_async.py
- PYTHONPATH=backend:. uv run pytest backend/tests/test_enrage_stacking.py

------
https://chatgpt.com/codex/tasks/task_b_68c8c1298398832cad5ba7c75d3ecd40