### PR TITLE
frontend: theme settings action buttons

### DIFF
--- a/frontend/src/lib/components/GameplaySettings.svelte
+++ b/frontend/src/lib/components/GameplaySettings.svelte
@@ -124,7 +124,9 @@
       </Tooltip>
     </div>
     <div class="control-right">
-      <button on:click={handleEndRun} disabled={endingRun}>{endingRun ? 'Ending…' : 'End'}</button>
+      <button class="icon-btn" on:click={handleEndRun} disabled={endingRun}>
+        {endingRun ? 'Ending…' : 'End'}
+      </button>
     </div>
   </div>
   {#if endRunStatus}

--- a/frontend/src/lib/components/LLMSettings.svelte
+++ b/frontend/src/lib/components/LLMSettings.svelte
@@ -24,7 +24,7 @@
       <span class="label">Test Model</span>
     </div>
     <div class="control-right">
-      <button on:click={handleTestModel}>Test</button>
+      <button class="icon-btn" on:click={handleTestModel}>Test</button>
     </div>
   </div>
   {#if testReply}

--- a/frontend/src/lib/components/SystemSettings.svelte
+++ b/frontend/src/lib/components/SystemSettings.svelte
@@ -30,7 +30,7 @@
       {#if healthPing !== null}
         <span class="ping">{Math.round(healthPing)}ms</span>
       {/if}
-      <button on:click={() => refreshHealth(true)}>Refresh</button>
+      <button class="icon-btn" on:click={() => refreshHealth(true)}>Refresh</button>
     </div>
   </div>
   <div class="control" title="Limit server polling frequency.">
@@ -58,7 +58,7 @@
       <span class="label"><Trash2 /> Wipe Save Data</span>
     </div>
     <div class="control-right">
-      <button on:click={handleWipe}>Wipe</button>
+      <button class="icon-btn" on:click={handleWipe}>Wipe</button>
     </div>
   </div>
   {#if wipeStatus}
@@ -69,7 +69,7 @@
       <span class="label"><Download /> Backup Save Data</span>
     </div>
     <div class="control-right">
-      <button on:click={handleBackup}>Backup</button>
+      <button class="icon-btn" on:click={handleBackup}>Backup</button>
     </div>
   </div>
   <div class="control" title="Import an encrypted save backup.">

--- a/frontend/src/lib/components/settings-shared.css
+++ b/frontend/src/lib/components/settings-shared.css
@@ -77,6 +77,65 @@
 
 .settings-panel button {
   padding: 0.3rem 0.6rem;
+  font-size: 0.8rem;
+  color: inherit;
+}
+
+.settings-panel .icon-btn,
+.settings-panel input[type='file']::file-selector-button {
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 0;
+  padding: 0.35rem 0.85rem;
+  min-height: 2.25rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  cursor: pointer;
+  color: inherit;
+  box-shadow: 0 1px 4px 0 rgba(0, 40, 120, 0.1);
+  transition: background 0.18s ease, box-shadow 0.18s ease, transform 0.18s ease;
+}
+
+.settings-panel input[type='file']::file-selector-button {
+  margin-right: 0.65rem;
+}
+
+.settings-panel .icon-btn:hover,
+.settings-panel input[type='file']::file-selector-button:hover {
+  background: rgba(120, 180, 255, 0.22);
+  border-color: rgba(160, 205, 255, 0.6);
+  box-shadow: 0 2px 8px 0 rgba(0, 40, 120, 0.18);
+}
+
+.settings-panel .icon-btn:active,
+.settings-panel input[type='file']::file-selector-button:active {
+  transform: translateY(1px);
+}
+
+.settings-panel .icon-btn:disabled,
+.settings-panel input[type='file']:disabled::file-selector-button {
+  opacity: 0.55;
+  cursor: not-allowed;
+  box-shadow: none;
+  background: rgba(255, 255, 255, 0.08);
+  border-color: rgba(255, 255, 255, 0.12);
+  transform: none;
+}
+
+.settings-panel .icon-btn:focus-visible,
+.settings-panel input[type='file']:focus-visible {
+  outline: 2px solid rgba(160, 205, 255, 0.85);
+  outline-offset: 2px;
+}
+
+.settings-panel input[type='file'] {
+  font-size: 0.78rem;
+  color: inherit;
 }
 
 .settings-panel .status {


### PR DESCRIPTION
## Summary
- align settings action buttons with the shared icon-btn theme across gameplay, system, and LLM tabs
- extend settings-shared.css with icon button and file input styling so controls stay consistent on dark and light backgrounds

## Testing
- bun run lint

------
https://chatgpt.com/codex/tasks/task_b_68c9f4dba098832c95b0299f061068f2