### PR TITLE
[FIX] Scope relic listeners per party state

### DIFF
--- a/backend/plugins/relics/echo_bell.py
+++ b/backend/plugins/relics/echo_bell.py
@@ -19,38 +19,69 @@ class EchoBell(RelicBase):
     def apply(self, party) -> None:
         super().apply(party)
 
-        used: set[int] = set()
+        state = getattr(party, "_echo_bell_state", None)
+        stacks = party.relics.count(self.id)
 
-        def _battle_start(*args) -> None:
-            used.clear()
+        if state is None:
+            used: set[int] = set()
 
-        def _action(actor, target, amount, action_type="damage") -> None:
-            pid = id(actor)
-            if pid in used:
-                return
-            used.add(pid)
-            stacks = party.relics.count(self.id)
-            echo_amount = int(amount * 0.15 * stacks)
+            def _battle_start(*_args) -> None:
+                used.clear()
 
-            # Emit relic effect event for echo action
-            BUS.emit("relic_effect", "echo_bell", actor, "echo_action", echo_amount, {
-                "original_amount": amount,
-                "echo_percentage": 15 * stacks,
-                "target": getattr(target, 'id', str(target)),
-                "first_action": True,
-                "action_type": action_type,
-                "stacks": stacks
-            })
+            def _action(actor, target, amount, action_type="damage") -> None:
+                pid = id(actor)
+                if pid in used:
+                    return
+                used.add(pid)
+                current_stacks = state.get("stacks", 0)
+                if current_stacks <= 0:
+                    return
+                echo_amount = int(amount * 0.15 * current_stacks)
 
-            # Echo the same type of action - damage or healing
-            if action_type == "healing":
-                safe_async_task(target.apply_healing(echo_amount, healer=actor))
-            else:
-                safe_async_task(target.apply_damage(echo_amount, attacker=actor))
+                # Emit relic effect event for echo action
+                BUS.emit("relic_effect", "echo_bell", actor, "echo_action", echo_amount, {
+                    "original_amount": amount,
+                    "echo_percentage": 15 * current_stacks,
+                    "target": getattr(target, 'id', str(target)),
+                    "first_action": True,
+                    "action_type": action_type,
+                    "stacks": current_stacks
+                })
 
-        BUS.subscribe("battle_start", _battle_start)
-        BUS.subscribe("action_used", _action)
-        BUS.subscribe("healing_used", lambda actor, target, amount: _action(actor, target, amount, "healing"))
+                # Echo the same type of action - damage or healing
+                if action_type == "healing":
+                    safe_async_task(target.apply_healing(echo_amount, healer=actor))
+                else:
+                    safe_async_task(target.apply_damage(echo_amount, attacker=actor))
+
+            def _healing(actor, target, amount) -> None:
+                _action(actor, target, amount, "healing")
+
+            def _cleanup(*_args) -> None:
+                BUS.unsubscribe("battle_start", state["battle_start_handler"])
+                BUS.unsubscribe("action_used", state["action_handler"])
+                BUS.unsubscribe("healing_used", state["healing_handler"])
+                BUS.unsubscribe("battle_end", state["cleanup_handler"])
+                used.clear()
+                if getattr(party, "_echo_bell_state", None) is state:
+                    delattr(party, "_echo_bell_state")
+
+            state = {
+                "stacks": stacks,
+                "used": used,
+                "battle_start_handler": _battle_start,
+                "action_handler": _action,
+                "healing_handler": _healing,
+                "cleanup_handler": _cleanup,
+            }
+            party._echo_bell_state = state
+
+            BUS.subscribe("battle_start", _battle_start)
+            BUS.subscribe("action_used", _action)
+            BUS.subscribe("healing_used", _healing)
+            BUS.subscribe("battle_end", _cleanup)
+        else:
+            state["stacks"] = stacks
 
     def describe(self, stacks: int) -> str:
         pct = 15 * stacks

--- a/backend/plugins/relics/echoing_drum.py
+++ b/backend/plugins/relics/echoing_drum.py
@@ -19,32 +19,58 @@ class EchoingDrum(RelicBase):
     def apply(self, party) -> None:
         super().apply(party)
 
-        used: set[int] = set()
+        state = getattr(party, "_echoing_drum_state", None)
+        stacks = party.relics.count(self.id)
 
-        def _battle_start(*args) -> None:
-            used.clear()
+        if state is None:
+            used: set[int] = set()
 
-        def _attack(attacker, target, amount) -> None:
-            pid = id(attacker)
-            if pid in used:
-                return
-            used.add(pid)
-            stacks = party.relics.count(self.id)
-            dmg = int(amount * 0.25 * stacks)
+            def _battle_start(*_args) -> None:
+                used.clear()
 
-            # Emit relic effect event for echo attack
-            BUS.emit("relic_effect", "echoing_drum", attacker, "echo_attack", dmg, {
-                "original_amount": amount,
-                "echo_percentage": 25 * stacks,
-                "target": getattr(target, 'id', str(target)),
-                "first_attack": True,
-                "stacks": stacks
-            })
+            def _attack(attacker, target, amount) -> None:
+                pid = id(attacker)
+                if pid in used:
+                    return
+                used.add(pid)
+                current_stacks = state.get("stacks", 0)
+                if current_stacks <= 0:
+                    return
+                dmg = int(amount * 0.25 * current_stacks)
 
-            safe_async_task(target.apply_damage(dmg, attacker=attacker))
+                # Emit relic effect event for echo attack
+                BUS.emit("relic_effect", "echoing_drum", attacker, "echo_attack", dmg, {
+                    "original_amount": amount,
+                    "echo_percentage": 25 * current_stacks,
+                    "target": getattr(target, 'id', str(target)),
+                    "first_attack": True,
+                    "stacks": current_stacks
+                })
 
-        BUS.subscribe("battle_start", _battle_start)
-        BUS.subscribe("action_used", _attack)
+                safe_async_task(target.apply_damage(dmg, attacker=attacker))
+
+            def _cleanup(*_args) -> None:
+                BUS.unsubscribe("battle_start", state["battle_start_handler"])
+                BUS.unsubscribe("action_used", state["attack_handler"])
+                BUS.unsubscribe("battle_end", state["cleanup_handler"])
+                used.clear()
+                if getattr(party, "_echoing_drum_state", None) is state:
+                    delattr(party, "_echoing_drum_state")
+
+            state = {
+                "stacks": stacks,
+                "used": used,
+                "battle_start_handler": _battle_start,
+                "attack_handler": _attack,
+                "cleanup_handler": _cleanup,
+            }
+            party._echoing_drum_state = state
+
+            BUS.subscribe("battle_start", _battle_start)
+            BUS.subscribe("action_used", _attack)
+            BUS.subscribe("battle_end", _cleanup)
+        else:
+            state["stacks"] = stacks
 
     def describe(self, stacks: int) -> str:
         pct = 25 * stacks

--- a/backend/plugins/relics/herbal_charm.py
+++ b/backend/plugins/relics/herbal_charm.py
@@ -17,21 +17,43 @@ class HerbalCharm(RelicBase):
     about: str = "Heals all allies for 0.5% Max HP at the start of each turn per stack."
 
     def apply(self, party) -> None:
-        def _heal(*_) -> None:
-            stacks = party.relics.count(self.id)
-            for member in party.members:
-                heal = int(member.max_hp * 0.005 * stacks)
+        state = getattr(party, "_herbal_charm_state", None)
+        stacks = party.relics.count(self.id)
 
-                # Emit relic effect event for healing
-                BUS.emit("relic_effect", "herbal_charm", member, "turn_start_healing", heal, {
-                    "healing_percentage": 0.5 * stacks,
-                    "max_hp": member.max_hp,
-                    "stacks": stacks
-                })
+        if state is None:
+            def _heal(*_) -> None:
+                current_stacks = state.get("stacks", 0)
+                if current_stacks <= 0:
+                    return
+                for member in party.members:
+                    heal = int(member.max_hp * 0.005 * current_stacks)
 
-                safe_async_task(member.apply_healing(heal))
+                    # Emit relic effect event for healing
+                    BUS.emit("relic_effect", "herbal_charm", member, "turn_start_healing", heal, {
+                        "healing_percentage": 0.5 * current_stacks,
+                        "max_hp": member.max_hp,
+                        "stacks": current_stacks
+                    })
 
-        BUS.subscribe("turn_start", _heal)
+                    safe_async_task(member.apply_healing(heal))
+
+            def _cleanup(*_args) -> None:
+                BUS.unsubscribe("turn_start", state["heal_handler"])
+                BUS.unsubscribe("battle_end", state["cleanup_handler"])
+                if getattr(party, "_herbal_charm_state", None) is state:
+                    delattr(party, "_herbal_charm_state")
+
+            state = {
+                "stacks": stacks,
+                "heal_handler": _heal,
+                "cleanup_handler": _cleanup,
+            }
+            party._herbal_charm_state = state
+
+            BUS.subscribe("turn_start", _heal)
+            BUS.subscribe("battle_end", _cleanup)
+        else:
+            state["stacks"] = stacks
 
     def describe(self, stacks: int) -> str:
         pct = 0.5 * stacks

--- a/backend/plugins/relics/vengeful_pendant.py
+++ b/backend/plugins/relics/vengeful_pendant.py
@@ -19,30 +19,52 @@ class VengefulPendant(RelicBase):
     def apply(self, party) -> None:
         super().apply(party)
 
-        def _reflect(target, attacker, amount) -> None:
-            if attacker is None or target not in party.members:
-                return
-            stacks = party.relics.count(self.id)
-            dmg = int(amount * 0.15 * stacks)
+        stacks = party.relics.count(self.id)
+        state = getattr(party, "_vengeful_pendant_state", None)
 
-            # Emit relic effect event for damage reflection
-            BUS.emit(
-                "relic_effect",
-                "vengeful_pendant",
-                target,
-                "damage_reflection",
-                dmg,
-                {
-                    "original_damage": amount,
-                    "reflection_percentage": 15 * stacks,
-                    "reflected_to": getattr(attacker, "id", str(attacker)),
-                    "stacks": stacks,
-                },
-            )
+        if state is None:
+            def _reflect(target, attacker, amount) -> None:
+                if attacker is None or target not in party.members:
+                    return
+                current_stacks = state.get("stacks", 0)
+                if current_stacks <= 0:
+                    return
+                dmg = int(amount * 0.15 * current_stacks)
 
-            safe_async_task(attacker.apply_damage(dmg, attacker=target))
+                # Emit relic effect event for damage reflection
+                BUS.emit(
+                    "relic_effect",
+                    "vengeful_pendant",
+                    target,
+                    "damage_reflection",
+                    dmg,
+                    {
+                        "original_damage": amount,
+                        "reflection_percentage": 15 * current_stacks,
+                        "reflected_to": getattr(attacker, "id", str(attacker)),
+                        "stacks": current_stacks,
+                    },
+                )
 
-        BUS.subscribe("damage_taken", _reflect)
+                safe_async_task(attacker.apply_damage(dmg, attacker=target))
+
+            def _cleanup(*_args) -> None:
+                BUS.unsubscribe("damage_taken", state["damage_handler"])
+                BUS.unsubscribe("battle_end", state["cleanup_handler"])
+                if getattr(party, "_vengeful_pendant_state", None) is state:
+                    delattr(party, "_vengeful_pendant_state")
+
+            state = {
+                "stacks": stacks,
+                "damage_handler": _reflect,
+                "cleanup_handler": _cleanup,
+            }
+            party._vengeful_pendant_state = state
+
+            BUS.subscribe("damage_taken", _reflect)
+            BUS.subscribe("battle_end", _cleanup)
+        else:
+            state["stacks"] = stacks
 
     def describe(self, stacks: int) -> str:
         pct = 15 * stacks


### PR DESCRIPTION
## Summary
- add per-party state tracking for Arcane Flask, Echo Bell, Echoing Drum, and Vengeful Pendant so shared handlers compute stack bonuses at runtime and clean up on battle end
- extend Ember Stone, Herbal Charm, Killer Instinct, Null Lantern, Old Coin, and Rusty Buckle with shared state updates and teardown logic to prevent duplicate BUS subscriptions between battles

## Testing
- `./run-tests.sh` *(fails: missing optional dependencies such as battle_logging and llms loader artifacts in the current environment)*

------
https://chatgpt.com/codex/tasks/task_b_68ca92bb7e44832c87d760824f13487c