### PR TITLE
Improve battle setup async helpers

### DIFF
--- a/backend/.codex/implementation/battle-setup.md
+++ b/backend/.codex/implementation/battle-setup.md
@@ -1,0 +1,13 @@
+# Battle Setup Thread Offloading
+
+The battle setup routine performs a few heavy operations that would otherwise block the event loop:
+
+- Deep cloning each `Stats` instance in the party before combat begins.
+- Applying relic effects, which mutates the party and can perform database or file lookups depending on relic behavior.
+
+To keep setup responsive, both steps are dispatched to worker threads via `asyncio.to_thread()`:
+
+- `_clone_members()` wraps the `copy.deepcopy` call so member cloning runs in a thread pool and returns the cloned list asynchronously.
+- `_apply_relics_async()` forwards the existing `apply_relics()` call to a worker thread and awaits completion.
+
+`setup_battle()` awaits both helpers, ensuring callers see consistent state without blocking other async tasks while the work is performed.

--- a/backend/autofighter/rooms/battle/setup.py
+++ b/backend/autofighter/rooms/battle/setup.py
@@ -1,6 +1,7 @@
 """Battle setup helpers for :mod:`autofighter.rooms.battle`."""
 from __future__ import annotations
 
+import asyncio
 import copy
 from dataclasses import dataclass
 from typing import Sequence
@@ -40,13 +41,16 @@ class BattleSetupResult:
 async def _clone_members(members: Sequence[Stats]) -> list[Stats]:
     """Create deep copies of party members for combat."""
 
-    return [copy.deepcopy(member) for member in members]
+    def _copy_members() -> list[Stats]:
+        return [copy.deepcopy(member) for member in members]
+
+    return await asyncio.to_thread(_copy_members)
 
 
 async def _apply_relics_async(party: Party) -> None:
     """Asynchronously apply relic effects to a party."""
 
-    apply_relics(party)
+    await asyncio.to_thread(apply_relics, party)
 
 
 async def setup_battle(


### PR DESCRIPTION
## Summary
- offload party cloning and relic application in battle setup to `asyncio.to_thread` helpers
- document the non-blocking battle setup behavior in backend `.codex`

## Testing
- `uv run ruff check autofighter/rooms/battle/setup.py`
- `uv run pytest` *(fails: known missing accelerate features and other pre-existing test failures; run interrupted after several minutes)*

------
https://chatgpt.com/codex/tasks/task_b_68c930868ed4832cbef1fe95b486f476