### PR TITLE
[FIX] Stabilize Bulwark Totem damage soak (follow-up)

### DIFF
--- a/backend/plugins/cards/bulwark_totem.py
+++ b/backend/plugins/cards/bulwark_totem.py
@@ -48,6 +48,9 @@ class BulwarkTotem(CardBase):
             if share_ratio <= 0:
                 return
 
+            current_hp = max(0, int(getattr(target, "hp", 0)))
+            effective_post_hit_hp = max(post_hit_hp, current_hp)
+
             redirect_amount = max(1, int(damage * share_ratio))
 
             # Identify a healthy ally that can donate HP.
@@ -72,15 +75,15 @@ class BulwarkTotem(CardBase):
             if max_transfer <= 0:
                 return
 
-            heal_cap = max_hp - post_hit_hp if max_hp else redirect_amount
+            heal_cap = max_hp - effective_post_hit_hp if max_hp else redirect_amount
             transfer_amount = min(redirect_amount, max_transfer, heal_cap)
             if transfer_amount <= 0:
                 return
 
             target.hp = (
-                post_hit_hp + transfer_amount
+                effective_post_hit_hp + transfer_amount
                 if not max_hp
-                else min(post_hit_hp + transfer_amount, max_hp)
+                else min(effective_post_hit_hp + transfer_amount, max_hp)
             )
             card_holder.hp = max(1, holder_hp - transfer_amount)
 


### PR DESCRIPTION
## Summary
- track the target's live HP when Bulwark Totem reacts to lethal damage
- base the heal cap and restoration amount on the greater of current and snapshot HP to avoid overwriting revives

## Testing
- `uv run ruff check backend/plugins/cards/bulwark_totem.py backend/autofighter/stats.py`


------
https://chatgpt.com/codex/tasks/task_b_68ca92f9d118832c989952bdc4e64fad