### PR TITLE
feat: add animation speed setting

### DIFF
--- a/frontend/.codex/implementation/settings-menu.md
+++ b/frontend/.codex/implementation/settings-menu.md
@@ -23,3 +23,5 @@ Audio volume controls use the `DotSelector` component to render ten selectable l
 `SettingsMenu.svelte` handles tab selection, LRM configuration, and dispatches `save` and `endRun` events. `SettingsMenu.svelte` receives `backendFlavor` from the page and checks it for `"llm"` to decide whether the LLM tab should appear. When the flavor string omits `"llm"`, the component skips `getLrmConfig()` and hides the model selector and test button.
 
 The Gameplay tab's **End Run** button now attempts to end the current run by ID and falls back to clearing all runs when the ID is missing or the targeted request fails.
+
+The Gameplay tab also exposes an **Animation Speed** slider (0.1–2.0×). Adjusting it writes the selected multiplier to settings storage and posts the derived turn pacing (`base_turn_pacing / animationSpeed`) to `/config/turn_pacing` so backend battle pacing matches the UI setting.

--- a/frontend/src/lib/components/GameViewport.svelte
+++ b/frontend/src/lib/components/GameViewport.svelte
@@ -41,6 +41,7 @@
   export let selected = [];
   export let backendFlavor = '';
   export let fullIdleMode = false;
+  export let animationSpeed = 1;
 
   let randomBg = '';
   let roster = [];
@@ -61,7 +62,7 @@
       randomBg = getHourlyBackground();
     }
     const init = await loadInitialState();
-      ({ sfxVolume, musicVolume, voiceVolume, framerate, reducedMotion, showActionValues, fullIdleMode } =
+      ({ sfxVolume, musicVolume, voiceVolume, framerate, reducedMotion, showActionValues, fullIdleMode, animationSpeed } =
         init.settings);
     roster = init.roster;
     userState = init.user;
@@ -294,6 +295,7 @@
         {reducedMotion}
         {showActionValues}
         {fullIdleMode}
+        bind:animationSpeed
         {selectedParty}
         {battleActive}
         {backendFlavor}
@@ -309,7 +311,7 @@
       on:editorChange={(e) => dispatch('editorChange', e.detail)}
       on:loadRun={(e) => dispatch('loadRun', e.detail)}
       on:startNewRun={() => dispatch('startNewRun')}
-      on:saveSettings={(e) => ({ sfxVolume, musicVolume, voiceVolume, framerate, reducedMotion, showActionValues, fullIdleMode } = e.detail)}
+      on:saveSettings={(e) => ({ sfxVolume, musicVolume, voiceVolume, framerate, reducedMotion, showActionValues, fullIdleMode, animationSpeed } = e.detail)}
       on:endRun={() => dispatch('endRun')}
       on:shopBuy={(e) => dispatch('shopBuy', e.detail)}
       on:shopReroll={() => dispatch('shopReroll')}

--- a/frontend/src/lib/components/GameplaySettings.svelte
+++ b/frontend/src/lib/components/GameplaySettings.svelte
@@ -1,12 +1,31 @@
 <script>
-  import { Power } from 'lucide-svelte';
+  import { Power, Timer } from 'lucide-svelte';
   import Tooltip from './Tooltip.svelte';
+
+  const MIN_ANIMATION_SPEED = 0.1;
+  const MAX_ANIMATION_SPEED = 2;
+
   export let showActionValues = false;
   export let fullIdleMode = false;
+  export let animationSpeed = 1;
   export let scheduleSave;
   export let handleEndRun;
   export let endingRun = false;
   export let endRunStatus = '';
+
+  $: displaySpeed = (() => {
+    const numeric = Number(animationSpeed);
+    if (!Number.isFinite(numeric) || numeric <= 0) return '1.0';
+    return numeric.toFixed(1);
+  })();
+
+  function handleSpeedInput(event) {
+    const value = Number(event?.currentTarget?.value ?? animationSpeed);
+    if (!Number.isFinite(value)) return;
+    const clamped = Math.min(MAX_ANIMATION_SPEED, Math.max(MIN_ANIMATION_SPEED, value));
+    animationSpeed = Math.round(clamped * 10) / 10;
+    scheduleSave();
+  }
 </script>
 
 <div class="settings-panel">
@@ -28,6 +47,24 @@
     </div>
     <div class="control-right">
       <input type="checkbox" bind:checked={fullIdleMode} on:change={scheduleSave} />
+    </div>
+  </div>
+  <div class="control">
+    <div class="control-left">
+      <Tooltip text="Scale battle animation pacing. Higher is faster.">
+        <span class="label"><Timer /> Animation Speed</span>
+      </Tooltip>
+    </div>
+    <div class="control-right">
+      <input
+        type="range"
+        min={MIN_ANIMATION_SPEED}
+        max={MAX_ANIMATION_SPEED}
+        step="0.1"
+        value={animationSpeed}
+        on:input={handleSpeedInput}
+      />
+      <span class="value" aria-live="polite">{displaySpeed}×</span>
     </div>
   </div>
   <div class="control">

--- a/frontend/src/lib/components/OverlayHost.svelte
+++ b/frontend/src/lib/components/OverlayHost.svelte
@@ -39,6 +39,7 @@
   export let reducedMotion = false;
   export let showActionValues = false;
   export let fullIdleMode = false;
+  export let animationSpeed = 1;
   export let selectedParty = [];
   export let battleActive = false;
   export let backendFlavor = '';
@@ -284,6 +285,7 @@
       {reducedMotion}
       {showActionValues}
       {fullIdleMode}
+      bind:animationSpeed
       {runId}
       {backendFlavor}
       on:save={(e) => dispatch('saveSettings', e.detail)}

--- a/frontend/src/lib/components/SettingsMenu.svelte
+++ b/frontend/src/lib/components/SettingsMenu.svelte
@@ -1,13 +1,29 @@
 <script>
   import { createEventDispatcher, onMount } from 'svelte';
   import { Volume2, Cog, Brain, Gamepad } from 'lucide-svelte';
-  import { endRun, endAllRuns, wipeData, exportSave, importSave, getLrmConfig, setLrmModel, testLrmModel, getBackendHealth } from '../systems/api.js';
+  import {
+    endRun,
+    endAllRuns,
+    wipeData,
+    exportSave,
+    importSave,
+    getLrmConfig,
+    setLrmModel,
+    testLrmModel,
+    getBackendHealth,
+    getTurnPacing,
+    setTurnPacing
+  } from '../systems/api.js';
   import AudioSettings from './AudioSettings.svelte';
   import SystemSettings from './SystemSettings.svelte';
   import LLMSettings from './LLMSettings.svelte';
   import GameplaySettings from './GameplaySettings.svelte';
   import { getActiveRuns } from '../systems/uiApi.js';
   import { saveSettings, clearSettings, clearAllClientData } from '../systems/settingsStorage.js';
+
+  const MIN_ANIMATION_SPEED = 0.1;
+  const MAX_ANIMATION_SPEED = 2;
+  const DEFAULT_TURN_PACING = 0.5;
 
   const dispatch = createEventDispatcher();
   export let sfxVolume = 5;
@@ -17,6 +33,7 @@
   export let reducedMotion = false;
   export let showActionValues = false;
   export let fullIdleMode = false;
+  export let animationSpeed = 1;
   export let lrmModel = '';
   export let runId = '';
   export let backendFlavor = typeof window !== 'undefined' ? window.backendFlavor || '' : '';
@@ -30,12 +47,79 @@
   let lrmOptions = [];
   let testReply = '';
   let activeTab = 'audio';
+  let baseTurnPacing = DEFAULT_TURN_PACING;
+  let lastServerTurnPacing = null;
+  let lastSavedAnimationSpeed = (() => {
+    const numeric = Number(animationSpeed);
+    if (!Number.isFinite(numeric)) return 1;
+    return Math.min(MAX_ANIMATION_SPEED, Math.max(MIN_ANIMATION_SPEED, numeric));
+  })();
 
   let endingRun = false;
   let endRunStatus = '';
   let healthStatus = 'unknown'; // 'healthy' | 'degraded' | 'error' | 'unknown'
   let healthPing = null;
   let lastHealthFetch = 0;
+
+  function sanitizeSpeed(value) {
+    const numeric = Number(value);
+    if (!Number.isFinite(numeric) || numeric <= 0) return 1;
+    const clamped = Math.min(MAX_ANIMATION_SPEED, Math.max(MIN_ANIMATION_SPEED, numeric));
+    return Math.round(clamped * 10) / 10;
+  }
+
+  function resolvedBaseTurnPacing() {
+    return baseTurnPacing > 0 ? baseTurnPacing : DEFAULT_TURN_PACING;
+  }
+
+  async function loadTurnPacing() {
+    try {
+      const data = await getTurnPacing();
+      const defaultVal = Number(data?.default);
+      if (Number.isFinite(defaultVal) && defaultVal > 0) {
+        baseTurnPacing = defaultVal;
+      }
+      const serverValue = Number(data?.turn_pacing);
+      if (Number.isFinite(serverValue) && serverValue > 0) {
+        lastServerTurnPacing = serverValue;
+        const derived = sanitizeSpeed(resolvedBaseTurnPacing() / serverValue);
+        if (Math.abs(derived - Number(animationSpeed)) > 0.001) {
+          animationSpeed = derived;
+        }
+        lastSavedAnimationSpeed = derived;
+        saveSettings({ animationSpeed: derived });
+      }
+    } catch (err) {
+      console.warn('Failed to load turn pacing', err);
+    }
+  }
+
+  async function pushTurnPacing(speed) {
+    const sanitized = sanitizeSpeed(speed);
+    const base = resolvedBaseTurnPacing();
+    const target = base / sanitized;
+    if (lastServerTurnPacing !== null && Math.abs(lastServerTurnPacing - target) < 0.0001) {
+      return true;
+    }
+    try {
+      const data = await setTurnPacing(target);
+      const defaultVal = Number(data?.default);
+      if (Number.isFinite(defaultVal) && defaultVal > 0) {
+        baseTurnPacing = defaultVal;
+      }
+      const confirmed = Number(data?.turn_pacing);
+      if (Number.isFinite(confirmed) && confirmed > 0) {
+        lastServerTurnPacing = confirmed;
+      } else {
+        lastServerTurnPacing = target;
+      }
+      return true;
+    } catch (err) {
+      console.error('Failed to update turn pacing', err);
+      return false;
+    }
+  }
+
   async function refreshHealth(force = false) {
     const now = Date.now();
     if (!force && now - lastHealthFetch < 1500) return; // throttle within tab
@@ -62,30 +146,34 @@
         /* ignore */
       }
     }
+    await loadTurnPacing();
     // Preload health once so System tab has data quickly
     refreshHealth(true);
   });
   $: (activeTab === 'system') && refreshHealth(false);
 
-  function save() {
-    saveSettings({
+  async function save() {
+    const sanitizedSpeed = sanitizeSpeed(animationSpeed);
+    animationSpeed = sanitizedSpeed;
+    const numericFramerate = Number(framerate);
+    const payload = {
       sfxVolume,
       musicVolume,
       voiceVolume,
-      framerate: Number(framerate),
+      framerate: numericFramerate,
       reducedMotion,
       showActionValues,
-      fullIdleMode
-    });
-    dispatch('save', {
-      sfxVolume,
-      musicVolume,
-      voiceVolume,
-      framerate: Number(framerate),
-      reducedMotion,
-      showActionValues,
-      fullIdleMode
-    });
+      fullIdleMode,
+      animationSpeed: sanitizedSpeed
+    };
+    saveSettings(payload);
+    dispatch('save', payload);
+    if (Math.abs(sanitizedSpeed - lastSavedAnimationSpeed) > 0.001) {
+      const updated = await pushTurnPacing(sanitizedSpeed);
+      if (updated) {
+        lastSavedAnimationSpeed = sanitizedSpeed;
+      }
+    }
     saveStatus = 'Saved';
     clearTimeout(resetTimeout);
     resetTimeout = setTimeout(() => {
@@ -253,6 +341,7 @@
     <GameplaySettings
       bind:showActionValues
       bind:fullIdleMode
+      bind:animationSpeed
       {scheduleSave}
       {handleEndRun}
       {endingRun}

--- a/frontend/src/lib/components/settings-shared.css
+++ b/frontend/src/lib/components/settings-shared.css
@@ -49,6 +49,13 @@
   white-space: nowrap; /* keep label in one line so divider sits after text */
 }
 
+.settings-panel .value {
+  font-size: 0.8rem;
+  min-width: 2.6rem;
+  text-align: right;
+  opacity: 0.85;
+}
+
 /* Ensure left and right wrappers map to columns */
 .settings-panel .control-left { grid-column: 1; min-width: 0; display: flex; align-items: center; }
 .settings-panel .control-right { grid-column: 2; }

--- a/frontend/src/lib/systems/api.js
+++ b/frontend/src/lib/systems/api.js
@@ -96,6 +96,33 @@ export async function testLrmModel(prompt) {
   return httpPost('/config/lrm/test', { prompt });
 }
 
+async function fetchTurnPacing(url, options = {}, suppressOverlay = false) {
+  try {
+    return await httpRequest(url, options, null, suppressOverlay);
+  } catch (err) {
+    if (err?.status === 404 && url.includes('turn_pacing')) {
+      const fallbackUrl = url.replace('turn_pacing', 'turn-pacing');
+      return httpRequest(fallbackUrl, options, null, false);
+    }
+    throw err;
+  }
+}
+
+export async function getTurnPacing() {
+  return fetchTurnPacing('/config/turn_pacing', { method: 'GET', headers: { 'Accept': 'application/json' } }, true);
+}
+
+export async function setTurnPacing(turnPacing) {
+  return fetchTurnPacing(
+    '/config/turn_pacing',
+    {
+      method: 'POST',
+      body: JSON.stringify({ turn_pacing: turnPacing })
+    },
+    true
+  );
+}
+
 // Catalog: card/relic metadata for inventory and builders
 export async function getCardCatalog() {
   const data = await httpGet('/catalog/cards', { cache: 'no-store' }, true);

--- a/frontend/src/lib/systems/settingsStorage.js
+++ b/frontend/src/lib/systems/settingsStorage.js
@@ -10,6 +10,15 @@ export function loadSettings() {
     if (data.lrmModel !== undefined) data.lrmModel = String(data.lrmModel);
     if (data.showActionValues !== undefined) data.showActionValues = Boolean(data.showActionValues);
     if (data.fullIdleMode !== undefined) data.fullIdleMode = Boolean(data.fullIdleMode);
+    if (data.animationSpeed !== undefined) {
+      const numeric = Number(data.animationSpeed);
+      if (Number.isFinite(numeric) && numeric > 0) {
+        const clamped = Math.min(2, Math.max(0.1, numeric));
+        data.animationSpeed = Math.round(clamped * 10) / 10;
+      } else {
+        delete data.animationSpeed;
+      }
+    }
     return data;
   } catch {
     return {};
@@ -21,6 +30,15 @@ export function saveSettings(settings) {
     const current = loadSettings();
     const merged = { ...current, ...settings };
     if (merged.fullIdleMode !== undefined) merged.fullIdleMode = Boolean(merged.fullIdleMode);
+    if (merged.animationSpeed !== undefined) {
+      const numeric = Number(merged.animationSpeed);
+      if (Number.isFinite(numeric) && numeric > 0) {
+        const clamped = Math.min(2, Math.max(0.1, numeric));
+        merged.animationSpeed = Math.round(clamped * 10) / 10;
+      } else {
+        delete merged.animationSpeed;
+      }
+    }
     localStorage.setItem(SETTINGS_KEY, JSON.stringify(merged));
   } catch {
     // ignore write errors

--- a/frontend/src/lib/systems/viewportState.js
+++ b/frontend/src/lib/systems/viewportState.js
@@ -21,6 +21,12 @@ export async function loadInitialState() {
     reducedMotion: saved.reducedMotion ?? false,
     showActionValues: saved.showActionValues ?? false,
     fullIdleMode: saved.fullIdleMode ?? false,
+    animationSpeed: (() => {
+      const raw = Number(saved.animationSpeed);
+      if (!Number.isFinite(raw) || raw <= 0) return 1;
+      const clamped = Math.min(2, Math.max(0.1, raw));
+      return Math.round(clamped * 10) / 10;
+    })(),
   };
   let roster = [];
   let user = { level: 1, exp: 0, next_level_exp: 100 };

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -44,6 +44,7 @@
   // When true, suppress backend syncing/polling (e.g., during defeat popup)
   let haltSync = false;
   let fullIdleMode = false;
+  let animationSpeed = 1;
   // Preserve the last live battle snapshot (with statuses) for review UI
   let lastBattleSnapshot = null;
   // Prevent overlapping room fetches
@@ -1323,6 +1324,7 @@
     editorState={editorState}
     battleActive={battleActive}
     backendFlavor={backendFlavor}
+    bind:animationSpeed
     bind:fullIdleMode
     on:startRun={handleStart}
     on:editorSave={(e) => handleEditorSave(e)}

--- a/frontend/tests/actionqueue.test.js
+++ b/frontend/tests/actionqueue.test.js
@@ -23,4 +23,9 @@ describe('Settings menu toggle', () => {
     expect(content).toContain('Full Idle Mode');
     expect(content).toContain('bind:checked={fullIdleMode}');
   });
+  test('includes Animation Speed slider', () => {
+    expect(content).toContain('Animation Speed');
+    expect(content).toContain('type="range"');
+    expect(content).toContain('value={animationSpeed}');
+  });
 });


### PR DESCRIPTION
## Summary
- add a gameplay "Animation Speed" slider and display the selected multiplier
- persist the animation speed setting, forward it through the viewport state, and call the backend pacing endpoint
- update GameplaySettings tests and document the new control in the settings menu guide

## Testing
- [ ] Backend tests
- [x] Frontend tests
- [ ] Linting
- [x] Doc sync updates (README and `.codex/implementation` docs; link tasks below)

------
https://chatgpt.com/codex/tasks/task_b_68c951ff8298832c887e425b4ca51303