### PR TITLE
Fix Battle Meditation ultimate charge stacking

### DIFF
--- a/backend/plugins/cards/battle_meditation.py
+++ b/backend/plugins/cards/battle_meditation.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 from dataclasses import field
+import logging
 
 from autofighter.stats import BUS
 from plugins.cards._base import CardBase
@@ -12,11 +13,23 @@ class BattleMeditation(CardBase):
     stars: int = 1
     effects: dict[str, float] = field(default_factory=lambda: {"exp_multiplier": 0.03, "vitality": 0.03})
     about: str = "+3% EXP Gain & +3% Vitality; If all allies start at full HP, grant +2% ultimate charge for the first turn"
+    _battle_boost_applied: bool = field(default=False, init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        self._battle_boost_applied = False
 
     async def apply(self, party) -> None:  # type: ignore[override]
         await super().apply(party)
 
-        def _on_battle_start(target):
+        log = logging.getLogger(__name__)
+
+        self._battle_boost_applied = False
+
+        async def _on_battle_start(target):
+            if self._battle_boost_applied:
+                return
+
             # Only trigger once per battle when one of our party members starts
             if target in party.members:
                 # Check if all allies start at full HP
@@ -26,16 +39,23 @@ class BattleMeditation(CardBase):
                 )
 
                 if all_full_hp:
+                    self._battle_boost_applied = True
                     # Grant +2 ultimate charge to all party members for first turn
                     for member in party.members:
                         member.add_ultimate_charge(2)
-                        import logging
-                        log = logging.getLogger(__name__)
                         log.debug("Battle Meditation ultimate charge bonus: +2 charge to %s", member.id)
-                        BUS.emit("card_effect", self.id, member, "meditation_charge", 2, {
+                        await BUS.emit_async("card_effect", self.id, member, "meditation_charge", 2, {
                             "charge_bonus": 2,
                             "trigger_condition": "all_full_hp",
                             "trigger_event": "battle_start"
                         })
 
+                    BUS.unsubscribe("battle_start", _on_battle_start)
+
+        def _on_battle_end(entity) -> None:
+            self._battle_boost_applied = False
+            BUS.unsubscribe("battle_start", _on_battle_start)
+            BUS.unsubscribe("battle_end", _on_battle_end)
+
         BUS.subscribe("battle_start", _on_battle_start)
+        BUS.subscribe("battle_end", _on_battle_end)


### PR DESCRIPTION
## Summary
- update Battle Meditation's battle start handler to be async so it emits its `card_effect` event through `BUS.emit_async`
- retain the per-battle guard and cleanup so the ultimate boost still only applies once per encounter

## Testing
- [x] `uv run ruff check plugins/cards/battle_meditation.py --fix`
- [ ] `uv run ruff check . --fix` *(fails: existing undefined `_LLR_old` reference in `plugins/damage_types/generic.py`)*
- [ ] `uv run pytest tests/test_card_effects.py` *(fails: ModuleNotFoundError: No module named 'battle_logging')*


------
https://chatgpt.com/codex/tasks/task_b_68ca5a7be06c832cbb3444fd22c29922