### PR TITLE
Add status phase pacing events for effect ticks

### DIFF
--- a/backend/.codex/implementation/battle-logging.md
+++ b/backend/.codex/implementation/battle-logging.md
@@ -56,6 +56,27 @@ The system is automatically integrated into the battle flow:
 
 The battle logging system subscribes to the global event bus and automatically captures relevant events. It integrates seamlessly with existing game mechanics without requiring code changes to emit events manually.
 
+#### Status Phase Timing Events
+
+`EffectManager.tick` emits two pacing events for every status phase so the frontend and log writers can highlight when HoTs and DoTs resolve within the turn beat:
+
+- `status_phase_start`
+- `status_phase_end`
+
+Both events provide the same argument signature as other battle bus events:
+
+1. `phase` – the string label (`"hot"` or `"dot"`).
+2. `Stats` – the combatant whose effects are ticking.
+3. `payload` – structured metadata with:
+   - `phase`: mirrors the phase label.
+   - `order`: `0` for HoTs, `1` for DoTs to preserve sequencing.
+   - `effect_count`: active effect total at the start/end of the phase.
+   - `expired_count`: number of effects that ended during the phase (zero on start events).
+   - `has_effects`: convenience boolean indicating whether any effects remain.
+   - `target_id`: the combatant identifier (if available).
+
+Phases always fire in HoT → DoT order even when a combatant has no active statuses, and the manager yields via `pace_sleep(YIELD_MULTIPLIER)` between phases to create a short, predictable beat for UI animations and log snapshots.
+
 ### File Formats
 
 #### battle_summary.json

--- a/backend/autofighter/effects.py
+++ b/backend/autofighter/effects.py
@@ -439,28 +439,57 @@ class EffectManager:
             remaining -= 1.0
 
     async def tick(self, others: Optional["EffectManager"] = None) -> None:
-        for collection, names in (
-            (self.hots, self.stats.hots),
-            (self.dots, self.stats.dots),
+        try:
+            from autofighter.rooms.battle.pacing import YIELD_MULTIPLIER
+            from autofighter.rooms.battle.pacing import pace_sleep
+        except (ImportError, ModuleNotFoundError):
+            YIELD_MULTIPLIER = 0.0
+
+            async def pace_sleep(_multiplier: float = 1.0) -> None:
+                await asyncio.sleep(0)
+
+        from autofighter.stats import BUS
+
+        for order, (phase_name, collection, names) in enumerate(
+            (
+                ("hot", self.hots, self.stats.hots),
+                ("dot", self.dots, self.stats.dots),
+            )
         ):
             expired: list[object] = []
+            effect_count = len(collection)
+            phase_label = "HoT" if phase_name == "hot" else "DoT"
+            color = "green" if phase_name == "hot" else "light_red"
+            phase_payload = {
+                "phase": phase_name,
+                "effect_count": effect_count,
+                "expired_count": 0,
+                "has_effects": effect_count > 0,
+                "order": order,
+                "target_id": getattr(self.stats, "id", None),
+            }
+
+            # Announce phase start so the frontend can render pacing beats
+            await BUS.emit_async(
+                "status_phase_start",
+                phase_name,
+                self.stats,
+                phase_payload.copy(),
+            )
 
             # Batch logging for performance when many effects are present
-            if self._debug and len(collection) > 10:
-                effect_type = "HoT" if (collection and isinstance(collection[0], HealingOverTime)) else "DoT"
-                color = "green" if effect_type == "HoT" else "light_red"
+            if self._debug and effect_count > 10:
                 asyncio.create_task(
                     self._log(
-                        f"[{color}]{self.stats.id} processing {len(collection)} {effect_type} effects[/]"
+                        f"[{color}]{self.stats.id} processing {effect_count} {phase_label} effects[/]"
                     )
                 )
 
             # Process effects in parallel for better async performance when many are present
-            if len(collection) > 20:
+            if effect_count > 20:
                 # Parallel processing for large collections
                 async def tick_effect(eff):
-                    if self._debug and len(collection) <= 10:
-                        color = "green" if isinstance(eff, HealingOverTime) else "light_red"
+                    if self._debug and effect_count <= 10:
                         asyncio.create_task(
                             self._log(f"[{color}]{self.stats.id} {eff.name} tick[/]")
                         )
@@ -468,7 +497,7 @@ class EffectManager:
 
                 # Process in batches to avoid overwhelming the event loop
                 batch_size = 50
-                for i in range(0, len(collection), batch_size):
+                for i in range(0, effect_count, batch_size):
                     batch = collection[i:i + batch_size]
                     results = await asyncio.gather(*[tick_effect(eff) for eff in batch])
                     for still_active, eff in results:
@@ -481,8 +510,7 @@ class EffectManager:
                 # Sequential processing for smaller collections
                 for eff in collection:
                     # Only log individual effects if there are few of them
-                    if self._debug and len(collection) <= 10:
-                        color = "green" if isinstance(eff, HealingOverTime) else "light_red"
+                    if self._debug and effect_count <= 10:
                         asyncio.create_task(
                             self._log(f"[{color}]{self.stats.id} {eff.name} tick[/]")
                         )
@@ -494,16 +522,37 @@ class EffectManager:
 
             for eff in expired:
                 # Emit effect expired event - async for better performance
-                from autofighter.stats import BUS
-                await BUS.emit_async("effect_expired", eff.name, self.stats, {
-                    "effect_type": "hot" if isinstance(eff, HealingOverTime) else "dot",
-                    "effect_id": eff.id,
-                    "expired_naturally": True
-                })
+                await BUS.emit_async(
+                    "effect_expired",
+                    eff.name,
+                    self.stats,
+                    {
+                        "effect_type": "hot" if isinstance(eff, HealingOverTime) else "dot",
+                        "effect_id": eff.id,
+                        "expired_naturally": True,
+                    },
+                )
 
                 collection.remove(eff)
                 if eff.id in names:
                     names.remove(eff.id)
+
+            phase_payload.update(
+                {
+                    "effect_count": len(collection),
+                    "expired_count": len(expired),
+                    "has_effects": len(collection) > 0,
+                }
+            )
+
+            await BUS.emit_async(
+                "status_phase_end",
+                phase_name,
+                self.stats,
+                phase_payload,
+            )
+
+            await pace_sleep(YIELD_MULTIPLIER)
 
         # Enhanced stat modifier processing with parallelization
         expired_mods: list[StatModifier] = []
@@ -553,7 +602,6 @@ class EffectManager:
         # Clean up expired modifiers
         for mod in expired_mods:
             # Emit effect expired event for stat modifiers - async for better performance
-            from autofighter.stats import BUS
             await BUS.emit_async("effect_expired", mod.name, self.stats, {
                 "effect_type": "stat_modifier",
                 "effect_id": mod.id,

--- a/backend/tests/test_status_phase_events.py
+++ b/backend/tests/test_status_phase_events.py
@@ -1,0 +1,87 @@
+import sys
+from types import ModuleType
+
+import pytest
+
+from autofighter.effects import DamageOverTime
+from autofighter.effects import EffectManager
+from autofighter.effects import HealingOverTime
+from autofighter.stats import Stats
+
+
+@pytest.mark.asyncio
+async def test_status_phase_events_emit_with_pacing(monkeypatch):
+    target = Stats(hp=1000)
+    target.set_base_stat('max_hp', 1000)
+    target.set_base_stat('defense', 1)
+    target.set_base_stat('mitigation', 1)
+    target.set_base_stat('vitality', 1)
+    target.id = "phase_target"
+
+    manager = EffectManager(target)
+
+    hot = HealingOverTime("regen", healing=10, turns=1, id="hot_1", source=target)
+    dot = DamageOverTime("burn", damage=10, turns=1, id="dot_1", source=target)
+
+    manager.add_hot(hot)
+    manager.add_dot(dot)
+
+    captured_events: list[tuple[str, tuple[object, ...]]] = []
+
+    async def fake_emit_async(event: str, *args: object) -> None:
+        captured_events.append((event, args))
+
+    monkeypatch.setattr("autofighter.stats.BUS.emit_async", fake_emit_async)
+
+    sleep_calls: list[float] = []
+    expected_multiplier = 0.25
+
+    async def fake_pace_sleep(multiplier: float = 1.0) -> None:
+        sleep_calls.append(multiplier)
+
+    pacing_stub = ModuleType("autofighter.rooms.battle.pacing")
+    pacing_stub.YIELD_MULTIPLIER = expected_multiplier
+    pacing_stub.pace_sleep = fake_pace_sleep
+
+    monkeypatch.setitem(sys.modules, "autofighter.rooms.battle.pacing", pacing_stub)
+
+    await manager.tick()
+
+    assert sleep_calls == [expected_multiplier, expected_multiplier]
+
+    status_events = [evt for evt in captured_events if evt[0].startswith("status_phase_")]
+    assert [name for name, _ in status_events] == [
+        "status_phase_start",
+        "status_phase_end",
+        "status_phase_start",
+        "status_phase_end",
+    ]
+
+    start_hot_name, start_hot_args = status_events[0]
+    assert start_hot_args[0] == "hot"
+    assert start_hot_args[1] is target
+    assert start_hot_args[2]["phase"] == "hot"
+    assert start_hot_args[2]["effect_count"] == 1
+    assert start_hot_args[2]["order"] == 0
+    assert start_hot_args[2]["has_effects"] is True
+
+    end_hot_name, end_hot_args = status_events[1]
+    assert end_hot_args[2]["phase"] == "hot"
+    assert end_hot_args[2]["effect_count"] == 0
+    assert end_hot_args[2]["expired_count"] == 1
+    assert end_hot_args[2]["order"] == 0
+
+    start_dot_name, start_dot_args = status_events[2]
+    assert start_dot_args[0] == "dot"
+    assert start_dot_args[2]["phase"] == "dot"
+    assert start_dot_args[2]["effect_count"] == 1
+    assert start_dot_args[2]["order"] == 1
+
+    end_dot_name, end_dot_args = status_events[3]
+    assert end_dot_args[2]["phase"] == "dot"
+    assert end_dot_args[2]["effect_count"] == 0
+    assert end_dot_args[2]["expired_count"] == 1
+    assert end_dot_args[2]["order"] == 1
+
+    assert manager.hots == []
+    assert manager.dots == []


### PR DESCRIPTION
## Summary
- emit dedicated `status_phase_start`/`status_phase_end` events from `EffectManager.tick` and pace each HoT/DoT pass
- document the new status phase timing contract in the battle logging guide
- add coverage that patches the pacing module and asserts event order plus pacing multipliers

## Testing
- uv run pytest tests/test_status_phase_events.py
- uv run ruff check backend/autofighter/effects.py backend/tests/test_status_phase_events.py

------
https://chatgpt.com/codex/tasks/task_b_68c9f527f420832cb173c2f40e100a07