### PR TITLE
Add incremental battle snapshot updates for targeting cues

### DIFF
--- a/backend/autofighter/rooms/battle/engine.py
+++ b/backend/autofighter/rooms/battle/engine.py
@@ -121,6 +121,7 @@ async def run_battle(
                 enrage_state,
                 temp_rdr,
                 _EXTRA_TURNS,
+                run_id=run_id,
                 active_id=None,
                 active_target_id=None,
                 ended=True,

--- a/backend/autofighter/rooms/battle/turn_loop/turn_end.py
+++ b/backend/autofighter/rooms/battle/turn_loop/turn_end.py
@@ -29,6 +29,7 @@ async def finish_turn(
         context.enrage_state,
         context.temp_rdr,
         _EXTRA_TURNS,
+        run_id=context.run_id,
         active_id=getattr(actor, "id", None),
         active_target_id=active_target_id,
         include_summon_foes=include_summon_foes,
@@ -43,6 +44,7 @@ async def finish_turn(
         context.temp_rdr,
         _EXTRA_TURNS,
         actor,
+        context.run_id,
     )
     await pace_sleep(2.2 / TURN_PACING)
     await pace_sleep(YIELD_MULTIPLIER)


### PR DESCRIPTION
## Summary
- add a helper in the battle turns module to persist active target, status phase, and recent event state between snapshot refreshes
- hook the new helper into the player and foe turn loops, snapshot dispatches, and final progress update so targeting hints appear immediately
- extend the status phase test suite to cover the interim snapshot fields and new event queue expectations

## Testing
- `uv run pytest tests/test_status_phase_events.py`


------
https://chatgpt.com/codex/tasks/task_b_68ca231c05f4832c93409edd3bda0ad6