### PR TITLE
feat: add summon slot tracking and tests

### DIFF
--- a/backend/plugins/passives/becca_menagerie_bond.py
+++ b/backend/plugins/passives/becca_menagerie_bond.py
@@ -35,6 +35,11 @@ class BeccaMenagerieBond:
         """Apply Becca's Menagerie Bond mechanics."""
         entity_id = id(target)
 
+        if hasattr(target, "ensure_permanent_summon_slots"):
+            target.ensure_permanent_summon_slots(1)
+
+        setattr(target, "_becca_menagerie_passive", self)
+
         # Initialize tracking if not present
         if entity_id not in self._summon_cooldown:
             self._summon_cooldown[entity_id] = 0
@@ -142,6 +147,11 @@ class BeccaMenagerieBond:
             self._summon_cooldown[entity_id] = 0
             self._spirit_stacks[entity_id] = 0
 
+        if hasattr(target, "ensure_permanent_summon_slots"):
+            target.ensure_permanent_summon_slots(1)
+        if not hasattr(target, "_becca_menagerie_passive"):
+            setattr(target, "_becca_menagerie_passive", self)
+
         # Check cooldown
         if self._summon_cooldown[entity_id] > 0:
             return False
@@ -191,7 +201,6 @@ class BeccaMenagerieBond:
             stat_multiplier=0.5,  # 50% of Becca's stats as specified
             turns_remaining=-1,  # Permanent until replaced or defeated
             override_damage_type=damage_type,
-            max_summons=1,  # Only one jellyfish at a time
         )
 
         if summon:

--- a/backend/tests/test_summon_decision_logic.py
+++ b/backend/tests/test_summon_decision_logic.py
@@ -21,6 +21,7 @@ async def test_summon_viability_evaluation(monkeypatch):
     summoner._base_atk = 100
     summoner._base_max_hp = 200
     summoner._base_defense = 50
+    summoner.ensure_permanent_summon_slots(1)
 
     summon = Summon.create_from_summoner(
         summoner=summoner,
@@ -70,6 +71,7 @@ async def test_resummon_decision_logic(monkeypatch):
     summoner._base_atk = 100
     summoner._base_max_hp = 200
     summoner._base_defense = 50
+    summoner.ensure_permanent_summon_slots(1)
 
     # Test no existing summons - should resummon
     decision = SummonManager.should_resummon("test_summoner")
@@ -114,13 +116,13 @@ async def test_smart_summon_creation(monkeypatch):
     summoner._base_atk = 100
     summoner._base_max_hp = 200
     summoner._base_defense = 50
+    summoner.ensure_permanent_summon_slots(1)
 
     # Create first summon (should succeed)
     summon1 = SummonManager.create_summon(
         summoner=summoner,
         summon_type="test1",
         source="test_source",
-        max_summons=1
     )
     assert summon1 is not None
     summon1.hp = summon1.max_hp  # Ensure healthy
@@ -130,7 +132,6 @@ async def test_smart_summon_creation(monkeypatch):
         summoner=summoner,
         summon_type="test2",
         source="test_source",
-        max_summons=1
     )
     assert summon2 is None  # Should be blocked by smart logic
 
@@ -142,7 +143,6 @@ async def test_smart_summon_creation(monkeypatch):
         summoner=summoner,
         summon_type="test3",
         source="test_source",
-        max_summons=1
     )
     assert summon3 is not None  # Should succeed because first summon is low health
 
@@ -164,13 +164,13 @@ async def test_force_create_bypasses_logic(monkeypatch):
     summoner._base_atk = 100
     summoner._base_max_hp = 200
     summoner._base_defense = 50
+    summoner.ensure_permanent_summon_slots(1)
 
     # Create first summon
     summon1 = SummonManager.create_summon(
         summoner=summoner,
         summon_type="test1",
         source="test_source",
-        max_summons=1
     )
     assert summon1 is not None
     summon1.hp = summon1.max_hp  # Ensure healthy
@@ -180,7 +180,6 @@ async def test_force_create_bypasses_logic(monkeypatch):
         summoner=summoner,
         summon_type="test2",
         source="test_source",
-        max_summons=1,
         force_create=True
     )
     assert summon2 is not None  # Should succeed due to force_create
@@ -203,6 +202,7 @@ async def test_health_threshold_customization(monkeypatch):
     summoner._base_atk = 100
     summoner._base_max_hp = 200
     summoner._base_defense = 50
+    summoner.ensure_permanent_summon_slots(1)
 
     # Create summon with 40% health
     summon = SummonManager.create_summon(

--- a/backend/tests/test_summon_manager_no_event_loop_warning.py
+++ b/backend/tests/test_summon_manager_no_event_loop_warning.py
@@ -19,6 +19,7 @@ async def test_on_entity_killed_no_event_loop_warning(monkeypatch, caplog):
 
     summoner = Stats()
     summoner.id = "test_summoner"
+    summoner.ensure_permanent_summon_slots(1)
     SummonManager.create_summon(summoner, summon_type="test")
     summon = SummonManager.get_summons("test_summoner")[0]
 

--- a/backend/tests/test_summon_safeguards.py
+++ b/backend/tests/test_summon_safeguards.py
@@ -26,6 +26,7 @@ async def test_summons_cannot_create_more_summons(monkeypatch):
     # Create original summoner
     original_summoner = Ally()
     original_summoner.id = "original_summoner"
+    original_summoner.ensure_permanent_summon_slots(1)
 
     # Create a summon from the original summoner
     first_summon = SummonManager.create_summon(
@@ -64,9 +65,11 @@ async def test_regular_entities_can_still_create_summons(monkeypatch):
     # Create regular entities
     player1 = Ally()
     player1.id = "player1"
+    player1.ensure_permanent_summon_slots(1)
 
     player2 = Ally()
     player2.id = "player2"
+    player2.ensure_permanent_summon_slots(1)
 
     # Both should be able to create summons
     summon1 = SummonManager.create_summon(
@@ -102,6 +105,7 @@ async def test_summon_identification_works(monkeypatch):
     # Create regular entity and summon
     player = Ally()
     player.id = "player"
+    player.ensure_permanent_summon_slots(1)
 
     summon = SummonManager.create_summon(
         summoner=player,
@@ -137,6 +141,7 @@ async def test_summon_safeguard_logging(monkeypatch, caplog):
     # Create original summoner and first summon
     player = Ally()
     player.id = "test_player"
+    player.ensure_permanent_summon_slots(1)
 
     first_summon = SummonManager.create_summon(
         summoner=player,


### PR DESCRIPTION
## Summary
- add persistent and temporary summon slot bookkeeping to Stats with automatic battle-end cleanup
- update the summon manager, Phantom Ally card, and Becca's passive to respect the new slot counters
- expand summon-related tests, including a regression that ensures Becca can summon a jellyfish after Phantom Ally

## Testing
- uv run pytest tests/test_summons_system.py tests/test_summon_decision_logic.py tests/test_summon_safeguards.py tests/test_summon_manager_no_event_loop_warning.py

------
https://chatgpt.com/codex/tasks/task_b_68ca24f7d1f8832c90a72e2397136842