### PR TITLE
Fix slime stat initialization and defense override

### DIFF
--- a/backend/autofighter/rooms/utils.py
+++ b/backend/autofighter/rooms/utils.py
@@ -122,7 +122,13 @@ def _scale_stats(obj: Stats, node: MapNode, strength: float = 1.0) -> None:
         if isinstance(obj, FoeBase):
             d = getattr(obj, "defense", None)
             if isinstance(d, (int, float)):
-                new_def = max(2 + cumulative_rooms, int(d))
+                override = getattr(obj, "min_defense_override", None)
+                if isinstance(override, (int, float)):
+                    min_def = max(int(override), 0)
+                else:
+                    min_def = 2 + cumulative_rooms
+
+                new_def = max(min_def, int(d))
                 # For foes, 'defense' is a dataclass field; set the field directly
                 try:
                     setattr(obj, "defense", type(d)(new_def))


### PR DESCRIPTION
## Summary
- ensure the slime foe calls the base post-init and rescales its stats via `set_base_stat` so max HP/attack/defense reductions are reflected by runtime getters
- update the room defense clamp to honor a foe-provided `min_defense_override`, preserving custom low defense floors during scaling

## Testing
- `./run-tests.sh` *(fails: current suite hits existing missing-dependency/time-out failures)*

------
https://chatgpt.com/codex/tasks/task_b_68c9fa549fb0832c8227c8c8229e5433