### PR TITLE
Restore turn pacing underscore API route

### DIFF
--- a/backend/.codex/implementation/settings-menu.md
+++ b/backend/.codex/implementation/settings-menu.md
@@ -7,10 +7,10 @@
 - `refresh_turn_pacing()` rereads the option from storage so other services can rehydrate the runtime pacing value without restarting the backend.
 
 ## API Endpoints
-- `GET /config/turn-pacing`
+- `GET /config/turn_pacing`
   - Returns the current pacing (`turn_pacing`) and the default of `0.5` seconds.
   - Refreshes the in-memory pacing constant so the backend reflects any out-of-band changes to the option.
-- `POST /config/turn-pacing`
+- `POST /config/turn_pacing`
   - Accepts a JSON body with a positive `turn_pacing` value (seconds between actions).
   - Persists the sanitized value via `options.set_option` and calls `pacing.set_turn_pacing` so the running battle loop immediately adopts the new cadence.
   - Responds with the applied pacing and the default for UI slider calibration.

--- a/backend/routes/config.py
+++ b/backend/routes/config.py
@@ -53,13 +53,13 @@ async def test_lrm_model() -> tuple[str, int, dict[str, str]]:
     return jsonify({"response": reply})
 
 
-@bp.get("/turn-pacing")
+@bp.get("/turn_pacing")
 async def get_turn_pacing() -> tuple[str, int, dict[str, float]]:
     value = refresh_turn_pacing()
     return jsonify({"turn_pacing": value, "default": _TURN_PACING_DEFAULT})
 
 
-@bp.post("/turn-pacing")
+@bp.post("/turn_pacing")
 async def update_turn_pacing() -> tuple[str, int, dict[str, float]]:
     data = await request.get_json()
     if not isinstance(data, dict) or "turn_pacing" not in data:

--- a/backend/tests/test_config_lrm.py
+++ b/backend/tests/test_config_lrm.py
@@ -65,30 +65,30 @@ async def test_turn_pacing_endpoints(app_with_db):
     app = app_with_db
     client = app.test_client()
 
-    resp = await client.get("/config/turn-pacing")
+    resp = await client.get("/config/turn_pacing")
     data = await resp.get_json()
     assert data["turn_pacing"] == pytest.approx(0.5)
     assert data["default"] == pytest.approx(0.5)
 
-    resp = await client.post("/config/turn-pacing", json={"turn_pacing": 0.8})
+    resp = await client.post("/config/turn_pacing", json={"turn_pacing": 0.8})
     data = await resp.get_json()
     assert data["turn_pacing"] == pytest.approx(0.8)
     assert data["default"] == pytest.approx(0.5)
     assert pacing_module.TURN_PACING == pytest.approx(0.8)
 
-    resp = await client.get("/config/turn-pacing")
+    resp = await client.get("/config/turn_pacing")
     data = await resp.get_json()
     assert data["turn_pacing"] == pytest.approx(0.8)
 
-    resp = await client.post("/config/turn-pacing", json={"turn_pacing": "NaN"})
+    resp = await client.post("/config/turn_pacing", json={"turn_pacing": "NaN"})
     assert resp.status_code == 400
     assert pacing_module.TURN_PACING == pytest.approx(0.8)
 
-    resp = await client.post("/config/turn-pacing", json={"turn_pacing": "Infinity"})
+    resp = await client.post("/config/turn_pacing", json={"turn_pacing": "Infinity"})
     assert resp.status_code == 400
     assert pacing_module.TURN_PACING == pytest.approx(0.8)
 
-    resp = await client.post("/config/turn-pacing", json={"turn_pacing": -1})
+    resp = await client.post("/config/turn_pacing", json={"turn_pacing": -1})
     assert resp.status_code == 400
 
     set_option(OptionKey.TURN_PACING, "NaN")


### PR DESCRIPTION
## Summary
- revert the frontend turn pacing helper to call `/config/turn_pacing`
- update the backend config blueprint to serve the underscore route and adjust docs/tests accordingly

## Testing
- uv run pytest tests/test_config_lrm.py
- bun run lint

------
https://chatgpt.com/codex/tasks/task_b_68c9f0187840832c8b64c483315a42b4