### PR TITLE
[FIX] Scope relic listeners per party state

### DIFF
--- a/backend/plugins/relics/null_lantern.py
+++ b/backend/plugins/relics/null_lantern.py
@@ -83,7 +83,12 @@ class NullLantern(RelicBase):
                         "disabled_rests": True
                     })
 
-            def _cleanup(*_args) -> None:
+            def _cleanup(entity) -> None:
+                from plugins.foes._base import FoeBase
+
+                if not isinstance(entity, FoeBase):
+                    return
+
                 BUS.unsubscribe("battle_start", state["battle_start_handler"])
                 BUS.unsubscribe("battle_end", state["battle_end_handler"])
                 BUS.unsubscribe("battle_end", state["cleanup_handler"])


### PR DESCRIPTION
## Summary
- add per-party state tracking for Arcane Flask, Echo Bell, Echoing Drum, and Vengeful Pendant so shared handlers compute stack bonuses at runtime and clean up on battle end
- extend Ember Stone, Herbal Charm, Killer Instinct, Null Lantern, Old Coin, and Rusty Buckle with shared state updates and teardown logic to prevent duplicate BUS subscriptions between battles, and guard Null Lantern cleanup so foe events award pulls before listeners are removed

## Testing
- `./run-tests.sh` *(fails: accelerate, battle_logging, and llms optional dependencies missing and event batching perf assertion in current environment)*

------
https://chatgpt.com/codex/tasks/task_b_68ca972b179c832c8cec54cc65514e58