### PR TITLE
feat(battle): enforce pacing for immediate impacts

### DIFF
--- a/backend/autofighter/rooms/battle/turn_loop/foe_turn.py
+++ b/backend/autofighter/rooms/battle/turn_loop/foe_turn.py
@@ -14,6 +14,7 @@ from ..logging import queue_log
 from ..pacing import _EXTRA_TURNS
 from ..pacing import YIELD_MULTIPLIER
 from ..pacing import _pace
+from ..pacing import impact_pause
 from ..pacing import pace_sleep
 from ..turn_helpers import credit_if_dead
 from ..turns import mutate_snapshot_overlay
@@ -170,6 +171,7 @@ async def execute_foe_phase(context: TurnLoopContext) -> bool:
                         targets_hit,
                         duration,
                     )
+            await impact_pause(acting_foe, targets_hit, duration=duration)
             await context.registry.trigger("action_taken", acting_foe)
             try:
                 SummonManager.add_summons_to_party(context.combat_party)

--- a/backend/autofighter/rooms/battle/turn_loop/player_turn.py
+++ b/backend/autofighter/rooms/battle/turn_loop/player_turn.py
@@ -14,6 +14,7 @@ from ..logging import queue_log
 from ..pacing import _EXTRA_TURNS
 from ..pacing import YIELD_MULTIPLIER
 from ..pacing import _pace
+from ..pacing import impact_pause
 from ..pacing import pace_sleep
 from ..turn_helpers import credit_if_dead
 from ..turn_helpers import remove_dead_foes
@@ -221,6 +222,7 @@ async def execute_player_phase(context: TurnLoopContext) -> bool:
                         targets_hit,
                         duration,
                     )
+            await impact_pause(member, targets_hit, duration=duration)
             await context.registry.trigger(
                 "action_taken",
                 member,

--- a/backend/plugins/passives/lady_of_fire_infernal_momentum.py
+++ b/backend/plugins/passives/lady_of_fire_infernal_momentum.py
@@ -56,6 +56,14 @@ class LadyOfFireInfernalMomentum:
         )
         attacker.add_effect(burn_effect)
 
+        try:
+            from autofighter.rooms.battle.pacing import impact_pause as _impact_pause
+        except ModuleNotFoundError:
+            _impact_pause = None
+
+        if _impact_pause is not None:
+            await _impact_pause(target, 1)
+
     async def on_self_damage(self, target: "Stats", self_damage: int) -> None:
         """Grant HoT when taking self-damage from Fire drain."""
         # Apply HoT equal to half the self-damage for two turns

--- a/backend/tests/test_animation_timers.py
+++ b/backend/tests/test_animation_timers.py
@@ -1,10 +1,59 @@
+from pathlib import Path
+import sys
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from autofighter.rooms.battle.pacing import YIELD_MULTIPLIER
+from autofighter.rooms.battle.pacing import impact_pause
 from autofighter.stats import Stats
 from autofighter.stats import calc_animation_time
 
 
-def test_animation_time_scaling():
+def test_animation_time_scaling() -> None:
     actor = Stats()
     actor.animation_duration = 0.5
     actor.animation_per_target = 0.25
     assert calc_animation_time(actor, 1) == 0.5
     assert calc_animation_time(actor, 3) == 1.0
+
+
+@pytest.mark.asyncio
+async def test_impact_pause_yields_without_animation(monkeypatch) -> None:
+    actor = Stats()
+    actor.animation_duration = 0.0
+    actor.animation_per_target = 0.0
+
+    calls: list[float] = []
+
+    async def fake_sleep(multiplier: float = 1.0) -> None:
+        calls.append(multiplier)
+
+    monkeypatch.setattr(
+        "autofighter.rooms.battle.pacing.pace_sleep",
+        fake_sleep,
+        raising=True,
+    )
+
+    await impact_pause(actor, 1)
+
+    assert calls == [YIELD_MULTIPLIER]
+
+
+@pytest.mark.asyncio
+async def test_impact_pause_skips_when_animation_present(monkeypatch) -> None:
+    actor = Stats()
+    actor.animation_duration = 0.3
+    actor.animation_per_target = 0.0
+
+    async def fake_sleep(multiplier: float = 1.0) -> None:  # pragma: no cover - should not run
+        raise AssertionError("pace_sleep should not be awaited for animated actions")
+
+    monkeypatch.setattr(
+        "autofighter.rooms.battle.pacing.pace_sleep",
+        fake_sleep,
+        raising=True,
+    )
+
+    await impact_pause(actor, 1, duration=0.3)


### PR DESCRIPTION
## Summary
- add an `impact_pause` helper so instant actions still respect turn pacing
- invoke the helper from player/foe loops and counter passives to keep counters synchronized with pacing
- add unit coverage verifying zero-duration animations still yield via the pacing helper

## Testing
- uv run pytest tests/test_animation_timers.py tests/test_graygray_counter_maestro_burst.py


------
https://chatgpt.com/codex/tasks/task_b_68ca3bdac62c832ca554426f0d932501