### PR TITLE
feat(frontend): use dot selector for animation speed

### DIFF
--- a/frontend/src/lib/components/DotSelector.svelte
+++ b/frontend/src/lib/components/DotSelector.svelte
@@ -1,23 +1,38 @@
 <script>
   import { createEventDispatcher, onMount } from 'svelte';
   export let value = 50;
+  export let includeZero = true;
+  export let zeroAriaLabel = 'Mute';
+  export let zeroContent = '✕';
+  const defaultStepAriaLabel = (index) => `${(index + 1) * 10}%`;
+  export let formatStepAriaLabel = defaultStepAriaLabel;
   const dispatch = createEventDispatcher();
 
   let wrapEl;
   let arrowX = 0; // center position in px relative to wrapper
 
   const select = (v) => {
-    value = v;
-    dispatch('change', v);
+    const numeric = Number(v);
+    const clamped = Number.isFinite(numeric) ? Math.min(100, Math.max(0, Math.round(numeric))) : 0;
+    value = clamped;
+    dispatch('change', clamped);
   };
 
   function updateArrow() {
     if (!wrapEl) return;
-    const buttons = wrapEl.querySelectorAll('.dot-selector button');
+    const buttons = wrapEl.querySelectorAll('.dot-selector button[data-dot]');
     if (!buttons || !buttons.length) return;
-    // Index 0 is mute, 1..10 are dots (10%..100%)
-    const targetIndex = value === 0 ? 0 : Math.min(10, Math.max(1, Math.round(value / 10)));
-    const target = buttons[targetIndex];
+    const numericValue = Number.isFinite(Number(value)) ? Number(value) : 0;
+    let target = null;
+    let smallestDiff = Infinity;
+    for (const button of buttons) {
+      const dotValue = Number(button.dataset.dot || '0');
+      const diff = Math.abs(dotValue - numericValue);
+      if (!target || diff < smallestDiff || (diff === smallestDiff && dotValue > Number(target.dataset.dot || '0'))) {
+        target = button;
+        smallestDiff = diff;
+      }
+    }
     if (!target) return;
     const wrapRect = wrapEl.getBoundingClientRect();
     const rect = target.getBoundingClientRect();
@@ -42,27 +57,31 @@
 <div class="dot-selector-wrap" bind:this={wrapEl}>
   <div class="dot-arrow" style={`transform: translateX(${arrowX}px) translateX(-50%)`}/>
   <div class="dot-selector">
-    <button
-      type="button"
-      class="mute"
-      class:selected={value === 0}
-      aria-label="Mute"
-      on:click={() => select(0)}
-    >
-      ✕
-    </button>
+    {#if includeZero}
+      <button
+        type="button"
+        class="mute"
+        class:selected={Number(value) <= 0}
+        aria-label={zeroAriaLabel}
+        data-dot="0"
+        on:click={() => select(0)}
+      >
+        {zeroContent}
+      </button>
+    {/if}
     <div class="dot-steps">
       {#each Array(10) as _, i}
         <button
           type="button"
-          class:selected={value >= (i + 1) * 10}
-          aria-label={(i + 1) * 10 + '%'}
+          class:selected={Number(value) >= (i + 0.5) * 10}
+          aria-label={formatStepAriaLabel ? formatStepAriaLabel(i) : defaultStepAriaLabel(i)}
+          data-dot={(i + 1) * 10}
           on:click={() => select((i + 1) * 10)}
         />
       {/each}
     </div>
   </div>
-  
+
 </div>
 
 <style>

--- a/frontend/src/lib/components/GameplaySettings.svelte
+++ b/frontend/src/lib/components/GameplaySettings.svelte
@@ -1,17 +1,66 @@
 <script>
   import { Power, Timer } from 'lucide-svelte';
+  import DotSelector from './DotSelector.svelte';
   import Tooltip from './Tooltip.svelte';
 
   const MIN_ANIMATION_SPEED = 0.1;
   const MAX_ANIMATION_SPEED = 2;
+  const DEFAULT_ANIMATION_SPEED = 1;
+  const DOT_SCALE = 100;
 
   export let showActionValues = false;
   export let fullIdleMode = false;
-  export let animationSpeed = 1;
+  export let animationSpeed = DEFAULT_ANIMATION_SPEED;
   export let scheduleSave;
   export let handleEndRun;
   export let endingRun = false;
   export let endRunStatus = '';
+
+  const zeroSpeedLabel = `${MIN_ANIMATION_SPEED.toFixed(1)}× speed`;
+  const ZERO_DOT_CONTENT = ' ';
+
+  function clampValue(value, min, max) {
+    if (!Number.isFinite(value)) return min;
+    if (value < min) return min;
+    if (value > max) return max;
+    return value;
+  }
+
+  function normalizedSpeed(value) {
+    const numeric = Number(value);
+    if (!Number.isFinite(numeric)) return DEFAULT_ANIMATION_SPEED;
+    return clampValue(numeric, MIN_ANIMATION_SPEED, MAX_ANIMATION_SPEED);
+  }
+
+  function speedToDots(speed) {
+    const clamped = normalizedSpeed(speed);
+    const ratio = (clamped - MIN_ANIMATION_SPEED) / (MAX_ANIMATION_SPEED - MIN_ANIMATION_SPEED);
+    return Math.round(ratio * DOT_SCALE);
+  }
+
+  function dotsToSpeed(dots) {
+    const numeric = Number(dots);
+    if (!Number.isFinite(numeric)) return normalizedSpeed(animationSpeed);
+    const clampedDots = clampValue(numeric, 0, DOT_SCALE);
+    const ratio = clampedDots / DOT_SCALE;
+    const raw = MIN_ANIMATION_SPEED + ratio * (MAX_ANIMATION_SPEED - MIN_ANIMATION_SPEED);
+    const rounded = Math.round(raw * 10) / 10;
+    return clampValue(rounded, MIN_ANIMATION_SPEED, MAX_ANIMATION_SPEED);
+  }
+
+  function formatSpeedStepLabel(index) {
+    const derived = dotsToSpeed((index + 1) * 10);
+    return `${derived.toFixed(1)}× speed`;
+  }
+
+  let dotSpeed = speedToDots(animationSpeed);
+
+  $: {
+    const mapped = speedToDots(animationSpeed);
+    if (mapped !== dotSpeed) {
+      dotSpeed = mapped;
+    }
+  }
 
   $: displaySpeed = (() => {
     const numeric = Number(animationSpeed);
@@ -19,12 +68,14 @@
     return numeric.toFixed(1);
   })();
 
-  function handleSpeedInput(event) {
-    const value = Number(event?.currentTarget?.value ?? animationSpeed);
-    if (!Number.isFinite(value)) return;
-    const clamped = Math.min(MAX_ANIMATION_SPEED, Math.max(MIN_ANIMATION_SPEED, value));
-    animationSpeed = Math.round(clamped * 10) / 10;
-    scheduleSave();
+  function handleSpeedChange() {
+    const nextSpeed = dotsToSpeed(dotSpeed);
+    if (!Number.isFinite(nextSpeed)) return;
+    const previous = Number(animationSpeed);
+    animationSpeed = nextSpeed;
+    if (!Number.isFinite(previous) || Math.abs(nextSpeed - previous) > 0.001) {
+      scheduleSave();
+    }
   }
 </script>
 
@@ -56,13 +107,12 @@
       </Tooltip>
     </div>
     <div class="control-right">
-      <input
-        type="range"
-        min={MIN_ANIMATION_SPEED}
-        max={MAX_ANIMATION_SPEED}
-        step="0.1"
-        value={animationSpeed}
-        on:input={handleSpeedInput}
+      <DotSelector
+        bind:value={dotSpeed}
+        on:change={handleSpeedChange}
+        zeroAriaLabel={zeroSpeedLabel}
+        zeroContent={ZERO_DOT_CONTENT}
+        formatStepAriaLabel={formatSpeedStepLabel}
       />
       <span class="value" aria-live="polite">{displaySpeed}×</span>
     </div>

--- a/frontend/tests/dot-selector.test.js
+++ b/frontend/tests/dot-selector.test.js
@@ -8,7 +8,8 @@ describe('DotSelector component', () => {
       join(import.meta.dir, '../src/lib/components/DotSelector.svelte'),
       'utf8'
     );
-    expect(content).toMatch(/aria-label="Mute"/);
+    expect(content).toMatch(/zeroAriaLabel = 'Mute'/);
+    expect(content).toMatch(/aria-label=\{zeroAriaLabel\}/);
     expect(content).toMatch(/select\(0\)/);
   });
 });


### PR DESCRIPTION
## Summary
- replace the gameplay animation speed range input with a DotSelector mapped to the 0.1–2.0× multiplier range
- generalize DotSelector with configurable zero button and aria labels so it can power gameplay controls
- refresh the DotSelector unit test to cover the new markup contract

## Testing
- bun test tests/dot-selector.test.js tests/audio-settings.test.js --no-color
- bun test --no-color *(fails: tests/partypersistence.test.js expects legacy `selectedParty = data.party || selectedParty` snippet)*

------
https://chatgpt.com/codex/tasks/task_b_68c9f0178be4832c9318c58a6233424c