### PR TITLE
feat(damage): rework dark siphon bonus

### DIFF
--- a/backend/.codex/implementation/vitality-effects.md
+++ b/backend/.codex/implementation/vitality-effects.md
@@ -6,10 +6,10 @@
 - Light damage type users grant all allies a stack of Radiant Regeneration
   (5 HP over 2 turns) on each action and will directly heal allies under 25%
   HP instead of attacking.
-- Dark damage type users apply a stack of Shadow Siphon to every party member
-  each action. The DoT has no turn limit and drains 5% of max HP per stack each
-  tick. For every 1% of max HP drained, the Dark user gains matching attack and
-  defense. All Shadow Siphon stacks are cleared when the battle ends.
+- Dark damage type users siphon 10% of each living ally's current HP whenever
+  they act, never reducing anyone below 1 HP. The health drained contributes to
+  a temporary damage multiplier on their next strike (roughly 0.0001× per HP
+  siphoned with slight randomness), after which the bonus is cleared.
 - Wind damage type users strike all remaining foes after their first hit,
   repeating the damage and rolling their Gale Erosion DoT on each target.
 - When a Wind user fires their ultimate, all existing enemy DoTs are pulled

--- a/backend/plugins/damage_types/dark.py
+++ b/backend/plugins/damage_types/dark.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
+import random
 
 from autofighter.effects import DamageOverTime
-from autofighter.effects import create_stat_buff
 from autofighter.stats import BUS
 from autofighter.stats import Stats
 from plugins import damage_effects
@@ -15,78 +15,45 @@ class Dark(DamageTypeBase):
     weakness: str = "Light"
     color: tuple[int, int, int] = (145, 0, 145)
 
-    _cleanup_registered: bool = False
-
     async def on_action(self, actor, allies, enemies) -> bool:
+        from autofighter.rooms.battle.pacing import YIELD_MULTIPLIER
+        from autofighter.rooms.battle.pacing import pace_sleep
+
+        total_drained = 0
+
         for member in allies:
-            mgr = getattr(member, "effect_manager", None)
-            if mgr is not None:
-                dmg = int(member.max_hp * 0.05)
-                mgr.add_dot(damage_effects.create_shadow_siphon(dmg, actor))
+            if getattr(member, "hp", 0) <= 1:
+                await pace_sleep(YIELD_MULTIPLIER)
+                continue
 
-        if not self._cleanup_registered:
-            def _clear(_):
-                sid = damage_effects.SHADOW_SIPHON_ID
-                for member in allies:
-                    member.dots = [d for d in member.dots if d != sid]
-                    mgr = getattr(member, "effect_manager", None)
-                    if mgr is not None:
-                        mgr.dots = [d for d in mgr.dots if getattr(d, "id", "") != sid]
-                self._cleanup_registered = False
+            drain = max(int(member.hp * 0.10), 1)
+            drain = min(drain, member.hp - 1)
+            if drain <= 0:
+                await pace_sleep(YIELD_MULTIPLIER)
+                continue
 
-            BUS.subscribe("battle_end", _clear)
-            self._cleanup_registered = True
+            drained = await member.apply_cost_damage(drain)
+            total_drained += max(int(drained), 0)
+            await pace_sleep(YIELD_MULTIPLIER)
+
+        if total_drained > 0:
+            variance = random.uniform(0.99, 1.01)
+            bonus = 1.0 + (total_drained * 0.0001 * variance)
+            setattr(actor, "_pending_dark_bonus", bonus)
+        else:
+            if hasattr(actor, "_pending_dark_bonus"):
+                delattr(actor, "_pending_dark_bonus")
 
         return True
 
-    def on_party_dot_damage_taken(self, damage, attacker, target) -> float:
-        """Grant a tiny scaling bonus when Dark DoTs tick on allies.
-
-        If the ticking DoT comes from a Dark attacker and the target is
-        currently affected by Shadow Siphon, increase the attacker's
-        offensive and defensive stats by a factor proportional to the
-        damage dealt as a fraction of the target's max HP.
-
-        The incoming ``damage`` value is returned unchanged; only the
-        attacker is adjusted.
-        """
-
-        try:
-            # Preconditions: source must be Dark and the target must have Shadow Siphon.
-            if getattr(attacker, "damage_type", None) is not self:
-                return damage
-
-            if damage_effects.SHADOW_SIPHON_ID not in getattr(target, "dots", []):
-                return damage
-
-            # Compute damage as a fraction of max HP (guard against div-by-zero).
-            max_hp = max(float(getattr(target, "max_hp", 0) or 0.0), 1.0)
-            percent_of_max = max(float(damage) / max_hp, 0.0)
-
-            # 0.05 per 1.0 (i.e., +5% when DoT equals 100% of max HP).
-            scale = 1.0 + percent_of_max * 0.05
-
-            # Apply scale to common stats via a temporary buff.
-            mgr = getattr(attacker, "effect_manager", None)
-            changes: dict[str, float] = {}
-            if hasattr(attacker, "atk"):
-                changes["atk_mult"] = scale
-                changes["atk"] = 1
-            if hasattr(attacker, "defense"):
-                changes["defense_mult"] = scale
-                changes["defense"] = 1
-            if mgr is not None and changes:
-                mod = create_stat_buff(
-                    attacker,
-                    name="Dark Resonance",
-                    id="dark_resonance",
-                    turns=9999,
-                    **changes
-                )
-                mgr.add_modifier(mod)
-        except Exception:
-            # Intentionally swallow errors to avoid breaking combat flow.
-            pass
+    def on_damage(self, damage, attacker, target) -> float:
+        bonus = getattr(attacker, "_pending_dark_bonus", None)
+        if isinstance(bonus, (int, float)) and bonus > 0:
+            damage *= bonus
+            try:
+                delattr(attacker, "_pending_dark_bonus")
+            except AttributeError:
+                pass
         return damage
 
     # Per-stack damage multiplier for Darkness ultimate.


### PR DESCRIPTION
## Summary
- replace Shadow Siphon upkeep with a paced HP drain that feeds a temporary Dark damage multiplier
- apply the stored multiplier to the next Dark attack and drop the old DoT scaling hook
- document the new siphon behaviour in the vitality effects reference

## Testing
- [ ] Backend tests
- [ ] Frontend tests
- [x] Linting
- [x] Doc sync updates (README and `.codex/implementation` docs; link tasks below)

## Checklist
- [ ] Linked or updated relevant `.codex/tasks` entries
- [ ] Updated player roster and foe docs if adding or modifying fighters or enemies
- [ ] Referenced `.codex/implementation/ui-animation-guidelines.md` when adding UI animations

------
https://chatgpt.com/codex/tasks/task_b_68ca5573111c832c8eaaa6c29ccef472