### PR TITLE
feat: expose turn pacing configuration

### DIFF
--- a/backend/autofighter/rooms/battle/pacing.py
+++ b/backend/autofighter/rooms/battle/pacing.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import math
 
 from options import OptionKey
 from options import get_option
@@ -30,6 +31,10 @@ def _coerce_turn_pacing(raw: object) -> float:
         value = float(raw)
     except (TypeError, ValueError):
         return DEFAULT_TURN_PACING
+
+    if not math.isfinite(value):
+        return DEFAULT_TURN_PACING
+
     if value <= 0:
         return _MIN_TURN_PACING
     return value

--- a/backend/routes/config.py
+++ b/backend/routes/config.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import math
+
 from llms.loader import ModelName
 from options import OptionKey
 from options import get_option
@@ -67,6 +69,9 @@ async def update_turn_pacing() -> tuple[str, int, dict[str, float]]:
         requested = float(data["turn_pacing"])
     except (TypeError, ValueError):
         return jsonify({"error": "turn_pacing must be numeric"}), 400
+
+    if not math.isfinite(requested):
+        return jsonify({"error": "turn_pacing must be finite"}), 400
 
     if requested <= 0:
         return jsonify({"error": "turn_pacing must be positive"}), 400


### PR DESCRIPTION
## Summary
- add OptionKey constants so configuration keys (including turn_pacing) can be reused safely
- load battle pacing from the persisted turn_pacing option and expose helpers to refresh it at runtime
- expose /config/turn-pacing API endpoints and document the setting in the backend settings menu reference
- reject non-finite turn pacing updates and ensure runtime refreshes fall back to defaults when persisted pacing is invalid

## Testing
- [x] Backend tests (uv run pytest backend/tests/test_config_lrm.py)
- [x] Linting (uv run ruff check . --fix)
- [x] Doc sync updates

------
https://chatgpt.com/codex/tasks/task_b_68c9530b7db4832c9f5fe66a8ea10f58