### PR TITLE
[FEAT] Render floating battle events

### DIFF
--- a/frontend/.codex/implementation/battle-effects.md
+++ b/frontend/.codex/implementation/battle-effects.md
@@ -66,3 +66,10 @@ watches incoming battle log lines, maps keywords like `damage`, `burn`,
 component so the matching animation plays. `vite.config.js` copies the
 `effekseer.wasm` runtime and marks `.efkefc` files as static assets so the
 player can fetch them at runtime.
+
+`BattleEventFloaters.svelte` listens to the incremental `recent_events`
+stream from battle snapshots. It filters damage and healing payloads,
+derives damage-type visuals through `assetLoader.js`, and spawns floating
+badges that drift upward over the polling cadence. The overlay removes each
+badge after its animation (or a timer when Reduced Motion is enabled) so
+the DOM stays bounded.

--- a/frontend/src/lib/components/BattleEventFloaters.svelte
+++ b/frontend/src/lib/components/BattleEventFloaters.svelte
@@ -1,0 +1,211 @@
+<script>
+  import { onDestroy } from 'svelte';
+  import { getDamageTypeVisual } from '$lib/systems/assetLoader.js';
+
+  const RANDOM_OFFSETS = 120;
+  const BASE_DURATION = 900;
+
+  export let events = [];
+  export let reducedMotion = false;
+  export let paceMs = 1200;
+
+  let floaters = [];
+  let counter = 0;
+  const timeouts = new Map();
+
+  function resolveVariant(type) {
+    const t = String(type || '').toLowerCase();
+    if (t === 'heal_received' || t === 'hot_tick') return 'heal';
+    if (t === 'dot_tick') return 'dot';
+    return 'damage';
+  }
+
+  function resolveLabel(metadata) {
+    if (!metadata || typeof metadata !== 'object') return '';
+    const list = Array.isArray(metadata.effects) ? metadata.effects : [];
+    for (const entry of list) {
+      if (!entry || typeof entry !== 'object') continue;
+      if (entry.name) return String(entry.name);
+      if (entry.id) return String(entry.id);
+    }
+    return '';
+  }
+
+  function scheduleRemoval(id, duration) {
+    const timeoutMs = Math.max(BASE_DURATION, Number(duration) || BASE_DURATION) + 100;
+    const handle = setTimeout(() => removeFloater(id), timeoutMs);
+    timeouts.set(id, handle);
+  }
+
+  function removeFloater(id) {
+    const handle = timeouts.get(id);
+    if (handle) {
+      clearTimeout(handle);
+      timeouts.delete(id);
+    }
+    floaters = floaters.filter((entry) => entry.id !== id);
+  }
+
+  function pushEvents(list) {
+    if (!Array.isArray(list) || list.length === 0) return;
+    const duration = Math.max(BASE_DURATION, Number(paceMs) || BASE_DURATION);
+    const next = [...floaters];
+    for (const raw of list) {
+      if (!raw || typeof raw !== 'object') continue;
+      const amount = Math.abs(Number(raw.amount ?? 0));
+      if (!Number.isFinite(amount) || amount <= 0) continue;
+      const variant = resolveVariant(raw.type);
+      const damageType = raw.damageTypeId || raw.metadata?.damage_type_id || '';
+      const { icon: Icon, color } = getDamageTypeVisual(damageType, { variant });
+      const label = raw.effectLabel || resolveLabel(raw.metadata);
+      const id = `${Date.now()}-${counter++}`;
+      const offset = Math.random() * RANDOM_OFFSETS - RANDOM_OFFSETS / 2;
+      next.push({
+        id,
+        Icon,
+        color,
+        amount,
+        variant,
+        label,
+        offset,
+        tone: variant === 'heal' || variant === 'hot' ? 'heal' : 'damage',
+        type: raw.type,
+      });
+      scheduleRemoval(id, duration);
+    }
+    floaters = next;
+  }
+
+  $: if (events && events.length) {
+    pushEvents(events);
+  }
+
+  function handleAnimationEnd(entry) {
+    if (!reducedMotion) {
+      removeFloater(entry.id);
+    }
+  }
+
+  onDestroy(() => {
+    for (const handle of timeouts.values()) {
+      clearTimeout(handle);
+    }
+    timeouts.clear();
+  });
+</script>
+
+<div class:reduced={reducedMotion} class="floater-host" aria-hidden="true">
+  {#each floaters as entry (entry.id)}
+    <div
+      class={`floater ${entry.tone} ${entry.variant}`}
+      style={`--accent: ${entry.color}; --offset: ${entry.offset}px; --floater-duration: ${Math.max(BASE_DURATION, Number(paceMs) || BASE_DURATION)}ms;`}
+      on:animationend={() => handleAnimationEnd(entry)}
+    >
+      <div class="badge">
+        <span class="icon" style={`background:${entry.color}`}> 
+          {#if entry.Icon}
+            <svelte:component this={entry.Icon} size={14} stroke-width={2} />
+          {/if}
+        </span>
+        <span class="amount" data-variant={entry.variant}>
+          {entry.variant === 'heal' || entry.variant === 'hot' ? '+' : '-'}{Math.round(entry.amount)}
+        </span>
+        {#if entry.label}
+          <span class="label">{entry.label}</span>
+        {/if}
+      </div>
+    </div>
+  {/each}
+</div>
+
+<style>
+  .floater-host {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    z-index: 3;
+    overflow: hidden;
+    display: block;
+  }
+
+  .floater {
+    position: absolute;
+    left: calc(50% + var(--offset, 0px));
+    top: 52%;
+    transform: translate(-50%, 0);
+    animation: float-up var(--floater-duration, 1200ms) cubic-bezier(0.2, 0.8, 0.2, 1) forwards;
+  }
+
+  .floater.dot {
+    filter: drop-shadow(0 0 6px rgba(0, 0, 0, 0.4));
+  }
+
+  .floater .badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.35rem 0.6rem;
+    border-radius: 999px;
+    background: rgba(15, 15, 20, 0.75);
+    border: 1px solid var(--accent, rgba(255, 255, 255, 0.35));
+    color: white;
+    font-weight: 600;
+    font-size: 0.95rem;
+    letter-spacing: 0.01em;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.35);
+  }
+
+  .floater.heal .badge {
+    background: rgba(30, 40, 30, 0.75);
+  }
+
+  .floater .icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.6rem;
+    height: 1.6rem;
+    border-radius: 999px;
+    color: #101010;
+  }
+
+  .floater .amount {
+    min-width: 3ch;
+    text-align: right;
+  }
+
+  .floater .label {
+    font-size: 0.8rem;
+    opacity: 0.85;
+    text-transform: capitalize;
+  }
+
+  @keyframes float-up {
+    0% {
+      opacity: 0;
+      transform: translate(-50%, 24px) scale(0.9);
+    }
+    10% {
+      opacity: 1;
+      transform: translate(-50%, 0) scale(1);
+    }
+    85% {
+      opacity: 1;
+      transform: translate(-50%, -48px) scale(1);
+    }
+    100% {
+      opacity: 0;
+      transform: translate(-50%, -56px) scale(0.98);
+    }
+  }
+
+  .floater-host.reduced .floater {
+    animation: none;
+    opacity: 1;
+    transform: translate(-50%, 0);
+  }
+
+  .floater-host.reduced .badge {
+    transition: opacity 0.25s ease;
+  }
+</style>


### PR DESCRIPTION
## Summary
- parse the enriched `recent_events` payloads in `BattleView` and emit overlays for new damage/heal ticks
- add a `BattleEventFloaters` overlay that animates badges with damage-type iconography while respecting reduced motion
- expand the asset loader with damage/heal color+icon helpers and document the new overlay pipeline

## Testing
- bun run lint

------
https://chatgpt.com/codex/tasks/task_b_68ca430835a0832c86d6105fab1187fe