### PR TITLE
fix: guard fire drain scheduling without loop

### DIFF
--- a/backend/plugins/damage_types/fire.py
+++ b/backend/plugins/damage_types/fire.py
@@ -8,6 +8,7 @@ from autofighter.stats import BUS
 from autofighter.stats import Stats
 from plugins import damage_effects
 from plugins.damage_types._base import DamageTypeBase
+from plugins.event_bus import bus as _event_bus
 
 
 @dataclass
@@ -80,6 +81,7 @@ class Fire(DamageTypeBase):
                 loop = asyncio.get_running_loop()
             except RuntimeError:
                 asyncio.run(actor.apply_damage(pre))
+                _event_bus._process_batches_sync()
             else:
                 loop.create_task(actor.apply_damage(pre))
 


### PR DESCRIPTION
## Summary
- guard Fire damage type's turn-start drain scheduling with `asyncio.get_running_loop`
- fall back to `asyncio.run` when no loop is running so the self-burn still applies synchronously
- flush the event bus batches after the synchronous fallback so damage events still dispatch

## Testing
- `uv run ruff check backend/plugins/damage_types/fire.py --fix`


------
https://chatgpt.com/codex/tasks/task_b_68ca4761615c832cbf56ee09bdfab938