### PR TITLE
[FIX] route turn pacing through damage plugins

### DIFF
--- a/backend/plugins/damage_types/dark.py
+++ b/backend/plugins/damage_types/dark.py
@@ -1,4 +1,3 @@
-import asyncio
 from dataclasses import dataclass
 
 from autofighter.effects import DamageOverTime
@@ -103,6 +102,9 @@ class Dark(DamageTypeBase):
     ) -> bool:
         """Strike a foe six times, scaling with allied DoT stacks."""
 
+        from autofighter.rooms.battle.pacing import YIELD_MULTIPLIER
+        from autofighter.rooms.battle.pacing import pace_sleep
+
         if not getattr(actor, "use_ultimate", lambda: False)():
             return False
         if not enemies:
@@ -121,7 +123,7 @@ class Dark(DamageTypeBase):
         target = enemies[0]
         for _ in range(6):
             dealt = await target.apply_damage(dmg, attacker=actor, action_name="Dark Ultimate")
-            await asyncio.sleep(0.002)
+            await pace_sleep(YIELD_MULTIPLIER)
             await BUS.emit_async("damage", actor, target, dealt)
         return True
 
@@ -133,5 +135,5 @@ class Dark(DamageTypeBase):
         return (
             "Multiplies the user's attack by `ULT_PER_STACK` for each DoT stack on allied "
             "targets, then deals that damage to one enemy six times, emitting a 'damage' "
-            "event after each hit."
+            "event after each hit. Each strike yields via TURN_PACING-aware pacing."
         )

--- a/backend/plugins/damage_types/generic.py
+++ b/backend/plugins/damage_types/generic.py
@@ -1,4 +1,3 @@
-import asyncio
 from dataclasses import dataclass
 
 from autofighter.passives import PassiveRegistry
@@ -18,6 +17,9 @@ class Generic(DamageTypeBase):
 
     async def ultimate(self, actor, allies, enemies):
         """Split the user's attack into 64 rapid strikes on one target."""
+        from autofighter.rooms.battle.pacing import YIELD_MULTIPLIER
+        from autofighter.rooms.battle.pacing import pace_sleep
+
         if not getattr(actor, "use_ultimate", lambda: False)():
             return False
 
@@ -40,6 +42,7 @@ class Generic(DamageTypeBase):
         for i in range(64):
             dmg = base + (1 if i < remainder else 0)
             await target.apply_damage(dmg, attacker=actor, action_name="Generic Ultimate")
+            await pace_sleep(YIELD_MULTIPLIER)
             await BUS.emit_async(
                 "hit_landed", actor, target, dmg, "attack", "generic_ultimate"
             )
@@ -59,7 +62,6 @@ class Generic(DamageTypeBase):
                 party=allies,
                 foes=enemies,
             )
-            await asyncio.sleep(0.002)
         from plugins.passives.luna_lunar_reservoir import LunaLunarReservoir
 
         if LunaLunarReservoir is not _LLR_old:
@@ -71,5 +73,6 @@ class Generic(DamageTypeBase):
     def get_ultimate_description(cls) -> str:
         return (
             "Splits the user's attack into 64 rapid strikes on a single target, "
-            "counting each hit as a separate action."
+            "counting each hit as a separate action. The strike cadence follows "
+            "TURN_PACING via the battle pacing helper."
         )

--- a/backend/plugins/damage_types/ice.py
+++ b/backend/plugins/damage_types/ice.py
@@ -1,4 +1,3 @@
-import asyncio
 from dataclasses import dataclass
 
 from autofighter.effects import DamageOverTime
@@ -19,6 +18,9 @@ class Ice(DamageTypeBase):
 
     async def ultimate(self, user: Stats, foes: list[Stats]) -> bool:
         """Strike all foes six times, ramping damage by 30% per target."""
+        from autofighter.rooms.battle.pacing import YIELD_MULTIPLIER
+        from autofighter.rooms.battle.pacing import pace_sleep
+
         if not getattr(user, "use_ultimate", lambda: False)():
             return False
         base = user.atk
@@ -27,14 +29,15 @@ class Ice(DamageTypeBase):
             for foe in foes:
                 dmg = int(base * bonus)
                 await foe.apply_damage(dmg, attacker=user, action_name="Ice Ultimate")
-                await asyncio.sleep(0.002)
+                await pace_sleep(YIELD_MULTIPLIER)
                 bonus += 0.3
-            await asyncio.sleep(0.002)
+            await pace_sleep(YIELD_MULTIPLIER)
         return True
 
     @classmethod
     def get_ultimate_description(cls) -> str:
         return (
             "Strikes all foes six times in succession. Each hit within a wave "
-            "deals 30% more damage than the previous target."
+            "deals 30% more damage than the previous target. Hits are paced via "
+            "the TURN_PACING-aware helper."
         )


### PR DESCRIPTION
## Summary
- switch damage type ultimates and Aftertaste to import `pace_sleep` lazily and use `pace_sleep(YIELD_MULTIPLIER)` instead of fixed `asyncio.sleep`
- yield after each damage or heal event in multi-hit loops and update docstrings to explain TURN_PACING-aware timing

## Testing
- uv run pytest *(hangs after existing failures)*

------
https://chatgpt.com/codex/tasks/task_b_68c9faad42c0832c81cfc1379aea123f