### PR TITLE
refactor: await event bus emissions

### DIFF
--- a/backend/autofighter/effects.py
+++ b/backend/autofighter/effects.py
@@ -473,7 +473,7 @@ class EffectManager:
                 if predicted_turns is not None:
                     details["predicted_turns"] = predicted_turns
 
-                BUS.emit(
+                BUS.emit_batched(
                     "effect_resisted",
                     effect_name,
                     self.stats,

--- a/backend/autofighter/relics.py
+++ b/backend/autofighter/relics.py
@@ -42,9 +42,9 @@ def relic_choices(party: Party, stars: int, count: int = 3) -> list[RelicBase]:
     k = min(count, len(available))
     return random.sample(available, k=k)
 
-def apply_relics(party: Party) -> None:
+async def apply_relics(party: Party) -> None:
     registry = _registry()
     for rid in party.relics:
         relic_cls = registry.get(rid)
         if relic_cls:
-            relic_cls().apply(party)
+            await relic_cls().apply(party)

--- a/backend/autofighter/rooms/battle/setup.py
+++ b/backend/autofighter/rooms/battle/setup.py
@@ -50,14 +50,10 @@ async def _clone_members(members: Sequence[Stats]) -> list[Stats]:
 async def _apply_relics_async(party: Party) -> None:
     """Asynchronously apply relic effects to a party."""
 
-    # `apply_relics` relies on `safe_async_task` to schedule follow-up coroutine
-    # work on the running event loop. When executed inside ``asyncio.to_thread``
-    # there is no active loop, so the helper falls back to spinning up a
-    # temporary loop via ``asyncio.run``. That temporary loop is torn down as
-    # soon as the coroutine returns, cancelling any batched bus emissions (for
-    # example, healing notifications). Keep the call on the main loop so that
-    # relic effects continue to dispatch their async side effects.
-    apply_relics(party)
+    # `apply_relics` now awaits each relic's async setup directly. Running it on
+    # the main loop ensures follow-up emissions (e.g. healing notifications)
+    # execute without being cancelled by temporary event loops.
+    await apply_relics(party)
 
 
 async def setup_battle(

--- a/backend/plugins/cards/_base.py
+++ b/backend/plugins/cards/_base.py
@@ -62,11 +62,18 @@ class CardBase:
                 mgr.add_modifier(mod)
 
                 # Emit card effect event
-                BUS.emit("card_effect", self.id, member, f"stat_buff_{attr}", int(pct * 100), {
-                    "stat_affected": attr,
-                    "percentage_change": pct * 100,
-                    "new_modifier": f"{self.id}_{attr}"
-                })
+                await BUS.emit_async(
+                    "card_effect",
+                    self.id,
+                    member,
+                    f"stat_buff_{attr}",
+                    int(pct * 100),
+                    {
+                        "stat_affected": attr,
+                        "percentage_change": pct * 100,
+                        "new_modifier": f"{self.id}_{attr}",
+                    },
+                )
 
                 if attr == "max_hp":
                     heal = int(getattr(member, "hp", 0) * pct)
@@ -78,10 +85,17 @@ class CardBase:
                         asyncio.create_task(member.apply_healing(heal))
 
                     # Emit card healing event
-                    BUS.emit("card_effect", self.id, member, "healing", heal, {
-                        "heal_amount": heal,
-                        "heal_type": "max_hp_increase"
-                    })
+                    await BUS.emit_async(
+                        "card_effect",
+                        self.id,
+                        member,
+                        "healing",
+                        heal,
+                        {
+                            "heal_amount": heal,
+                            "heal_type": "max_hp_increase",
+                        },
+                    )
 
                     log.debug(
                         "Updated %s max_hp and healed %s",

--- a/backend/plugins/cards/a_micro_blade.py
+++ b/backend/plugins/cards/a_micro_blade.py
@@ -21,7 +21,7 @@ class MicroBlade(CardBase):
     async def apply(self, party) -> None:  # type: ignore[override]
         await super().apply(party)
 
-        def _on_damage_dealt(attacker, target, damage, damage_type, source, source_action, action_name):
+        async def _on_damage_dealt(attacker, target, damage, damage_type, source, source_action, action_name):
             # Check if attacker is one of our party members and this is an attack
             if attacker in party.members and action_name == "attack":
                 # 6% chance to deal +8% bonus physical damage
@@ -39,7 +39,7 @@ class MicroBlade(CardBase):
                         log.debug(
                             "Micro Blade bonus damage: +%d physical damage", bonus_damage
                         )
-                        BUS.emit(
+                        await BUS.emit_async(
                             "card_effect",
                             self.id,
                             attacker,

--- a/backend/plugins/cards/arc_lightning.py
+++ b/backend/plugins/cards/arc_lightning.py
@@ -35,7 +35,7 @@ class ArcLightning(CardBase):
                 BUS.unsubscribe("battle_start", _battle_start)
                 BUS.unsubscribe("battle_end", _battle_end)
 
-        def _hit(attacker, target, amount, source, *_):
+        async def _hit(attacker, target, amount, source, *_):
             if attacker not in party.members or source != "attack":
                 return
             valid = [f for f in foes if f.hp > 0 and f is not target]
@@ -44,7 +44,7 @@ class ArcLightning(CardBase):
             extra = random.choice(valid)
             extra_dmg = int(amount * 0.5)
             safe_async_task(extra.apply_damage(extra_dmg, attacker, trigger_on_hit=False))
-            BUS.emit(
+            await BUS.emit_async(
                 "card_effect",
                 self.id,
                 attacker,

--- a/backend/plugins/cards/arcane_repeater.py
+++ b/backend/plugins/cards/arcane_repeater.py
@@ -22,13 +22,13 @@ class ArcaneRepeater(CardBase):
     async def apply(self, party) -> None:  # type: ignore[override]
         await super().apply(party)
 
-        def _attack(attacker, target, amount) -> None:
+        async def _attack(attacker, target, amount) -> None:
             if attacker not in party.members:
                 return
             if random.random() >= 0.30:
                 return
             dmg = int(amount * 0.5)
-            BUS.emit(
+            await BUS.emit_async(
                 "card_effect",
                 self.id,
                 attacker,

--- a/backend/plugins/cards/balanced_diet.py
+++ b/backend/plugins/cards/balanced_diet.py
@@ -18,7 +18,7 @@ class BalancedDiet(CardBase):
     async def apply(self, party) -> None:  # type: ignore[override]
         await super().apply(party)
 
-        def _on_heal_received(target, healer, heal_amount):
+        async def _on_heal_received(target, healer, heal_amount):
             # Check if target is one of our party members
             if target in party.members:
                 # Grant +2% DEF for 1 turn
@@ -39,7 +39,7 @@ class BalancedDiet(CardBase):
                 import logging
                 log = logging.getLogger(__name__)
                 log.debug("Balanced Diet heal bonus: +2% DEF for 1 turn to %s", target.id)
-                BUS.emit("card_effect", self.id, target, "heal_def_bonus", 2, {
+                await BUS.emit_async("card_effect", self.id, target, "heal_def_bonus", 2, {
                     "def_bonus": 2,
                     "duration": 1,
                     "trigger_event": "heal_received",

--- a/backend/plugins/cards/bulwark_totem.py
+++ b/backend/plugins/cards/bulwark_totem.py
@@ -21,7 +21,7 @@ class BulwarkTotem(CardBase):
     async def apply(self, party) -> None:  # type: ignore[override]
         await super().apply(party)
 
-        def _on_damage_taken(target, attacker, damage, pre_damage_hp=None, post_damage_hp=None):
+        async def _on_damage_taken(target, attacker, damage, pre_damage_hp=None, post_damage_hp=None):
             if target not in party.members:
                 return
 
@@ -93,7 +93,7 @@ class BulwarkTotem(CardBase):
                 getattr(card_holder, "id", "unknown"),
                 getattr(target, "id", "unknown"),
             )
-            BUS.emit(
+            await BUS.emit_async(
                 "card_effect",
                 self.id,
                 target,

--- a/backend/plugins/cards/calm_beads.py
+++ b/backend/plugins/cards/calm_beads.py
@@ -16,7 +16,7 @@ class CalmBeads(CardBase):
     async def apply(self, party) -> None:  # type: ignore[override]
         await super().apply(party)
 
-        def _on_effect_resisted(effect_name, target, source, details=None):
+        async def _on_effect_resisted(effect_name, target, source, details=None):
             if target not in party.members:
                 return
 
@@ -56,6 +56,6 @@ class CalmBeads(CardBase):
             }
             if metadata:
                 payload["metadata"] = metadata
-            BUS.emit("card_effect", self.id, target, "resist_charge_gain", 1, payload)
+            await BUS.emit_async("card_effect", self.id, target, "resist_charge_gain", 1, payload)
 
         BUS.subscribe("effect_resisted", _on_effect_resisted)

--- a/backend/plugins/cards/coated_armor.py
+++ b/backend/plugins/cards/coated_armor.py
@@ -16,7 +16,7 @@ class CoatedArmor(CardBase):
     async def apply(self, party) -> None:  # type: ignore[override]
         await super().apply(party)
 
-        def _on_mitigation_triggered(target, original_damage, mitigated_damage):
+        async def _on_mitigation_triggered(target, original_damage, mitigated_damage):
             # Check if target is one of our party members and mitigation actually reduced damage
             if target in party.members and mitigated_damage < original_damage:
                 # Heal 1% HP
@@ -40,7 +40,7 @@ class CoatedArmor(CardBase):
                             heal_amount,
                             target.id,
                         )
-                        BUS.emit(
+                        await BUS.emit_async(
                             "card_effect",
                             self.id,
                             target,

--- a/backend/plugins/cards/critical_focus.py
+++ b/backend/plugins/cards/critical_focus.py
@@ -18,7 +18,7 @@ class CriticalFocus(CardBase):
         await super().apply(party)
         boosts: dict[int, CriticalBoost] = {}
 
-        def _turn_start() -> None:
+        async def _turn_start() -> None:
             for member in party.members:
                 pid = id(member)
                 effect = boosts.get(pid)
@@ -26,8 +26,8 @@ class CriticalFocus(CardBase):
                     effect = CriticalBoost()
                     boosts[pid] = effect
                     setattr(member, "_critical_boost", effect)
-                effect.apply(member)
-                BUS.emit(
+                await effect.apply(member)
+                await BUS.emit_async(
                     "card_effect",
                     self.id,
                     member,

--- a/backend/plugins/cards/critical_overdrive.py
+++ b/backend/plugins/cards/critical_overdrive.py
@@ -22,7 +22,7 @@ class CriticalOverdrive(CardBase):
         await super().apply(party)
         state: dict[int, object] = {}
 
-        def _change(target, stacks) -> None:
+        async def _change(target, stacks) -> None:
             if target not in party.members:
                 return
             pid = id(target)
@@ -45,7 +45,7 @@ class CriticalOverdrive(CardBase):
                 )
                 target.effect_manager.add_modifier(new_mod)
                 state[pid] = new_mod
-                BUS.emit(
+                await BUS.emit_async(
                     "card_effect",
                     self.id,
                     target,

--- a/backend/plugins/cards/critical_transfer.py
+++ b/backend/plugins/cards/critical_transfer.py
@@ -21,13 +21,13 @@ class CriticalTransfer(CardBase):
     async def apply(self, party) -> None:  # type: ignore[override]
         await super().apply(party)
 
-        def _ultimate_used(user) -> None:
+        async def _ultimate_used(user) -> None:
             total = 0
             for member in party.members:
                 boost = getattr(member, "_critical_boost", None)
                 if isinstance(boost, CriticalBoost):
                     total += boost.stacks
-                    boost._on_damage_taken(member)
+                    await boost._on_damage_taken(member)
             if total == 0:
                 return
             effect = getattr(user, "_critical_boost", None)
@@ -35,7 +35,7 @@ class CriticalTransfer(CardBase):
                 effect = CriticalBoost()
                 setattr(user, "_critical_boost", effect)
             for _ in range(total):
-                effect.apply(user)
+                await effect.apply(user)
             mgr = getattr(user, "effect_manager", None)
             if mgr is None:
                 mgr = EffectManager(user)
@@ -47,7 +47,7 @@ class CriticalTransfer(CardBase):
                 atk_mult=1 + 0.04 * total,
             )
             mgr.add_modifier(mod)
-            BUS.emit(
+            await BUS.emit_async(
                 "card_effect",
                 self.id,
                 user,

--- a/backend/plugins/cards/elemental_spark.py
+++ b/backend/plugins/cards/elemental_spark.py
@@ -24,7 +24,7 @@ class ElementalSpark(CardBase):
         await super().apply(party)
         chosen = {"member": None, "mod": None}
 
-        def _battle_start(entity) -> None:
+        async def _battle_start(entity) -> None:
             if not party.members:
                 return
             member = random.choice(party.members)
@@ -41,7 +41,7 @@ class ElementalSpark(CardBase):
             )
             mgr.add_modifier(mod)
             chosen["mod"] = (mgr, mod)
-            BUS.emit(
+            await BUS.emit_async(
                 "card_effect",
                 self.id,
                 member,

--- a/backend/plugins/cards/enduring_charm.py
+++ b/backend/plugins/cards/enduring_charm.py
@@ -24,7 +24,7 @@ class EnduringCharm(CardBase):
 
         active_boosts = set()
 
-        def _check_low_hp() -> None:
+        async def _check_low_hp() -> None:
             for member in party.members:
                 member_id = id(member)
                 current_hp = getattr(member, "hp", 0)
@@ -51,7 +51,7 @@ class EnduringCharm(CardBase):
                         "Enduring Charm activated vitality boost for %s: +3% vitality for 2 turns",
                         member.id,
                     )
-                    BUS.emit(
+                    await BUS.emit_async(
                         "card_effect",
                         self.id,
                         member,

--- a/backend/plugins/cards/enduring_will.py
+++ b/backend/plugins/cards/enduring_will.py
@@ -26,7 +26,7 @@ class EnduringWill(CardBase):
             if target in party.members:
                 battle_deaths += 1
 
-        def _on_battle_end():
+        async def _on_battle_end():
             nonlocal mitigation_bonus_pending
             # If no allies died, prepare mitigation bonus for next battle
             if battle_deaths == 0:
@@ -34,13 +34,13 @@ class EnduringWill(CardBase):
                 import logging
                 log = logging.getLogger(__name__)
                 log.debug("Enduring Will mitigation bonus pending for next battle")
-                BUS.emit("card_effect", self.id, None, "mitigation_bonus_pending", 1, {
+                await BUS.emit_async("card_effect", self.id, None, "mitigation_bonus_pending", 1, {
                     "mitigation_bonus": 1,
                     "trigger_condition": "no_deaths",
                     "trigger_event": "battle_end"
                 })
 
-        def _on_battle_start(target):
+        async def _on_battle_start(target):
             nonlocal battle_deaths, mitigation_bonus_pending
             if target in party.members:
                 # Reset death counter for new battle
@@ -68,7 +68,7 @@ class EnduringWill(CardBase):
                         import logging
                         log = logging.getLogger(__name__)
                         log.debug("Enduring Will mitigation bonus: +0.002 mitigation to %s", member.id)
-                        BUS.emit("card_effect", self.id, member, "mitigation_bonus", 0.002, {
+                        await BUS.emit_async("card_effect", self.id, member, "mitigation_bonus", 0.002, {
                             "mitigation_bonus": 0.002,
                             "trigger_event": "battle_start"
                         })

--- a/backend/plugins/cards/energizing_tea.py
+++ b/backend/plugins/cards/energizing_tea.py
@@ -18,7 +18,7 @@ class EnergizingTea(CardBase):
 
         battle_started = False
 
-        def _on_battle_start(target):
+        async def _on_battle_start(target):
             nonlocal battle_started
             # Only trigger once per battle and only for party members
             if not battle_started and target in party.members:
@@ -29,7 +29,7 @@ class EnergizingTea(CardBase):
                     import logging
                     log = logging.getLogger(__name__)
                     log.debug("Energizing Tea bonus ultimate charge: +1 charge to %s", member.id)
-                    BUS.emit(
+                    await BUS.emit_async(
                         "card_effect",
                         self.id,
                         member,
@@ -50,4 +50,3 @@ class EnergizingTea(CardBase):
 
         BUS.subscribe("battle_start", _on_battle_start)
         BUS.subscribe("battle_end", _on_battle_end)
-

--- a/backend/plugins/cards/expert_manual.py
+++ b/backend/plugins/cards/expert_manual.py
@@ -19,7 +19,7 @@ class ExpertManual(CardBase):
 
         extra_xp_used = set()
 
-        def _on_kill(target, killer, damage, death_type, details):
+        async def _on_kill(target, killer, damage, death_type, details):
             # Check if killer is one of our party members
             if killer in party.members:
                 killer_id = id(killer)
@@ -32,7 +32,7 @@ class ExpertManual(CardBase):
                     import logging
                     log = logging.getLogger(__name__)
                     log.debug("Expert Manual bonus XP: +%d XP to %s", extra_xp, killer.id)
-                    BUS.emit("card_effect", self.id, killer, "bonus_xp", extra_xp, {
+                    await BUS.emit_async("card_effect", self.id, killer, "bonus_xp", extra_xp, {
                         "bonus_xp": extra_xp,
                         "trigger_chance": 0.05,
                         "trigger_event": "kill"

--- a/backend/plugins/cards/farsight_scope.py
+++ b/backend/plugins/cards/farsight_scope.py
@@ -19,7 +19,7 @@ class FarsightScope(CardBase):
     async def apply(self, party) -> None:  # type: ignore[override]
         await super().apply(party)
 
-        def _before_attack(attacker, target):
+        async def _before_attack(attacker, target, *_extra):
             if attacker in party.members:
                 target_hp = getattr(target, "hp", 0)
                 target_max_hp = getattr(target, "max_hp", 1)
@@ -44,7 +44,7 @@ class FarsightScope(CardBase):
                         getattr(attacker, "id", "attacker"),
                         getattr(target, "id", "target"),
                     )
-                    BUS.emit(
+                    await BUS.emit_async(
                         "card_effect",
                         self.id,
                         attacker,

--- a/backend/plugins/cards/fortified_plating.py
+++ b/backend/plugins/cards/fortified_plating.py
@@ -19,7 +19,7 @@ class FortifiedPlating(CardBase):
         # Track which members have used their first hit reduction this turn
         first_hit_used = set()
 
-        def _on_damage_taken(target, attacker, damage):
+        async def _on_damage_taken(target, attacker, damage):
             # Check if target is one of our party members
             if target in party.members:
                 target_id = id(target)
@@ -33,7 +33,7 @@ class FortifiedPlating(CardBase):
                         import logging
                         log = logging.getLogger(__name__)
                         log.debug("Fortified Plating first hit reduction: +%d HP restored to %s", damage_reduction, target.id)
-                        BUS.emit("card_effect", self.id, target, "first_hit_reduction", damage_reduction, {
+                        await BUS.emit_async("card_effect", self.id, target, "first_hit_reduction", damage_reduction, {
                             "damage_reduction": damage_reduction,
                             "reduction_percentage": 6,
                             "trigger_event": "first_hit_per_turn"

--- a/backend/plugins/cards/guardian_shard.py
+++ b/backend/plugins/cards/guardian_shard.py
@@ -28,7 +28,7 @@ class GuardianShard(CardBase):
             if target in party.members:
                 battle_deaths += 1
 
-        def _on_battle_end(target):
+        async def _on_battle_end(target):
             nonlocal mitigation_bonus_pending, active_members
 
             if target is None:
@@ -51,7 +51,7 @@ class GuardianShard(CardBase):
                 import logging
                 log = logging.getLogger(__name__)
                 log.debug("Guardian Shard mitigation bonus pending for next battle")
-                BUS.emit(
+                await BUS.emit_async(
                     "card_effect",
                     self.id,
                     None,
@@ -64,7 +64,7 @@ class GuardianShard(CardBase):
                     },
                 )
 
-        def _on_battle_start(target):
+        async def _on_battle_start(target):
             nonlocal battle_deaths, mitigation_bonus_pending, active_members
             if target in party.members:
                 # Reset death counter for new battle
@@ -89,7 +89,7 @@ class GuardianShard(CardBase):
                             "Guardian Shard mitigation bonus: +1 mitigation to %s",
                             member.id,
                         )
-                        BUS.emit(
+                        await BUS.emit_async(
                             "card_effect",
                             self.id,
                             member,

--- a/backend/plugins/cards/guiding_compass.py
+++ b/backend/plugins/cards/guiding_compass.py
@@ -18,7 +18,7 @@ class GuidingCompass(CardBase):
 
         first_battle_bonus_used = False
 
-        def _on_battle_start(target):
+        async def _on_battle_start(target, *_args):
             nonlocal first_battle_bonus_used
             # Only trigger once for the first battle of the run
             if not first_battle_bonus_used and target in party.members:
@@ -35,7 +35,7 @@ class GuidingCompass(CardBase):
                         member.id,
                     )
                     member.exp += extra_xp
-                    BUS.emit(
+                    await BUS.emit_async(
                         "card_effect",
                         self.id,
                         member,

--- a/backend/plugins/cards/honed_point.py
+++ b/backend/plugins/cards/honed_point.py
@@ -22,7 +22,7 @@ class HonedPoint(CardBase):
 
         marked_enemies: dict[int, set[int]] = {}
 
-        def _on_damage_dealt(attacker, target, damage, _damage_type, source, source_action, action_name):
+        async def _on_damage_dealt(attacker, target, damage, _damage_type, source, source_action, action_name):
             if attacker in party.members and action_name == "attack":
                 attacker_id = id(attacker)
                 target_id = id(target)
@@ -45,7 +45,7 @@ class HonedPoint(CardBase):
                         log.debug(
                             "Honed Point bonus damage: +%d vs unmarked enemy", bonus_damage
                         )
-                        BUS.emit(
+                        await BUS.emit_async(
                             "card_effect",
                             self.id,
                             attacker,
@@ -63,4 +63,3 @@ class HonedPoint(CardBase):
 
         BUS.subscribe("damage_dealt", _on_damage_dealt)
         BUS.subscribe("battle_start", _on_battle_start)
-

--- a/backend/plugins/cards/inspiring_banner.py
+++ b/backend/plugins/cards/inspiring_banner.py
@@ -21,7 +21,7 @@ class InspiringBanner(CardBase):
 
         battle_started = False
 
-        def _on_battle_start(target):
+        async def _on_battle_start(target):
             nonlocal battle_started
             # Only trigger once per battle and only when one of our party members starts
             if not battle_started and target in party.members:
@@ -47,7 +47,7 @@ class InspiringBanner(CardBase):
                     import logging
                     log = logging.getLogger(__name__)
                     log.debug("Inspiring Banner battle start: +2% ATK for 2 turns to %s", random_ally.id)
-                    BUS.emit("card_effect", self.id, random_ally, "battle_start_atk", 2, {
+                    await BUS.emit_async("card_effect", self.id, random_ally, "battle_start_atk", 2, {
                         "atk_bonus": 2,
                         "duration": 2,
                         "trigger_event": "battle_start"

--- a/backend/plugins/cards/iron_guard.py
+++ b/backend/plugins/cards/iron_guard.py
@@ -20,11 +20,11 @@ class IronGuard(CardBase):
         await super().apply(party)
         seq = count()
 
-        def _damage_taken(victim, *_args) -> None:
+        async def _damage_taken(victim, *_args) -> None:
             if victim not in party.members:
                 return
             # Emit a single card effect event per trigger, regardless of how many party members get the buff
-            BUS.emit(
+            await BUS.emit_async(
                 "card_effect",
                 self.id,
                 victim,  # Use victim as the event source since they triggered the effect

--- a/backend/plugins/cards/iron_resolve.py
+++ b/backend/plugins/cards/iron_resolve.py
@@ -25,7 +25,7 @@ class IronResolve(CardBase):
 
         cooldowns: dict[int, int] = {id(m): 0 for m in party.members}
 
-        def _damage_taken(target, attacker, amount) -> None:
+        async def _damage_taken(target, attacker, amount) -> None:
             pid = id(target)
             if target not in party.members:
                 return
@@ -34,7 +34,7 @@ class IronResolve(CardBase):
             revive_hp = int(target.max_hp * 0.30)
             target.hp = revive_hp
             cooldowns[pid] = 3
-            BUS.emit(
+            await BUS.emit_async(
                 "card_effect",
                 self.id,
                 target,

--- a/backend/plugins/cards/iron_resurgence.py
+++ b/backend/plugins/cards/iron_resurgence.py
@@ -21,13 +21,13 @@ class IronResurgence(CardBase):
         await super().apply(party)
         state = {"cooldown": 0}
 
-        def _damage(victim, *_):
+        async def _damage(victim, *_):
             if victim not in party.members or victim.hp > 0 or state["cooldown"] > 0:
                 return
             heal = max(int(victim.max_hp * 0.1), 1)
             safe_async_task(victim.apply_healing(heal))
             state["cooldown"] = 4
-            BUS.emit(
+            await BUS.emit_async(
                 "card_effect",
                 self.id,
                 victim,

--- a/backend/plugins/cards/keen_goggles.py
+++ b/backend/plugins/cards/keen_goggles.py
@@ -21,7 +21,7 @@ class KeenGoggles(CardBase):
         # Track stacks per party member
         crit_stacks = {}
 
-        def _on_effect_applied(target, effect_name, duration, source):
+        async def _on_effect_applied(target, effect_name, duration, source):
             # Check if source is one of our party members and effect is a debuff
             if source in party.members:
                 effect_lower = effect_name.lower()
@@ -55,7 +55,7 @@ class KeenGoggles(CardBase):
                         import logging
                         log = logging.getLogger(__name__)
                         log.debug("Keen Goggles crit stack: %d stacks (+%d%% crit rate) for %s", new_stacks, new_stacks, source.id)
-                        BUS.emit("card_effect", self.id, source, "crit_stack", new_stacks, {
+                        await BUS.emit_async("card_effect", self.id, source, "crit_stack", new_stacks, {
                             "stack_count": new_stacks,
                             "crit_rate_bonus": new_stacks,
                             "max_stacks": 3,

--- a/backend/plugins/cards/lucky_coin.py
+++ b/backend/plugins/cards/lucky_coin.py
@@ -17,7 +17,7 @@ class LuckyCoin(CardBase):
     async def apply(self, party) -> None:  # type: ignore[override]
         await super().apply(party)
 
-        def _on_critical_hit(attacker, target, damage, action_name):
+        async def _on_critical_hit(attacker, target, damage, action_name):
             # Check if attacker is one of our party members
             if attacker in party.members:
                 # 20% chance to refund tiny ultimate charge
@@ -28,7 +28,7 @@ class LuckyCoin(CardBase):
                     import logging
                     log = logging.getLogger(__name__)
                     log.debug("Lucky Coin ultimate charge refund: +%d charge to %s", charge_refund, attacker.id)
-                    BUS.emit("card_effect", self.id, attacker, "charge_refund", charge_refund, {
+                    await BUS.emit_async("card_effect", self.id, attacker, "charge_refund", charge_refund, {
                         "charge_refund": charge_refund,
                         "trigger_chance": 0.20,
                         "trigger_event": "critical_hit"

--- a/backend/plugins/cards/mindful_tassel.py
+++ b/backend/plugins/cards/mindful_tassel.py
@@ -20,7 +20,7 @@ class MindfulTassel(CardBase):
 
         bonus_used = False
 
-        def _on_effect_applied(effect_name, entity, details=None):
+        async def _on_effect_applied(effect_name, entity, details=None):
             nonlocal bonus_used
 
             if bonus_used or not details:
@@ -69,7 +69,7 @@ class MindfulTassel(CardBase):
                 "Mindful Tassel first debuff potency: +5% potency to %s",
                 effect_name,
             )
-            BUS.emit(
+            await BUS.emit_async(
                 "card_effect",
                 self.id,
                 source,

--- a/backend/plugins/cards/mystic_aegis.py
+++ b/backend/plugins/cards/mystic_aegis.py
@@ -17,11 +17,11 @@ class MysticAegis(CardBase):
     async def apply(self, party) -> None:  # type: ignore[override]
         await super().apply(party)
 
-        def _resisted(member) -> None:
+        async def _resisted(member) -> None:
             if member not in party.members:
                 return
             heal = int(member.max_hp * 0.05)
-            BUS.emit(
+            await BUS.emit_async(
                 "card_effect",
                 self.id,
                 member,

--- a/backend/plugins/cards/overclock.py
+++ b/backend/plugins/cards/overclock.py
@@ -28,8 +28,8 @@ class Overclock(CardBase):
 
         async def _double_act(ally: Stats) -> None:
             for _ in range(2):
-                BUS.emit("extra_turn", ally)
-                BUS.emit(
+                await BUS.emit_async("extra_turn", ally)
+                await BUS.emit_async(
                     "card_effect",
                     self.id,
                     ally,

--- a/backend/plugins/cards/phantom_ally.py
+++ b/backend/plugins/cards/phantom_ally.py
@@ -84,7 +84,7 @@ class PhantomAlly(CardBase):
         party.members.append(summon)
 
         # Track phantom ally summoning
-        BUS.emit("card_effect", "phantom_ally", original, "phantom_summoned", 1, {
+        await BUS.emit_async("card_effect", "phantom_ally", original, "phantom_summoned", 1, {
             "original_ally": getattr(original, 'id', str(original)),
             "phantom_id": summon.id,
             "phantom_stats": {
@@ -109,11 +109,11 @@ class PhantomAlly(CardBase):
         })
 
         # Register cleanup handler to remove from party when battle ends
-        def _cleanup(_entity):
+        async def _cleanup(_entity):
             if summon in party.members:
                 party.members.remove(summon)
                 # Track phantom cleanup
-                BUS.emit("card_effect", "phantom_ally", summon, "phantom_dismissed", 1, {
+                await BUS.emit_async("card_effect", "phantom_ally", summon, "phantom_dismissed", 1, {
                     "reason": "battle_end",
                     "original_ally": getattr(original, 'id', str(original))
                 })

--- a/backend/plugins/cards/polished_shield.py
+++ b/backend/plugins/cards/polished_shield.py
@@ -18,7 +18,7 @@ class PolishedShield(CardBase):
     async def apply(self, party) -> None:  # type: ignore[override]
         await super().apply(party)
 
-        def _on_effect_resisted(effect_name, target, source, details=None):
+        async def _on_effect_resisted(effect_name, target, source, details=None):
             if target not in party.members:
                 return
 
@@ -59,6 +59,6 @@ class PolishedShield(CardBase):
             }
             if metadata:
                 payload["metadata"] = metadata
-            BUS.emit("card_effect", self.id, target, "resist_def_bonus", 3, payload)
+            await BUS.emit_async("card_effect", self.id, target, "resist_def_bonus", 3, payload)
 
         BUS.subscribe("effect_resisted", _on_effect_resisted)

--- a/backend/plugins/cards/precision_sights.py
+++ b/backend/plugins/cards/precision_sights.py
@@ -18,7 +18,7 @@ class PrecisionSights(CardBase):
     async def apply(self, party) -> None:  # type: ignore[override]
         await super().apply(party)
 
-        def _on_critical_hit(attacker, target, damage, action_name):
+        async def _on_critical_hit(attacker, target, damage, action_name):
             # Check if attacker is one of our party members
             if attacker in party.members:
                 # Grant +2% crit damage for 2 turns (stacking)
@@ -41,7 +41,7 @@ class PrecisionSights(CardBase):
                 import logging
                 log = logging.getLogger(__name__)
                 log.debug("Precision Sights crit damage boost: +2% crit damage for 2 turns to %s (stacking)", attacker.id)
-                BUS.emit("card_effect", self.id, attacker, "crit_damage_boost", 2, {
+                await BUS.emit_async("card_effect", self.id, attacker, "crit_damage_boost", 2, {
                     "crit_damage_boost": 2,
                     "duration": 2,
                     "stacking": True,

--- a/backend/plugins/cards/reality_split.py
+++ b/backend/plugins/cards/reality_split.py
@@ -51,7 +51,7 @@ class RealitySplit(CardBase):
             )
             mgr.add_modifier(mod)
 
-        def _hit_landed(attacker, _target, amount, *_args) -> None:
+        async def _hit_landed(attacker, _target, amount, *_args) -> None:
             if attacker is not state["active"]:
                 return
             foes = state["foes"]
@@ -62,7 +62,7 @@ class RealitySplit(CardBase):
                 if foe.hp <= 0:
                     continue
                 safe_async_task(foe.apply_damage(echo, attacker=attacker))
-                BUS.emit(
+                await BUS.emit_async(
                     "card_effect",
                     self.id,
                     attacker,

--- a/backend/plugins/cards/reinforced_cloak.py
+++ b/backend/plugins/cards/reinforced_cloak.py
@@ -17,7 +17,7 @@ class ReinforcedCloak(CardBase):
     async def apply(self, party) -> None:  # type: ignore[override]
         await super().apply(party)
 
-        def _on_effect_applied(target, effect_name, duration, source):
+        async def _on_effect_applied(target, effect_name, duration, source):
             # Check if target is one of our party members and effect is a long debuff
             if target in party.members and duration >= 3:  # Long debuff (3+ turns)
                 effect_lower = effect_name.lower()
@@ -36,7 +36,7 @@ class ReinforcedCloak(CardBase):
                                     import logging
                                     log = logging.getLogger(__name__)
                                     log.debug("Reinforced Cloak reduced long debuff duration by 1 for %s (%s)", target.id, effect_name)
-                                    BUS.emit("card_effect", self.id, target, "debuff_duration_reduction", 1, {
+                                    await BUS.emit_async("card_effect", self.id, target, "debuff_duration_reduction", 1, {
                                         "effect_reduced": effect_name,
                                         "turns_reduced": 1,
                                         "trigger_chance": 0.30,

--- a/backend/plugins/cards/rejuvenating_tonic.py
+++ b/backend/plugins/cards/rejuvenating_tonic.py
@@ -16,7 +16,7 @@ class RejuvenatingTonic(CardBase):
     async def apply(self, party) -> None:  # type: ignore[override]
         await super().apply(party)
 
-        def _on_heal(healer, target, heal_amount, source_type, source_name):
+        async def _on_heal(healer, target, heal_amount, source_type, source_name):
             # Check if healer is one of our party members and this is a heal action
             if healer in party.members and source_type in ["heal", "ability_heal"]:
                 # Heal an additional +1% HP
@@ -29,7 +29,7 @@ class RejuvenatingTonic(CardBase):
                     try:
                         asyncio.create_task(target.apply_healing(bonus_heal, healer, source_type="rejuvenating_tonic", source_name="rejuvenating_tonic"))
                         log.debug("Rejuvenating Tonic bonus heal: +%d HP to %s", bonus_heal, target.id)
-                        BUS.emit("card_effect", self.id, healer, "bonus_heal", bonus_heal, {
+                        await BUS.emit_async("card_effect", self.id, healer, "bonus_heal", bonus_heal, {
                             "bonus_heal": bonus_heal,
                             "heal_percentage": 1,
                             "trigger_event": "heal_used"

--- a/backend/plugins/cards/sharpening_stone.py
+++ b/backend/plugins/cards/sharpening_stone.py
@@ -18,7 +18,7 @@ class SharpeningStone(CardBase):
     async def apply(self, party) -> None:  # type: ignore[override]
         await super().apply(party)
 
-        def _on_critical_hit(attacker, target, damage, action_name):
+        async def _on_critical_hit(attacker, target, damage, action_name):
             # Check if attacker is one of our party members
             if attacker in party.members:
                 # Grant +2% crit damage for 2 turns
@@ -39,7 +39,7 @@ class SharpeningStone(CardBase):
                 import logging
                 log = logging.getLogger(__name__)
                 log.debug("Sharpening Stone crit damage boost: +2% crit damage for 2 turns to %s", attacker.id)
-                BUS.emit("card_effect", self.id, attacker, "crit_damage_boost", 2, {
+                await BUS.emit_async("card_effect", self.id, attacker, "crit_damage_boost", 2, {
                     "crit_damage_boost": 2,
                     "duration": 2,
                     "trigger_event": "critical_hit"

--- a/backend/plugins/cards/spiked_shield.py
+++ b/backend/plugins/cards/spiked_shield.py
@@ -51,7 +51,7 @@ class SpikedShield(CardBase):
                             target.id,
                             getattr(attacker, "id", "unknown"),
                         )
-                        BUS.emit(
+                        await BUS.emit_async(
                             "card_effect",
                             self.id,
                             target,

--- a/backend/plugins/cards/steady_grip.py
+++ b/backend/plugins/cards/steady_grip.py
@@ -18,7 +18,7 @@ class SteadyGrip(CardBase):
     async def apply(self, party) -> None:  # type: ignore[override]
         await super().apply(party)
 
-        def _on_effect_applied(target, effect_name, duration, source):
+        async def _on_effect_applied(target, effect_name, duration, source):
             # Check if source is one of our party members and effect is a control effect
             if source in party.members:
                 effect_lower = effect_name.lower()
@@ -43,7 +43,7 @@ class SteadyGrip(CardBase):
                     import logging
                     log = logging.getLogger(__name__)
                     log.debug("Steady Grip control bonus: +2%% ATK for next action to %s", source.id)
-                    BUS.emit("card_effect", self.id, source, "control_atk_bonus", 2, {
+                    await BUS.emit_async("card_effect", self.id, source, "control_atk_bonus", 2, {
                         "atk_bonus": 2,
                         "duration": 1,
                         "control_effect": effect_name,

--- a/backend/plugins/cards/steel_bangles.py
+++ b/backend/plugins/cards/steel_bangles.py
@@ -19,7 +19,7 @@ class SteelBangles(CardBase):
     async def apply(self, party) -> None:  # type: ignore[override]
         await super().apply(party)
 
-        def _on_damage_dealt(attacker, target, damage, damage_type, source, source_action, action_name):
+        async def _on_damage_dealt(attacker, target, damage, damage_type, source, source_action, action_name):
             # Check if attacker is one of our party members and this is an attack
             if attacker in party.members and action_name == "attack":
                 # 5% chance to reduce target's next attack damage by 3%
@@ -42,7 +42,7 @@ class SteelBangles(CardBase):
                     import logging
                     log = logging.getLogger(__name__)
                     log.debug("Steel Bangles attack debuff applied to %s", getattr(target, 'id', 'unknown'))
-                    BUS.emit("card_effect", self.id, attacker, "attack_debuff_applied", 3, {
+                    await BUS.emit_async("card_effect", self.id, attacker, "attack_debuff_applied", 3, {
                         "damage_reduction": 3,
                         "target": getattr(target, 'id', 'unknown'),
                         "trigger_chance": 0.05

--- a/backend/plugins/cards/sturdy_vest.py
+++ b/backend/plugins/cards/sturdy_vest.py
@@ -76,7 +76,7 @@ class SturdyVest(CardBase):
                         member.id,
                         hot_amount,
                     )
-                    BUS.emit(
+                    await BUS.emit_async(
                         "card_effect",
                         self.id,
                         member,

--- a/backend/plugins/cards/swift_bandanna.py
+++ b/backend/plugins/cards/swift_bandanna.py
@@ -18,7 +18,7 @@ class SwiftBandanna(CardBase):
     async def apply(self, party) -> None:  # type: ignore[override]
         await super().apply(party)
 
-        def _on_dodge(dodger, attacker, original_damage):
+        async def _on_dodge(dodger, attacker, original_damage):
             # Check if dodger is one of our party members
             if dodger in party.members:
                 # Grant +1% crit rate for next action
@@ -39,7 +39,7 @@ class SwiftBandanna(CardBase):
                 import logging
                 log = logging.getLogger(__name__)
                 log.debug("Swift Bandanna dodge bonus: +1%% crit rate for next action to %s", dodger.id)
-                BUS.emit("card_effect", self.id, dodger, "dodge_crit_bonus", 1, {
+                await BUS.emit_async("card_effect", self.id, dodger, "dodge_crit_bonus", 1, {
                     "crit_rate_bonus": 1,
                     "duration": 1,
                     "trigger_event": "dodge"

--- a/backend/plugins/cards/swift_footwork.py
+++ b/backend/plugins/cards/swift_footwork.py
@@ -23,7 +23,7 @@ class SwiftFootwork(CardBase):
         def _battle_start(entity) -> None:
             used.clear()
 
-        def _action_used(actor, *_args) -> None:
+        async def _action_used(actor, *_args) -> None:
             if actor not in party.members:
                 return
 
@@ -32,9 +32,9 @@ class SwiftFootwork(CardBase):
                 return
 
             actor.action_points += 1
-            BUS.emit("extra_turn", actor)
+            await BUS.emit_async("extra_turn", actor)
             used.add(pid)
-            BUS.emit("card_effect", self.id, actor, "free_action", 0, {})
+            await BUS.emit_async("card_effect", self.id, actor, "free_action", 0, {})
 
         BUS.subscribe("battle_start", _battle_start)
         BUS.subscribe("action_used", _action_used)

--- a/backend/plugins/cards/tactical_kit.py
+++ b/backend/plugins/cards/tactical_kit.py
@@ -21,7 +21,7 @@ class TacticalKit(CardBase):
         # Track which members have used their tactical conversion
         conversion_used = set()
 
-        def _on_action_about_to_start(actor):
+        async def _on_action_about_to_start(actor):
             # Check if actor is one of our party members and hasn't used conversion yet
             if actor in party.members:
                 actor_id = id(actor)
@@ -56,7 +56,7 @@ class TacticalKit(CardBase):
                         import logging
                         log = logging.getLogger(__name__)
                         log.debug("Tactical Kit conversion: -%d HP for +2%% ATK to %s", hp_to_convert, actor.id)
-                        BUS.emit("card_effect", self.id, actor, "hp_to_atk_conversion", 2, {
+                        await BUS.emit_async("card_effect", self.id, actor, "hp_to_atk_conversion", 2, {
                             "hp_converted": hp_to_convert,
                             "atk_bonus": 2,
                             "duration": 1,

--- a/backend/plugins/cards/temporal_shield.py
+++ b/backend/plugins/cards/temporal_shield.py
@@ -23,7 +23,7 @@ class TemporalShield(CardBase):
     async def apply(self, party):
         await super().apply(party)
 
-        def _turn_start() -> None:
+        async def _turn_start(*_args) -> None:
             for member in party.members:
                 if random.random() < 0.5:
                     mgr = getattr(member, "effect_manager", None)
@@ -37,7 +37,7 @@ class TemporalShield(CardBase):
                         mitigation_mult=100.0,
                     )
                     mgr.add_modifier(mod)
-                    BUS.emit(
+                    await BUS.emit_async(
                         "card_effect",
                         self.id,
                         member,
@@ -46,4 +46,4 @@ class TemporalShield(CardBase):
                         {"reduction_percent": 99},
                     )
 
-        BUS.subscribe("turn_start", lambda *_: _turn_start())
+        BUS.subscribe("turn_start", _turn_start)

--- a/backend/plugins/cards/thick_skin.py
+++ b/backend/plugins/cards/thick_skin.py
@@ -17,7 +17,7 @@ class ThickSkin(CardBase):
     async def apply(self, party) -> None:  # type: ignore[override]
         await super().apply(party)
 
-        def _on_effect_applied(target, effect_name, duration, source):
+        async def _on_effect_applied(target, effect_name, duration, source):
             # Check if target is one of our party members and effect is bleed
             if target in party.members and "bleed" in effect_name.lower():
                 # 50% chance to reduce bleed duration by 1
@@ -32,7 +32,7 @@ class ThickSkin(CardBase):
                                     import logging
                                     log = logging.getLogger(__name__)
                                     log.debug("Thick Skin reduced bleed duration by 1 turn for %s", target.id)
-                                    BUS.emit("card_effect", self.id, target, "duration_reduction", 1, {
+                                    await BUS.emit_async("card_effect", self.id, target, "duration_reduction", 1, {
                                         "effect_reduced": effect_name,
                                         "turns_reduced": 1,
                                         "trigger_chance": 0.50
@@ -46,4 +46,3 @@ class ThickSkin(CardBase):
             BUS.unsubscribe("battle_end", _on_battle_end)
 
         BUS.subscribe("battle_end", _on_battle_end)
-

--- a/backend/plugins/cards/vital_core.py
+++ b/backend/plugins/cards/vital_core.py
@@ -25,7 +25,7 @@ class VitalCore(CardBase):
         # Track which members have the vitality boost active to avoid stacking
         active_boosts = set()
 
-        def _check_low_hp() -> None:
+        async def _check_low_hp() -> None:
             for member in party.members:
                 member_id = id(member)
                 current_hp = getattr(member, "hp", 0)
@@ -52,7 +52,7 @@ class VitalCore(CardBase):
                         "Vital Core activated vitality boost for %s: +3% vitality for 2 turns",
                         member.id,
                     )
-                    BUS.emit(
+                    await BUS.emit_async(
                         "card_effect",
                         self.id,
                         member,

--- a/backend/plugins/cards/vital_surge.py
+++ b/backend/plugins/cards/vital_surge.py
@@ -19,7 +19,7 @@ class VitalSurge(CardBase):
         await super().apply(party)
         active: dict[int, object] = {}
 
-        def _check(member) -> None:
+        async def _check(member) -> None:
             pid = id(member)
             mgr = getattr(member, "effect_manager", None)
             if mgr is None:
@@ -36,7 +36,7 @@ class VitalSurge(CardBase):
                 )
                 active[pid] = mod
                 mgr.add_modifier(mod)
-                BUS.emit(
+                await BUS.emit_async(
                     "card_effect",
                     self.id,
                     member,

--- a/backend/plugins/damage_types/light.py
+++ b/backend/plugins/damage_types/light.py
@@ -85,7 +85,7 @@ class Light(DamageTypeBase):
             mgr.add_modifier(mod)
             await pace_sleep(YIELD_MULTIPLIER)
 
-        BUS.emit("light_ultimate", actor)
+        await BUS.emit_async("light_ultimate", actor)
         return True
 
     @classmethod

--- a/backend/plugins/effects/aftertaste.py
+++ b/backend/plugins/effects/aftertaste.py
@@ -91,7 +91,7 @@ class Aftertaste:
 
             # Emit event before applying damage to track aftertaste as relic effect
             from autofighter.stats import BUS
-            BUS.emit("relic_effect", "aftertaste", attacker, "damage", amount, {
+            await BUS.emit_async("relic_effect", "aftertaste", attacker, "damage", amount, {
                 "effect_type": "aftertaste",
                 "base_damage": self.base_pot,
                 "random_damage_type": random_damage_type.id if hasattr(random_damage_type, 'id') else str(random_damage_type),

--- a/backend/plugins/effects/critical_boost.py
+++ b/backend/plugins/effects/critical_boost.py
@@ -20,21 +20,21 @@ class CriticalBoost:
         """Get the description of this effect for display purposes."""
         return "+0.5% crit rate and +5% crit damage per stack. Removed when taking damage."
 
-    def apply(self, target: Stats) -> None:
+    async def apply(self, target: Stats) -> None:
         if self.target is None:
             self.target = target
             BUS.subscribe("damage_taken", self._on_damage_taken)
         self.stacks += 1
         target._base_crit_rate += self.crit_rate_per_stack
         target._base_crit_damage += self.crit_damage_per_stack
-        BUS.emit("critical_boost_change", target, self.stacks)
+        await BUS.emit_async("critical_boost_change", target, self.stacks)
 
-    def _on_damage_taken(self, victim: Stats, *_: object) -> None:
+    async def _on_damage_taken(self, victim: Stats, *_: object) -> None:
         if victim is not self.target or self.target is None or self.stacks == 0:
             return
         self.target._base_crit_rate -= self.crit_rate_per_stack * self.stacks
         self.target._base_crit_damage -= self.crit_damage_per_stack * self.stacks
         self.stacks = 0
-        BUS.emit("critical_boost_change", victim, 0)
+        await BUS.emit_async("critical_boost_change", victim, 0)
         BUS.unsubscribe("damage_taken", self._on_damage_taken)
         self.target = None

--- a/backend/plugins/relics/_base.py
+++ b/backend/plugins/relics/_base.py
@@ -35,7 +35,7 @@ class RelicBase:
     effects: dict[str, float] = field(default_factory=dict)
     about: str = ""
 
-    def apply(self, party: Party) -> None:
+    async def apply(self, party: Party) -> None:
         from autofighter.stats import BUS  # Import here to avoid circular imports
 
         log.info("Applying relic %s to party", self.id)
@@ -59,7 +59,7 @@ class RelicBase:
 
             # Emit relic effect tracking for stat modifications
             for attr, pct in self.effects.items():
-                BUS.emit("relic_effect", self.id, member, f"stat_buff_{attr}", int(pct * 100), {
+                await BUS.emit_async("relic_effect", self.id, member, f"stat_buff_{attr}", int(pct * 100), {
                     "stat_affected": attr,
                     "percentage_change": pct * 100,
                     "stacks": stacks,

--- a/backend/plugins/relics/arcane_flask.py
+++ b/backend/plugins/relics/arcane_flask.py
@@ -16,8 +16,8 @@ class ArcaneFlask(RelicBase):
     effects: dict[str, float] = field(default_factory=dict)
     about: str = "After an Ultimate, grant a shield equal to 20% Max HP."
 
-    def apply(self, party) -> None:
-        super().apply(party)
+    async def apply(self, party) -> None:
+        await super().apply(party)
 
         stacks = party.relics.count(self.id)
         state = getattr(party, "_arcane_flask_state", None)
@@ -25,7 +25,7 @@ class ArcaneFlask(RelicBase):
         if state is None:
             state = {"stacks": stacks}
 
-            def _ultimate(user) -> None:
+            async def _ultimate(user) -> None:
                 current_stacks = state.get("stacks", 0)
                 if current_stacks <= 0:
                     return
@@ -34,7 +34,7 @@ class ArcaneFlask(RelicBase):
                 shield = int(user.max_hp * 0.2 * current_stacks)
 
                 # Track the shield generation
-                BUS.emit("relic_effect", "arcane_flask", user, "shield_granted", shield, {
+                await BUS.emit_async("relic_effect", "arcane_flask", user, "shield_granted", shield, {
                     "shield_percentage": 20 * current_stacks,
                     "max_hp": user.max_hp,
                     "trigger": "ultimate_used",

--- a/backend/plugins/relics/bent_dagger.py
+++ b/backend/plugins/relics/bent_dagger.py
@@ -16,17 +16,17 @@ class BentDagger(RelicBase):
     effects: dict[str, float] = field(default_factory=lambda: {"atk": 0.03})
     about: str = "+3% ATK; killing a foe grants +1% ATK for the rest of combat."
 
-    def apply(self, party) -> None:
-        super().apply(party)
+    async def apply(self, party) -> None:
+        await super().apply(party)
 
         stacks = party.relics.count(self.id)
 
-        def _on_death(target, attacker, amount) -> None:
+        async def _on_death(target, attacker, amount) -> None:
             if target in party.members or target.hp > 0:
                 return
 
             # Track the kill trigger
-            BUS.emit("relic_effect", "bent_dagger", attacker, "foe_killed", amount, {
+            await BUS.emit_async("relic_effect", "bent_dagger", attacker, "foe_killed", amount, {
                 "target": getattr(target, 'id', str(target)),
                 "permanent_atk_boost": 1,
                 "stacks": stacks,
@@ -38,7 +38,7 @@ class BentDagger(RelicBase):
                 member.effect_manager.add_modifier(mod)
 
                 # Track the ATK buff application
-                BUS.emit("relic_effect", "bent_dagger", member, "atk_boost_applied", 1, {
+                await BUS.emit_async("relic_effect", "bent_dagger", member, "atk_boost_applied", 1, {
                     "boost_percentage": 1,
                     "permanent": True,
                     "triggered_by_kill": True

--- a/backend/plugins/relics/echo_bell.py
+++ b/backend/plugins/relics/echo_bell.py
@@ -16,8 +16,8 @@ class EchoBell(RelicBase):
     effects: dict[str, float] = field(default_factory=dict)
     about: str = "First action each battle repeats at 15% power per stack."
 
-    def apply(self, party) -> None:
-        super().apply(party)
+    async def apply(self, party) -> None:
+        await super().apply(party)
 
         state = getattr(party, "_echo_bell_state", None)
         stacks = party.relics.count(self.id)
@@ -28,7 +28,7 @@ class EchoBell(RelicBase):
             def _battle_start(*_args) -> None:
                 used.clear()
 
-            def _action(actor, target, amount, action_type="damage") -> None:
+            async def _action(actor, target, amount, action_type="damage") -> None:
                 pid = id(actor)
                 if pid in used:
                     return
@@ -39,7 +39,7 @@ class EchoBell(RelicBase):
                 echo_amount = int(amount * 0.15 * current_stacks)
 
                 # Emit relic effect event for echo action
-                BUS.emit("relic_effect", "echo_bell", actor, "echo_action", echo_amount, {
+                await BUS.emit_async("relic_effect", "echo_bell", actor, "echo_action", echo_amount, {
                     "original_amount": amount,
                     "echo_percentage": 15 * current_stacks,
                     "target": getattr(target, 'id', str(target)),

--- a/backend/plugins/relics/echoing_drum.py
+++ b/backend/plugins/relics/echoing_drum.py
@@ -16,8 +16,8 @@ class EchoingDrum(RelicBase):
     effects: dict[str, float] = field(default_factory=dict)
     about: str = "First attack each battle repeats at 25% power per stack."
 
-    def apply(self, party) -> None:
-        super().apply(party)
+    async def apply(self, party) -> None:
+        await super().apply(party)
 
         state = getattr(party, "_echoing_drum_state", None)
         stacks = party.relics.count(self.id)
@@ -28,7 +28,7 @@ class EchoingDrum(RelicBase):
             def _battle_start(*_args) -> None:
                 used.clear()
 
-            def _attack(attacker, target, amount) -> None:
+            async def _attack(attacker, target, amount) -> None:
                 pid = id(attacker)
                 if pid in used:
                     return
@@ -39,7 +39,7 @@ class EchoingDrum(RelicBase):
                 dmg = int(amount * 0.25 * current_stacks)
 
                 # Emit relic effect event for echo attack
-                BUS.emit("relic_effect", "echoing_drum", attacker, "echo_attack", dmg, {
+                await BUS.emit_async("relic_effect", "echoing_drum", attacker, "echo_attack", dmg, {
                     "original_amount": amount,
                     "echo_percentage": 25 * current_stacks,
                     "target": getattr(target, 'id', str(target)),

--- a/backend/plugins/relics/ember_stone.py
+++ b/backend/plugins/relics/ember_stone.py
@@ -16,12 +16,12 @@ class EmberStone(RelicBase):
     effects: dict[str, float] = field(default_factory=dict)
     about: str = "Below 25% HP, burn the attacker for 50% ATK per stack."
 
-    def apply(self, party) -> None:
+    async def apply(self, party) -> None:
         state = getattr(party, "_ember_stone_state", None)
         stacks = party.relics.count(self.id)
 
         if state is None:
-            def _burn(target, attacker, amount) -> None:
+            async def _burn(target, attacker, amount) -> None:
                 if attacker is None or target not in party.members:
                     return
                 current_stacks = state.get("stacks", 0)
@@ -31,7 +31,7 @@ class EmberStone(RelicBase):
                     dmg = int(target.atk * 0.5 * current_stacks)
 
                     # Emit relic effect event for burn counter-attack
-                    BUS.emit("relic_effect", "ember_stone", target, "burn_counter", dmg, {
+                    await BUS.emit_async("relic_effect", "ember_stone", target, "burn_counter", dmg, {
                         "trigger_condition": "below_25_percent_hp",
                         "current_hp_percentage": (target.hp / target.max_hp) * 100,
                         "burn_damage": dmg,

--- a/backend/plugins/relics/frost_sigil.py
+++ b/backend/plugins/relics/frost_sigil.py
@@ -17,14 +17,14 @@ class FrostSigil(RelicBase):
     effects: dict[str, float] = field(default_factory=dict)
     about: str = "Hits apply chill dealing 5% ATK as Aftertaste; each stack adds a hit."
 
-    def apply(self, party) -> None:
-        super().apply(party)
+    async def apply(self, party) -> None:
+        await super().apply(party)
 
         state = getattr(party, "_frost_sigil_state", None)
         if state is None:
             party._frost_sigil_state = True
 
-            def _hit(attacker, target, amount, source_type="attack", source_name=None) -> None:
+            async def _hit(attacker, target, amount, source_type="attack", source_name=None) -> None:
                 # Only trigger if the attacker is a party member
                 if attacker not in party.members:
                     return
@@ -33,7 +33,7 @@ class FrostSigil(RelicBase):
                 dmg = int(attacker.atk * 0.05)
 
                 # Track frost sigil application
-                BUS.emit("relic_effect", "frost_sigil", attacker, "chill_applied", dmg, {
+                await BUS.emit_async("relic_effect", "frost_sigil", attacker, "chill_applied", dmg, {
                     "target": getattr(target, 'id', str(target)),
                     "aftertaste_hits": stacks,
                     "damage_per_hit": dmg,

--- a/backend/plugins/relics/guardian_charm.py
+++ b/backend/plugins/relics/guardian_charm.py
@@ -15,10 +15,10 @@ class GuardianCharm(RelicBase):
     effects: dict[str, float] = field(default_factory=dict)
     about: str = "At battle start, grants +20% DEF to the lowest-HP ally per stack."
 
-    def apply(self, party) -> None:
+    async def apply(self, party) -> None:
         from autofighter.stats import BUS  # Import here to avoid circular imports
 
-        super().apply(party)
+        await super().apply(party)
         if not party.members:
             return
         member = min(party.members, key=lambda m: m.hp)
@@ -26,7 +26,7 @@ class GuardianCharm(RelicBase):
         defense_pct = 20 * stacks
 
         # Emit relic effect event for defense boost
-        BUS.emit(
+        await BUS.emit_async(
             "relic_effect",
             "guardian_charm",
             member,

--- a/backend/plugins/relics/herbal_charm.py
+++ b/backend/plugins/relics/herbal_charm.py
@@ -16,12 +16,12 @@ class HerbalCharm(RelicBase):
     effects: dict[str, float] = field(default_factory=dict)
     about: str = "Heals all allies for 0.5% Max HP at the start of each turn per stack."
 
-    def apply(self, party) -> None:
+    async def apply(self, party) -> None:
         state = getattr(party, "_herbal_charm_state", None)
         stacks = party.relics.count(self.id)
 
         if state is None:
-            def _heal(*_) -> None:
+            async def _heal(*_) -> None:
                 current_stacks = state.get("stacks", 0)
                 if current_stacks <= 0:
                     return
@@ -29,7 +29,7 @@ class HerbalCharm(RelicBase):
                     heal = int(member.max_hp * 0.005 * current_stacks)
 
                     # Emit relic effect event for healing
-                    BUS.emit("relic_effect", "herbal_charm", member, "turn_start_healing", heal, {
+                    await BUS.emit_async("relic_effect", "herbal_charm", member, "turn_start_healing", heal, {
                         "healing_percentage": 0.5 * current_stacks,
                         "max_hp": member.max_hp,
                         "stacks": current_stacks

--- a/backend/plugins/relics/null_lantern.py
+++ b/backend/plugins/relics/null_lantern.py
@@ -16,9 +16,9 @@ class NullLantern(RelicBase):
     effects: dict[str, float] = field(default_factory=dict)
     about: str = "Shops and rest rooms vanish; each fight grants extra pulls."
 
-    def apply(self, party) -> None:
+    async def apply(self, party) -> None:
         """Disable shops/rests, buff foes, and award pull tokens."""
-        super().apply(party)
+        await super().apply(party)
 
         party.no_shops = True
         party.no_rests = True
@@ -35,7 +35,7 @@ class NullLantern(RelicBase):
             if not hasattr(party, "pull_tokens"):
                 party.pull_tokens = 0
 
-            def _battle_start(entity) -> None:
+            async def _battle_start(entity) -> None:
                 from plugins.foes._base import FoeBase
 
                 if isinstance(entity, FoeBase):
@@ -55,14 +55,14 @@ class NullLantern(RelicBase):
                     entity.effect_manager.add_modifier(mod)
 
                     # Track foe buffing
-                    BUS.emit("relic_effect", "null_lantern", entity, "foe_buffed", int((mult - 1) * 100), {
+                    await BUS.emit_async("relic_effect", "null_lantern", entity, "foe_buffed", int((mult - 1) * 100), {
                         "battle_number": state["cleared"] + 1,
                         "multiplier": mult,
                         "escalation_percentage": 150 * current_stacks,
                         "stacks": current_stacks
                     })
 
-            def _battle_end(entity) -> None:
+            async def _battle_end(entity) -> None:
                 from plugins.foes._base import FoeBase
 
                 if isinstance(entity, FoeBase):
@@ -75,7 +75,7 @@ class NullLantern(RelicBase):
                     party.pull_tokens += pull_reward
 
                     # Track pull token generation
-                    BUS.emit("relic_effect", "null_lantern", entity, "pull_tokens_awarded", pull_reward, {
+                    await BUS.emit_async("relic_effect", "null_lantern", entity, "pull_tokens_awarded", pull_reward, {
                         "battles_cleared": state["cleared"],
                         "base_tokens": 1,
                         "stack_bonus": current_stacks - 1,

--- a/backend/plugins/relics/pocket_manual.py
+++ b/backend/plugins/relics/pocket_manual.py
@@ -17,13 +17,13 @@ class PocketManual(RelicBase):
     effects: dict[str, float] = field(default_factory=lambda: {"atk": 0.03})
     about: str = "+3% damage; every 10th hit triggers an additional Aftertaste hit dealing +3% of the original damage."
 
-    def apply(self, party) -> None:
-        super().apply(party)
+    async def apply(self, party) -> None:
+        await super().apply(party)
 
         counts: dict[int, int] = {}
         stacks = party.relics.count(self.id)
 
-        def _hit(attacker, target, amount, source_type="attack", source_name=None) -> None:
+        async def _hit(attacker, target, amount, source_type="attack", source_name=None) -> None:
             # Only trigger if the attacker is a party member
             if attacker not in party.members:
                 return
@@ -34,7 +34,7 @@ class PocketManual(RelicBase):
                 base = int(amount * 0.03 * stacks)
                 if base > 0:
                     # Emit relic effect event
-                    BUS.emit("relic_effect", "pocket_manual", attacker, "trigger_aftertaste", base, {
+                    await BUS.emit_async("relic_effect", "pocket_manual", attacker, "trigger_aftertaste", base, {
                         "hit_count": counts[pid],
                         "original_damage": amount,
                         "aftertaste_damage": base

--- a/backend/plugins/relics/shiny_pebble.py
+++ b/backend/plugins/relics/shiny_pebble.py
@@ -18,15 +18,15 @@ class ShinyPebble(RelicBase):
         "Boosts DEF and grants extra mitigation the first time an ally is hit."
     )
 
-    def apply(self, party) -> None:
-        super().apply(party)
+    async def apply(self, party) -> None:
+        await super().apply(party)
 
         state = getattr(party, "_shiny_pebble_state", None)
         if state is None:
             state = {"active": {}, "triggered": set()}
             party._shiny_pebble_state = state
 
-            def _first_hit(target, attacker, amount) -> None:
+            async def _first_hit(target, attacker, amount) -> None:
                 if target not in party.members or id(target) in state["triggered"]:
                     return
                 state["triggered"].add(id(target))
@@ -42,7 +42,7 @@ class ShinyPebble(RelicBase):
                 state["active"][id(target)] = (target, mod)
 
                 # Track mitigation burst application
-                BUS.emit(
+                await BUS.emit_async(
                     "relic_effect",
                     "shiny_pebble",
                     target,

--- a/backend/plugins/relics/tattered_flag.py
+++ b/backend/plugins/relics/tattered_flag.py
@@ -16,10 +16,10 @@ class TatteredFlag(RelicBase):
     effects: dict[str, float] = field(default_factory=lambda: {"max_hp": 0.03})
     about: str = "+3% party Max HP; ally deaths grant survivors +3% ATK."
 
-    def apply(self, party) -> None:
-        super().apply(party)
+    async def apply(self, party) -> None:
+        await super().apply(party)
 
-        def _fallen(target, attacker, amount) -> None:
+        async def _fallen(target, attacker, amount) -> None:
             if target not in party.members or target.hp > 0:
                 return
             survivors = [member for member in party.members if member is not target and member.hp > 0]
@@ -29,7 +29,7 @@ class TatteredFlag(RelicBase):
             stacks = party.relics.count(self.id)
 
             # Emit relic effect event for ally death buff
-            BUS.emit("relic_effect", "tattered_flag", target, "ally_death_buff", 3 * stacks, {
+            await BUS.emit_async("relic_effect", "tattered_flag", target, "ally_death_buff", 3 * stacks, {
                 "fallen_ally": getattr(target, 'id', str(target)),
                 "survivors": [getattr(m, 'id', str(m)) for m in survivors],
                 "atk_bonus_percentage": 3 * stacks,

--- a/backend/plugins/relics/threadbare_cloak.py
+++ b/backend/plugins/relics/threadbare_cloak.py
@@ -16,8 +16,8 @@ class ThreadbareCloak(RelicBase):
     effects: dict[str, float] = field(default_factory=dict)
     about: str = "Start battle with a small shield equal to 3% Max HP per stack."
 
-    def apply(self, party) -> None:
-        super().apply(party)
+    async def apply(self, party) -> None:
+        await super().apply(party)
 
         applied = getattr(party, "_threadbare_cloak_stacks", 0)
         stacks = party.relics.count(self.id)

--- a/backend/plugins/relics/timekeepers_hourglass.py
+++ b/backend/plugins/relics/timekeepers_hourglass.py
@@ -16,19 +16,19 @@ class TimekeepersHourglass(RelicBase):
     effects: dict[str, float] = field(default_factory=dict)
     about: str = "Each turn, 10% +1% per stack chance for allies to gain an extra turn."
 
-    def apply(self, party) -> None:
+    async def apply(self, party) -> None:
         if getattr(party, "_t_hourglass_applied", False):
             return
         party._t_hourglass_applied = True
-        super().apply(party)
+        await super().apply(party)
 
         stacks = party.relics.count(self.id)
         chance = 0.10 + 0.01 * (stacks - 1)
 
-        def _turn_start() -> None:
+        async def _turn_start() -> None:
             if random.random() < chance:
                 for member in party.members:
-                    BUS.emit("extra_turn", member)
+                    await BUS.emit_async("extra_turn", member)
 
         def _battle_end(_entity) -> None:
             BUS.unsubscribe("turn_start", _turn_start)

--- a/backend/plugins/relics/travelers_charm.py
+++ b/backend/plugins/relics/travelers_charm.py
@@ -17,13 +17,13 @@ class TravelersCharm(RelicBase):
     effects: dict[str, float] = field(default_factory=dict)
     about: str = "When hit, gain +25% DEF and +10% mitigation next turn per stack."
 
-    def apply(self, party) -> None:
-        super().apply(party)
+    async def apply(self, party) -> None:
+        await super().apply(party)
 
         pending: dict[int, tuple[float, float]] = {}
         active: dict[int, tuple[PlayerBase, object]] = {}
 
-        def _hit(target, attacker, amount) -> None:
+        async def _hit(target, attacker, amount) -> None:
             if target not in party.members:
                 return
             pid = id(target)
@@ -34,7 +34,7 @@ class TravelersCharm(RelicBase):
             pending[pid] = (pd + d_pct, pm + m_pct)
 
             # Track hit reaction
-            BUS.emit(
+            await BUS.emit_async(
                 "relic_effect",
                 "travelers_charm",
                 target,
@@ -50,7 +50,7 @@ class TravelersCharm(RelicBase):
                 },
             )
 
-        def _turn_start() -> None:
+        async def _turn_start() -> None:
             applied_count = 0
             for pid, (d_pct, m_pct) in list(pending.items()):
                 member = next((m for m in party.members if id(m) == pid), None)
@@ -68,7 +68,7 @@ class TravelersCharm(RelicBase):
                 applied_count += 1
 
                 # Track buff application
-                BUS.emit(
+                await BUS.emit_async(
                     "relic_effect",
                     "travelers_charm",
                     member,

--- a/backend/plugins/relics/vengeful_pendant.py
+++ b/backend/plugins/relics/vengeful_pendant.py
@@ -16,14 +16,14 @@ class VengefulPendant(RelicBase):
     effects: dict[str, float] = field(default_factory=dict)
     about: str = "Reflects 15% of damage taken back to the attacker."
 
-    def apply(self, party) -> None:
-        super().apply(party)
+    async def apply(self, party) -> None:
+        await super().apply(party)
 
         stacks = party.relics.count(self.id)
         state = getattr(party, "_vengeful_pendant_state", None)
 
         if state is None:
-            def _reflect(target, attacker, amount) -> None:
+            async def _reflect(target, attacker, amount) -> None:
                 if attacker is None or target not in party.members:
                     return
                 current_stacks = state.get("stacks", 0)
@@ -32,7 +32,7 @@ class VengefulPendant(RelicBase):
                 dmg = int(amount * 0.15 * current_stacks)
 
                 # Emit relic effect event for damage reflection
-                BUS.emit(
+                await BUS.emit_async(
                     "relic_effect",
                     "vengeful_pendant",
                     target,

--- a/backend/plugins/relics/wooden_idol.py
+++ b/backend/plugins/relics/wooden_idol.py
@@ -17,13 +17,13 @@ class WoodenIdol(RelicBase):
     effects: dict[str, float] = field(default_factory=lambda: {"effect_resistance": 0.03})
     about: str = "+3% Effect Res; resisting a debuff grants +1% Effect Res next turn."
 
-    def apply(self, party) -> None:
-        super().apply(party)
+    async def apply(self, party) -> None:
+        await super().apply(party)
 
         pending: dict[int, float] = {}
         active: dict[int, tuple[PlayerBase, object]] = {}
 
-        def _resisted(member) -> None:
+        async def _resisted(member) -> None:
             if member not in party.members:
                 return
             pid = id(member)
@@ -31,14 +31,14 @@ class WoodenIdol(RelicBase):
             pending[pid] = pending.get(pid, 0) + bonus
 
             # Track debuff resistance
-            BUS.emit("relic_effect", "wooden_idol", member, "debuff_resisted", int(bonus * 100), {
+            await BUS.emit_async("relic_effect", "wooden_idol", member, "debuff_resisted", int(bonus * 100), {
                 "ally": getattr(member, 'id', str(member)),
                 "resistance_bonus_next_turn": bonus * 100,
                 "total_pending_bonus": pending[pid] * 100,
                 "stacks": party.relics.count(self.id)
             })
 
-        def _turn_start() -> None:
+        async def _turn_start() -> None:
             applied_count = 0
             for pid, bonus in list(pending.items()):
                 member = next((m for m in party.members if id(m) == pid), None)
@@ -57,7 +57,7 @@ class WoodenIdol(RelicBase):
                 applied_count += 1
 
                 # Track resistance buff application
-                BUS.emit("relic_effect", "wooden_idol", member, "resistance_buff_applied", int(bonus * 100), {
+                await BUS.emit_async("relic_effect", "wooden_idol", member, "resistance_buff_applied", int(bonus * 100), {
                     "ally": getattr(member, 'id', str(member)),
                     "resistance_bonus": bonus * 100,
                     "new_total_resistance": member.effect_resistance * 100,

--- a/backend/routes/performance.py
+++ b/backend/routes/performance.py
@@ -111,7 +111,7 @@ async def get_backend_health():
 
         # Quick performance check
         start = time.perf_counter()
-        BUS.emit('health_check_ping')  # Emit a test event
+        await BUS.emit_async('health_check_ping')  # Emit a test event
         ping_time = (time.perf_counter() - start) * 1000  # Convert to ms
 
         health['ping_ms'] = ping_time

--- a/backend/tests/test_100_fallback_effects_stress.py
+++ b/backend/tests/test_100_fallback_effects_stress.py
@@ -23,7 +23,7 @@ class TestEventBusStressWithFallbackEffects:
 
         def fallback_effect_handler(effect_id):
             """Simulate a fallback effect that processes damage events."""
-            def handler(attacker, target, amount, *args):
+            async def handler(attacker, target, amount, *args):
                 nonlocal damage_events_handled
                 start = time.perf_counter()
 
@@ -55,7 +55,7 @@ class TestEventBusStressWithFallbackEffects:
 
             # Test single damage event processing time
             start_time = time.perf_counter()
-            BUS.emit("damage_dealt", attacker, target, 100, "attack", None, None, "Normal Attack")
+            await BUS.emit_async("damage_dealt", attacker, target, 100, "attack", None, None, "Normal Attack")
             single_event_time = time.perf_counter() - start_time
 
             print(f"Single damage event processing time: {single_event_time*1000:.1f}ms")
@@ -71,7 +71,7 @@ class TestEventBusStressWithFallbackEffects:
             start_time = time.perf_counter()
 
             for i in range(burst_size):
-                BUS.emit("damage_dealt", attacker, target, 25 + i, "attack", None, None, f"Attack_{i}")
+                await BUS.emit_async("damage_dealt", attacker, target, 25 + i, "attack", None, None, f"Attack_{i}")
 
             burst_time = time.perf_counter() - start_time
 
@@ -230,7 +230,7 @@ class TestEventBusStressWithFallbackEffects:
         def slow_handler(*args):
             time.sleep(0.02)  # 20ms - intentionally slow
 
-        def fast_handler(*args):
+        async def fast_handler(*args):
             time.sleep(0.001)  # 1ms - normal speed
 
         BUS.subscribe("test_slow", slow_handler)
@@ -238,9 +238,9 @@ class TestEventBusStressWithFallbackEffects:
 
         try:
             # Emit events
-            BUS.emit("test_slow", "data")
-            BUS.emit("test_fast", "data")
-            BUS.emit("test_fast", "data")  # Emit twice
+            await BUS.emit_async("test_slow", "data")
+            await BUS.emit_async("test_fast", "data")
+            await BUS.emit_async("test_fast", "data")  # Emit twice
 
             # Check metrics
             metrics = BUS.get_performance_metrics()

--- a/backend/tests/test_arc_lightning.py
+++ b/backend/tests/test_arc_lightning.py
@@ -20,11 +20,11 @@ async def test_arc_lightning_chains_damage() -> None:
     party = Party([attacker])
     card = ArcLightning()
     await card.apply(party)
-    BUS.emit("battle_start", foe1)
-    BUS.emit("battle_start", foe2)
-    BUS.emit("battle_start", attacker)
+    await BUS.emit_async("battle_start", foe1)
+    await BUS.emit_async("battle_start", foe2)
+    await BUS.emit_async("battle_start", attacker)
     initial = foe2.hp
     with patch("plugins.cards.arc_lightning.random.choice", return_value=foe2):
-        BUS.emit("hit_landed", attacker, foe1, 100, "attack")
+        await BUS.emit_async("hit_landed", attacker, foe1, 100, "attack")
         await asyncio.sleep(0)
     assert foe2.hp < initial

--- a/backend/tests/test_async_bus_stress_with_backend_ping.py
+++ b/backend/tests/test_async_bus_stress_with_backend_ping.py
@@ -169,7 +169,7 @@ async def test_sync_vs_async_comparison():
     start_sync = time.perf_counter()
 
     for i in range(event_count):
-        BUS.emit("test_sync_event", attacker, target, i)
+        await BUS.emit_async("test_sync_event", attacker, target, i)
 
     sync_time = time.perf_counter() - start_sync
 

--- a/backend/tests/test_async_improvements.py
+++ b/backend/tests/test_async_improvements.py
@@ -1,3 +1,4 @@
+import pytest
 #!/usr/bin/env python3
 """
 Simple test to verify async database operations work correctly.
@@ -19,6 +20,7 @@ sys.path.insert(0, '/home/runner/work/Midori-AI-AutoFighter/Midori-AI-AutoFighte
 from autofighter.save_manager import SaveManager
 
 
+@pytest.mark.asyncio
 async def test_sync_vs_async_db():
     """Test to show the difference between sync and async database operations."""
 

--- a/backend/tests/test_battle_logging.py
+++ b/backend/tests/test_battle_logging.py
@@ -39,7 +39,8 @@ def test_battle_logger_creates_folder_structure(temp_logs_dir):
     logger.finalize_battle("test")
 
 
-def test_battle_logger_tracks_events(temp_logs_dir):
+@pytest.mark.asyncio
+async def test_battle_logger_tracks_events(temp_logs_dir):
     """Test that BattleLogger properly tracks battle events."""
     run_id = "test_run_456"
     battle_index = 1
@@ -53,10 +54,10 @@ def test_battle_logger_tracks_events(temp_logs_dir):
     target.id = "test_target"
 
     # Simulate battle events
-    BUS.emit("battle_start", attacker)
-    BUS.emit("battle_start", target)
-    BUS.emit("damage_dealt", attacker, target, 50)
-    BUS.emit("hit_landed", attacker, target, 50)
+    await BUS.emit_async("battle_start", attacker)
+    await BUS.emit_async("battle_start", target)
+    await BUS.emit_async("damage_dealt", attacker, target, 50)
+    await BUS.emit_async("hit_landed", attacker, target, 50)
 
     # Finalize to write summary
     logger.finalize_battle("victory")
@@ -108,7 +109,8 @@ def test_run_logging_management(temp_logs_dir):
     assert run_path.exists()
 
 
-def test_human_readable_summary(temp_logs_dir):
+@pytest.mark.asyncio
+async def test_human_readable_summary(temp_logs_dir):
     """Test that human-readable summary is generated correctly."""
     run_id = "test_run_readable"
     battle_index = 1
@@ -121,12 +123,12 @@ def test_human_readable_summary(temp_logs_dir):
     target = Stats()
     target.id = "monster"
 
-    BUS.emit("battle_start", attacker)
-    BUS.emit("battle_start", target)
-    BUS.emit("damage_dealt", attacker, target, 100)
-    BUS.emit("damage_taken", target, attacker, 100)
-    BUS.emit("hit_landed", attacker, target, 100)
-    BUS.emit("heal", attacker, attacker, 25)
+    await BUS.emit_async("battle_start", attacker)
+    await BUS.emit_async("battle_start", target)
+    await BUS.emit_async("damage_dealt", attacker, target, 100)
+    await BUS.emit_async("damage_taken", target, attacker, 100)
+    await BUS.emit_async("hit_landed", attacker, target, 100)
+    await BUS.emit_async("heal", attacker, attacker, 25)
 
     logger.finalize_battle("victory")
 
@@ -144,7 +146,8 @@ def test_human_readable_summary(temp_logs_dir):
     assert "Total Events:" in content
 
 
-def test_damage_dealt_defaults_to_normal_attack(temp_logs_dir):
+@pytest.mark.asyncio
+async def test_damage_dealt_defaults_to_normal_attack(temp_logs_dir):
     run_id = "test_run_normal_attack"
     battle_index = 1
     logger = BattleLogger(run_id, battle_index, temp_logs_dir)
@@ -154,9 +157,9 @@ def test_damage_dealt_defaults_to_normal_attack(temp_logs_dir):
     target = Stats()
     target.id = "monster"
 
-    BUS.emit("battle_start", attacker)
-    BUS.emit("battle_start", target)
-    BUS.emit("damage_dealt", attacker, target, 42)
+    await BUS.emit_async("battle_start", attacker)
+    await BUS.emit_async("battle_start", target)
+    await BUS.emit_async("damage_dealt", attacker, target, 42)
 
     logger.finalize_battle("victory")
 

--- a/backend/tests/test_battle_summary_endpoint.py
+++ b/backend/tests/test_battle_summary_endpoint.py
@@ -17,7 +17,7 @@ async def test_battle_summary_endpoint(app_with_db):
     target = Stats()
     target.id = 'foe'
 
-    BUS.emit('damage_dealt', attacker, target, 42, damage_type='Fire')
+    await BUS.emit_async('damage_dealt', attacker, target, 42, damage_type='Fire')
     logger.finalize_battle('victory')
 
     client = app.test_client()

--- a/backend/tests/test_card_rewards.py
+++ b/backend/tests/test_card_rewards.py
@@ -151,10 +151,10 @@ async def test_critical_focus_grants_boost():
     await asyncio.sleep(0)
     base_rate = member.crit_rate
     base_dmg = member.crit_damage
-    BUS.emit("turn_start")
+    await BUS.emit_async("turn_start")
     assert member.crit_rate == pytest.approx(base_rate + 0.005)
     assert member.crit_damage == pytest.approx(base_dmg + 0.05)
-    BUS.emit("damage_taken", member, None, 10)
+    await BUS.emit_async("damage_taken", member, None, 10)
     assert member.crit_rate == pytest.approx(base_rate)
 
 
@@ -167,11 +167,11 @@ async def test_critical_transfer_moves_stacks():
     await cards_module.apply_cards(party)
     await asyncio.sleep(0)
     cb_a = CriticalBoost()
-    cb_a.apply(a)
-    cb_a.apply(a)
+    await cb_a.apply(a)
+    await cb_a.apply(a)
     setattr(a, "_critical_boost", cb_a)
     cb_b = CriticalBoost()
-    cb_b.apply(b)
+    await cb_b.apply(b)
     setattr(b, "_critical_boost", cb_b)
     base_atk = a.atk
     a.add_ultimate_charge(15)
@@ -191,7 +191,7 @@ async def test_iron_guard_defense_buff():
     await asyncio.sleep(0)
     base_a = a.defense
     base_b = b.defense
-    BUS.emit("damage_taken", a, b, 10)
+    await BUS.emit_async("damage_taken", a, b, 10)
     assert a.defense == base_a + 20
     assert b.defense == base_b + 20
 
@@ -207,18 +207,18 @@ async def test_swift_footwork_first_action(monkeypatch):
     assert member.actions_per_turn == 2
     events: list[str] = []
 
-    def _listener(card_id, *_args):
+    async def _listener(card_id, *_args):
         if card_id == "swift_footwork":
             events.append(_args[1])
 
     BUS.subscribe("card_effect", _listener)
-    BUS.emit("battle_start")
+    await BUS.emit_async("battle_start")
     member.action_points -= 1
-    BUS.emit("action_used", member, None, 10)
+    await BUS.emit_async("action_used", member, None, 10)
     await asyncio.sleep(0.05)
     assert member.action_points == 1
     member.action_points -= 1
-    BUS.emit("action_used", member, None, 10)
+    await BUS.emit_async("action_used", member, None, 10)
     await asyncio.sleep(0.05)
     BUS.unsubscribe("card_effect", _listener)
     assert member.action_points == 0
@@ -233,7 +233,7 @@ async def test_mystic_aegis_heals_on_resist():
     award_card(party, "mystic_aegis")
     await cards_module.apply_cards(party)
     await asyncio.sleep(0)
-    BUS.emit("debuff_resisted", member)
+    await BUS.emit_async("debuff_resisted", member)
     await asyncio.sleep(0)
     assert member.hp == 800 + int(member.max_hp * 0.05)
 
@@ -247,10 +247,10 @@ async def test_vital_surge_low_hp_bonus():
     await asyncio.sleep(0)
     assert member.max_hp == int(1000 * 1.55)
     member.hp = int(member.max_hp * 0.4)
-    BUS.emit("turn_start")
+    await BUS.emit_async("turn_start")
     assert member.atk == int(200 * 1.55)
     member.hp = member.max_hp
-    BUS.emit("heal_received", member, member, 100)
+    await BUS.emit_async("heal_received", member, member, 100)
     assert member.atk == 200
 
 
@@ -266,8 +266,8 @@ async def test_elemental_spark_selects_ally(monkeypatch):
     import random
 
     monkeypatch.setattr(random, "choice", lambda seq: seq[0])
-    BUS.emit("battle_start")
+    await BUS.emit_async("battle_start")
     assert member.effect_hit_rate == pytest.approx(base + 0.05)
-    BUS.emit("battle_end")
+    await BUS.emit_async("battle_end")
     await asyncio.sleep(0)
     assert member.effect_hit_rate == pytest.approx(base)

--- a/backend/tests/test_character_passives.py
+++ b/backend/tests/test_character_passives.py
@@ -181,7 +181,7 @@ async def test_hilander_aftertaste_and_soft_cap(monkeypatch):
     monkeypatch.setattr(Aftertaste, "rolls", lambda self: [self.base_pot])
     damage_before = target.damage_taken
     set_battle_active(True)
-    BUS.emit("critical_hit", hilander, target, 100, "attack")
+    await BUS.emit_async("critical_hit", hilander, target, 100, "attack")
     await asyncio.sleep(0)
     set_battle_active(False)
 

--- a/backend/tests/test_critical_boost.py
+++ b/backend/tests/test_critical_boost.py
@@ -2,17 +2,22 @@ from pathlib import Path
 
 import pytest
 
+from pathlib import Path
+
+import pytest
+
 from autofighter.stats import BUS
 from autofighter.stats import Stats
 from plugins.effects.critical_boost import CriticalBoost
 from plugins.plugin_loader import PluginLoader
 
 
-def test_critical_boost_stacking():
+@pytest.mark.asyncio
+async def test_critical_boost_stacking():
     stats = Stats()
     boost = CriticalBoost()
-    boost.apply(stats)
-    boost.apply(stats)
+    await boost.apply(stats)
+    await boost.apply(stats)
     assert stats.crit_rate == pytest.approx(0.05 + 0.005 * 2)
     assert stats.crit_damage == pytest.approx(2.0 + 0.05 * 2)
     BUS.unsubscribe("damage_taken", boost._on_damage_taken)
@@ -22,8 +27,8 @@ def test_critical_boost_stacking():
 async def test_critical_boost_resets_on_hit():
     stats = Stats()
     boost = CriticalBoost()
-    boost.apply(stats)
-    boost.apply(stats)
+    await boost.apply(stats)
+    await boost.apply(stats)
     await stats.apply_damage(10)
     assert stats.crit_rate == pytest.approx(0.05)
     assert stats.crit_damage == pytest.approx(2.0)

--- a/backend/tests/test_critical_overdrive.py
+++ b/backend/tests/test_critical_overdrive.py
@@ -1,5 +1,7 @@
 import asyncio
 
+import asyncio
+
 import pytest
 
 from autofighter.party import Party
@@ -18,11 +20,11 @@ async def test_critical_overdrive_boosts_and_converts() -> None:
     await card.apply(party)
     boost = CriticalBoost()
     for _ in range(200):
-        boost.apply(member)
+        await boost.apply(member)
     assert member.atk == int(100 * 3.55)
     assert member.crit_rate == pytest.approx(1.15)
     assert member.crit_damage == pytest.approx(12.3)
-    boost._on_damage_taken(member)
+    await boost._on_damage_taken(member)
     await asyncio.sleep(0)
     assert member.crit_rate == pytest.approx(0.05)
     assert member.crit_damage == pytest.approx(2.0)

--- a/backend/tests/test_event_bus_performance.py
+++ b/backend/tests/test_event_bus_performance.py
@@ -43,7 +43,7 @@ class TestEventBusPerformance:
 
         def slow_subscriber(index):
             """Simulate a subscriber that takes time to process (like complex relic effects)."""
-            def handler(*args):
+            async def handler(*args):
                 start = time.perf_counter()
                 # Simulate 1ms of processing time per subscriber (realistic for complex effects)
                 time.sleep(YIELD_DELAY)
@@ -68,7 +68,7 @@ class TestEventBusPerformance:
             target = Stats()
             target.id = "test_target"
 
-            BUS.emit("damage_dealt", attacker, target, 100, "attack", None, None, "Normal Attack")
+            await BUS.emit_async("damage_dealt", attacker, target, 100, "attack", None, None, "Normal Attack")
 
             end_time = time.perf_counter()
             total_time = end_time - start_time
@@ -104,7 +104,7 @@ class TestEventBusPerformance:
         # Track event emissions
         emission_times = []
 
-        def track_emission(*args):
+        async def track_emission(*args):
             emission_times.append(time.perf_counter())
 
         BUS.subscribe("damage_dealt", track_emission)
@@ -122,7 +122,7 @@ class TestEventBusPerformance:
             # Simulate initial attack triggering multiple Aftertaste effects
             for i in range(aftertaste_count):
                 # Each Aftertaste effect emits a relic_effect event
-                BUS.emit("relic_effect", "aftertaste", attacker, "damage", 25, {
+                await BUS.emit_async("relic_effect", "aftertaste", attacker, "damage", 25, {
                     "effect_type": "aftertaste",
                     "base_damage": 25,
                     "random_damage_type": "Fire",
@@ -130,7 +130,7 @@ class TestEventBusPerformance:
                 })
 
                 # Then emits damage_dealt when damage is applied
-                BUS.emit("damage_dealt", attacker, target, 25, "effect", "aftertaste", "Fire", "Aftertaste (Fire)")
+                await BUS.emit_async("damage_dealt", attacker, target, 25, "effect", "aftertaste", "Fire", "Aftertaste (Fire)")
 
             end_time = time.perf_counter()
             total_time = end_time - start_time
@@ -167,7 +167,7 @@ class TestEventBusPerformance:
 
         try:
             start = time.perf_counter()
-            BUS.emit("test_sync", "data")
+            await BUS.emit_async("test_sync", "data")
             sync_time = time.perf_counter() - start
             sync_times.append(sync_time)
         finally:
@@ -201,7 +201,7 @@ class TestEventBusPerformance:
 
         event_times = []
 
-        def timing_handler(*args):
+        async def timing_handler(*args):
             event_times.append(time.perf_counter())
 
         BUS.subscribe("burst_test", timing_handler)
@@ -211,7 +211,7 @@ class TestEventBusPerformance:
 
             # Rapid fire events (simulates intense combat with many effects)
             for i in range(burst_size):
-                BUS.emit("burst_test", f"event_{i}")
+                await BUS.emit_async("burst_test", f"event_{i}")
 
             end_time = time.perf_counter()
             total_time = end_time - start_time

--- a/backend/tests/test_farsight_scope.py
+++ b/backend/tests/test_farsight_scope.py
@@ -15,7 +15,8 @@ def setup_event_loop():
     return loop
 
 
-def test_farsight_scope_crit_bonus_applied_and_removed():
+@pytest.mark.asyncio
+async def test_farsight_scope_crit_bonus_applied_and_removed():
     loop = setup_event_loop()
     party = Party()
     ally = Stats()
@@ -30,9 +31,8 @@ def test_farsight_scope_crit_bonus_applied_and_removed():
     base_crit = ally.crit_rate
 
     enemy.hp = 400  # Below 50%
-    BUS.emit("before_attack", ally, enemy)
+    await BUS.emit_async("before_attack", ally, enemy)
     assert ally.crit_rate == pytest.approx(base_crit + 0.06, abs=1e-6)
 
-    BUS.emit("action_used", ally, enemy, ally.atk)
+    await BUS.emit_async("action_used", ally, enemy, ally.atk)
     assert ally.crit_rate == pytest.approx(base_crit, abs=1e-6)
-

--- a/backend/tests/test_fire_ultimate.py
+++ b/backend/tests/test_fire_ultimate.py
@@ -28,7 +28,7 @@ async def test_fire_ultimate_stack_accumulation_and_drain():
     await actor.use_ultimate()
     assert actor.damage_type._drain_stacks == 1
 
-    BUS.emit("turn_start", actor)
+    await BUS.emit_async("turn_start", actor)
     await asyncio.sleep(0)
     expected = actor.max_hp - int(actor.max_hp * 0.05)
     assert actor.hp == expected
@@ -38,12 +38,12 @@ async def test_fire_ultimate_stack_accumulation_and_drain():
     await actor.use_ultimate()
     assert actor.damage_type._drain_stacks == 2
 
-    BUS.emit("turn_start", actor)
+    await BUS.emit_async("turn_start", actor)
     await asyncio.sleep(0)
     expected -= int(actor.max_hp * 0.10)
     assert actor.hp == expected
 
-    BUS.emit("battle_end", actor)
+    await BUS.emit_async("battle_end", actor)
 
 
 @pytest.mark.asyncio
@@ -56,11 +56,11 @@ async def test_fire_ultimate_resets_on_battle_end():
     await actor.use_ultimate()
     assert actor.damage_type._drain_stacks == 1
 
-    BUS.emit("battle_end", actor)
+    await BUS.emit_async("battle_end", actor)
     assert actor.damage_type._drain_stacks == 0
 
     actor.hp = actor.max_hp
-    BUS.emit("turn_start", actor)
+    await BUS.emit_async("turn_start", actor)
     await asyncio.sleep(0)
     assert actor.hp == actor.max_hp
 
@@ -85,4 +85,4 @@ async def test_fire_ultimate_damage_multiplier():
     boosted = await target2.apply_damage(100, attacker)
     assert boosted == base * 5
 
-    BUS.emit("battle_end", attacker)
+    await BUS.emit_async("battle_end", attacker)

--- a/backend/tests/test_five_star_cards.py
+++ b/backend/tests/test_five_star_cards.py
@@ -37,7 +37,7 @@ async def test_phantom_ally_summon_lifecycle(monkeypatch):
     assert phantom_found
 
     # Test cleanup - emit battle end to trigger summon removal
-    BUS.emit("battle_end", FoeBase())
+    await BUS.emit_async("battle_end", FoeBase())
     assert len(party.members) == 2
 
 
@@ -50,11 +50,11 @@ async def test_temporal_shield_damage_reduction(monkeypatch):
     await TemporalShield().apply(party)
     base_mit = member.mitigation
     monkeypatch.setattr(random, "random", lambda: 0.4)
-    BUS.emit("turn_start")
+    await BUS.emit_async("turn_start")
     assert member.mitigation >= base_mit * 50
     await member.effect_manager.cleanup(member)
     monkeypatch.setattr(random, "random", lambda: 0.6)
-    BUS.emit("turn_start")
+    await BUS.emit_async("turn_start")
     assert member.mitigation == base_mit
 
 
@@ -71,12 +71,12 @@ async def test_reality_split_afterimage(monkeypatch):
     f1.id = "f1"
     f2 = FoeBase()
     f2.id = "f2"
-    BUS.emit("battle_start", f1)
-    BUS.emit("battle_start", f2)
+    await BUS.emit_async("battle_start", f1)
+    await BUS.emit_async("battle_start", f2)
     monkeypatch.setattr(random, "choice", lambda seq: a1)
     monkeypatch.setattr(random, "random", lambda: 1.0)
-    BUS.emit("turn_start")
-    BUS.emit("hit_landed", a1, f1, 100, "attack", "test")
+    await BUS.emit_async("turn_start")
+    await BUS.emit_async("hit_landed", a1, f1, 100, "attack", "test")
     await asyncio.sleep(0)
     loss1 = f1.max_hp - f1.hp
     loss2 = f2.max_hp - f2.hp

--- a/backend/tests/test_frozen_wound.py
+++ b/backend/tests/test_frozen_wound.py
@@ -16,6 +16,7 @@ from plugins.dots.frozen_wound import FrozenWound
         (100, 0.99, True),
     ],
 )
+@pytest.mark.asyncio
 async def test_frozen_wound_miss_chance(stacks, roll, expect_miss, monkeypatch):
     actor = Stats()
     actor.set_base_stat('atk', 10)

--- a/backend/tests/test_guardian_shard.py
+++ b/backend/tests/test_guardian_shard.py
@@ -16,7 +16,8 @@ def setup_event_loop():
     return loop
 
 
-def test_guardian_shard_applies_bonus_after_no_deaths():
+@pytest.mark.asyncio
+async def test_guardian_shard_applies_bonus_after_no_deaths():
     loop = setup_event_loop()
     party = Party()
     ally1 = PlayerBase()
@@ -25,24 +26,25 @@ def test_guardian_shard_applies_bonus_after_no_deaths():
     award_card(party, "guardian_shard")
     loop.run_until_complete(apply_cards(party))
 
-    BUS.emit("battle_start", ally1)
-    BUS.emit("battle_start", ally2)
+    await BUS.emit_async("battle_start", ally1)
+    await BUS.emit_async("battle_start", ally2)
     loop.run_until_complete(asyncio.sleep(0))
-    BUS.emit("battle_end", FoeBase())
+    await BUS.emit_async("battle_end", FoeBase())
     loop.run_until_complete(asyncio.sleep(0))
 
     pre = ally1.mitigation
-    BUS.emit("battle_start", ally1)
-    BUS.emit("battle_start", ally2)
+    await BUS.emit_async("battle_start", ally1)
+    await BUS.emit_async("battle_start", ally2)
     loop.run_until_complete(asyncio.sleep(0))
     assert ally1.mitigation == pytest.approx(pre + 1)
 
-    BUS.emit("battle_end", FoeBase())
+    await BUS.emit_async("battle_end", FoeBase())
     loop.run_until_complete(asyncio.sleep(0))
     assert ally1.mitigation == pytest.approx(pre)
 
 
-def test_guardian_shard_no_bonus_after_death():
+@pytest.mark.asyncio
+async def test_guardian_shard_no_bonus_after_death():
     loop = setup_event_loop()
     party = Party()
     ally1 = PlayerBase()
@@ -51,15 +53,15 @@ def test_guardian_shard_no_bonus_after_death():
     award_card(party, "guardian_shard")
     loop.run_until_complete(apply_cards(party))
 
-    BUS.emit("battle_start", ally1)
-    BUS.emit("battle_start", ally2)
-    BUS.emit("death", ally1)
+    await BUS.emit_async("battle_start", ally1)
+    await BUS.emit_async("battle_start", ally2)
+    await BUS.emit_async("death", ally1)
     loop.run_until_complete(asyncio.sleep(0))
-    BUS.emit("battle_end", FoeBase())
+    await BUS.emit_async("battle_end", FoeBase())
     loop.run_until_complete(asyncio.sleep(0))
 
     pre = ally1.mitigation
-    BUS.emit("battle_start", ally1)
-    BUS.emit("battle_start", ally2)
+    await BUS.emit_async("battle_start", ally1)
+    await BUS.emit_async("battle_start", ally2)
     loop.run_until_complete(asyncio.sleep(0))
     assert ally1.mitigation == pytest.approx(pre)

--- a/backend/tests/test_guiding_compass.py
+++ b/backend/tests/test_guiding_compass.py
@@ -35,20 +35,20 @@ async def test_guiding_compass_first_battle_xp_only_once() -> None:
 
     events: list[tuple[str, str, int]] = []
 
-    def _on_card_effect(card_id, member, effect, amount, extra):
+    async def _on_card_effect(card_id, member, effect, amount, extra):
         if effect == "first_battle_xp":
             events.append((card_id, member.id, amount))
 
     BUS.subscribe("card_effect", _on_card_effect)
 
-    BUS.emit("battle_start", member1)
+    await BUS.emit_async("battle_start", member1)
     await asyncio.sleep(0.05)
 
     assert member1.exp == base_exp + 10
     assert member2.exp == base_exp + 10
     assert len(events) == 2
 
-    BUS.emit("battle_start", member1)
+    await BUS.emit_async("battle_start", member1)
     await asyncio.sleep(0.05)
 
     assert member1.exp == base_exp + 10

--- a/backend/tests/test_hit_landed_event.py
+++ b/backend/tests/test_hit_landed_event.py
@@ -49,7 +49,7 @@ async def test_pocket_manual_triggers_aftertaste():
     import asyncio
     original_create_task = asyncio.get_event_loop().create_task
 
-    def mock_create_task(coro):
+    async def mock_create_task(coro):
         tasks_created.append(coro)
         # Return a mock task that doesn't actually run
         task = AsyncMock()
@@ -66,18 +66,18 @@ async def test_pocket_manual_triggers_aftertaste():
 
         # Simulate 9 hits (should not trigger aftertaste)
         for i in range(9):
-            BUS.emit("hit_landed", attacker, target, 100)
+            await BUS.emit_async("hit_landed", attacker, target, 100)
 
         assert len(tasks_created) == 0
 
         # 10th hit should trigger aftertaste
-        BUS.emit("hit_landed", attacker, target, 100)
+        await BUS.emit_async("hit_landed", attacker, target, 100)
 
         assert len(tasks_created) >= 1  # At least one aftertaste task should be created
 
         # 20th hit should trigger aftertaste again
         for i in range(10):
-            BUS.emit("hit_landed", attacker, target, 100)
+            await BUS.emit_async("hit_landed", attacker, target, 100)
 
         assert len(tasks_created) >= 2  # At least two aftertaste tasks should be created
 

--- a/backend/tests/test_integration_complete.py
+++ b/backend/tests/test_integration_complete.py
@@ -51,7 +51,7 @@ async def test_complete_integration():
             import asyncio
             original_create_task = asyncio.get_event_loop().create_task
 
-            def mock_create_task(coro):
+            async def mock_create_task(coro):
                 nonlocal aftertaste_count
                 # Check if this is an aftertaste coroutine
                 if hasattr(coro, '__name__') or (hasattr(coro, 'cr_code') and coro.cr_code):
@@ -65,23 +65,23 @@ async def test_complete_integration():
             asyncio.get_event_loop().create_task = mock_create_task
 
             # Simulate battle events
-            BUS.emit("battle_start", player)
-            BUS.emit("battle_start", enemy)
+            await BUS.emit_async("battle_start", player)
+            await BUS.emit_async("battle_start", enemy)
 
             # Simulate 15 hits to trigger aftertaste (should trigger on 10th hit)
             for i in range(15):
                 damage = 25 + i  # Varying damage
-                BUS.emit("damage_dealt", player, enemy, damage)
-                BUS.emit("hit_landed", player, enemy, damage)
+                await BUS.emit_async("damage_dealt", player, enemy, damage)
+                await BUS.emit_async("hit_landed", player, enemy, damage)
 
             # Some healing
-            BUS.emit("heal", player, player, 50)
+            await BUS.emit_async("heal", player, player, 50)
 
             # Enemy attacks back a few times
             for i in range(3):
                 damage = 15 + i
-                BUS.emit("damage_dealt", enemy, player, damage)
-                BUS.emit("hit_landed", enemy, player, damage)
+                await BUS.emit_async("damage_dealt", enemy, player, damage)
+                await BUS.emit_async("hit_landed", enemy, player, damage)
 
             # End battle
             battle_logger.finalize_battle("victory")

--- a/backend/tests/test_iron_resurgence.py
+++ b/backend/tests/test_iron_resurgence.py
@@ -25,7 +25,7 @@ async def test_iron_resurgence_revives_and_cools_down() -> None:
     await asyncio.sleep(0)
     assert member.hp == 0
     for _ in range(4):
-        BUS.emit("turn_start")
+        await BUS.emit_async("turn_start")
     await member.apply_healing(member.max_hp)
     await member.apply_damage(member.max_hp)
     await asyncio.sleep(0)

--- a/backend/tests/test_lightning_ultimate.py
+++ b/backend/tests/test_lightning_ultimate.py
@@ -81,11 +81,11 @@ async def test_lightning_ultimate_aftertaste_stacks(monkeypatch):
 
     # Test BUS directly
     simple_calls = []
-    def simple_handler(*args):
+    async def simple_handler(*args):
         simple_calls.append(args)
 
     BUS.subscribe("hit_landed", simple_handler)
-    BUS.emit("hit_landed", attacker, target, 10, "attack")
+    await BUS.emit_async("hit_landed", attacker, target, 10, "attack")
     await asyncio.sleep(0)
     print(f"Simple handler calls: {simple_calls}")
     assert len(simple_calls) > 0  # Verify BUS works
@@ -97,6 +97,6 @@ async def test_lightning_ultimate_aftertaste_stacks(monkeypatch):
     print(f"Has handler attribute: {hasattr(attacker, '_lightning_aftertaste_handler')}")
     print(f"Stacks: {getattr(attacker, '_lightning_aftertaste_stacks', 'None')}")
 
-    BUS.emit("hit_landed", attacker, target, 10, "attack")
+    await BUS.emit_async("hit_landed", attacker, target, 10, "attack")
     await asyncio.sleep(0)
     assert hits == [1]

--- a/backend/tests/test_optimized_performance.py
+++ b/backend/tests/test_optimized_performance.py
@@ -1,3 +1,4 @@
+import pytest
 #!/usr/bin/env python3
 """
 Test script to measure performance improvements with async optimizations.
@@ -11,6 +12,7 @@ from autofighter.effects import EffectManager
 from autofighter.stats import Stats
 
 
+@pytest.mark.asyncio
 async def test_optimized_performance():
     """Test performance with optimized DOT processing."""
 

--- a/backend/tests/test_relic_awards.py
+++ b/backend/tests/test_relic_awards.py
@@ -1,16 +1,19 @@
+import pytest
+
 from autofighter.party import Party
 from autofighter.relics import apply_relics
 from autofighter.relics import award_relic
 from plugins.players._base import PlayerBase
 
 
-def test_award_relics_stack():
+@pytest.mark.asyncio
+async def test_award_relics_stack():
     party = Party()
     member = PlayerBase()
     member.set_base_stat('atk', 100)
     party.members.append(member)
     assert award_relic(party, "bent_dagger") is not None
     assert award_relic(party, "bent_dagger") is not None
-    apply_relics(party)
+    await apply_relics(party)
     assert party.relics == ["bent_dagger", "bent_dagger"]
     assert party.members[0].atk == int(100 * 1.03 * 1.03)

--- a/backend/tests/test_relic_effects.py
+++ b/backend/tests/test_relic_effects.py
@@ -23,7 +23,8 @@ class DummyPlayer(Stats):
         return True
 
 
-def test_bent_dagger_kill_trigger():
+@pytest.mark.asyncio
+async def test_bent_dagger_kill_trigger():
     event_bus_module.bus._subs.clear()
     party = Party()
     member = PlayerBase()
@@ -32,13 +33,14 @@ def test_bent_dagger_kill_trigger():
     enemy.hp = enemy.set_base_stat('max_hp', 10)
     party.members.append(member)
     award_relic(party, "bent_dagger")
-    apply_relics(party)
+    await apply_relics(party)
     enemy.hp = 0
-    BUS.emit("damage_taken", enemy, member, 10)
+    await BUS.emit_async("damage_taken", enemy, member, 10)
     assert member.atk == int(100 * 1.03 * 1.01)
 
 
-def test_bent_dagger_kill_trigger_stacks():
+@pytest.mark.asyncio
+async def test_bent_dagger_kill_trigger_stacks():
     event_bus_module.bus._subs.clear()
     party = Party()
     member = PlayerBase()
@@ -48,26 +50,28 @@ def test_bent_dagger_kill_trigger_stacks():
     party.members.append(member)
     award_relic(party, "bent_dagger")
     award_relic(party, "bent_dagger")
-    apply_relics(party)
+    await apply_relics(party)
     enemy.hp = 0
-    BUS.emit("damage_taken", enemy, member, 10)
+    await BUS.emit_async("damage_taken", enemy, member, 10)
     expected = int(100 * 1.03 * 1.03 * 1.01 * 1.01)
     assert member.atk == expected
 
 
-def test_lucky_button_stacks():
+@pytest.mark.asyncio
+async def test_lucky_button_stacks():
     party = Party()
     member = PlayerBase()
     member.set_base_stat('crit_rate', 0.1)
     party.members.append(member)
     award_relic(party, "lucky_button")
     award_relic(party, "lucky_button")
-    apply_relics(party)
+    await apply_relics(party)
     assert isclose(party.members[0].crit_rate, 0.1 * 1.03 * 1.03)
 
 
 @pytest.mark.parametrize("copies", [1, 2, 3])
-def test_vengeful_pendant_reflects(copies: int) -> None:
+@pytest.mark.asyncio
+async def test_vengeful_pendant_reflects(copies: int) -> None:
     event_bus_module.bus._subs.clear()
     party = Party()
     ally = PlayerBase()
@@ -79,12 +83,13 @@ def test_vengeful_pendant_reflects(copies: int) -> None:
     party.members.append(ally)
     for _ in range(copies):
         award_relic(party, "vengeful_pendant")
-    apply_relics(party)
-    BUS.emit("damage_taken", ally, enemy, 20)
+    await apply_relics(party)
+    await BUS.emit_async("damage_taken", ally, enemy, 20)
     assert enemy.hp == 100 - int(20 * 0.15 * copies)
 
 
-def test_guardian_charm_targets_lowest_hp():
+@pytest.mark.asyncio
+async def test_guardian_charm_targets_lowest_hp():
     party = Party()
     low = PlayerBase()
     high = PlayerBase()
@@ -92,12 +97,13 @@ def test_guardian_charm_targets_lowest_hp():
     high.hp = high.set_base_stat('max_hp', 100)
     party.members.extend([low, high])
     award_relic(party, "guardian_charm")
-    apply_relics(party)
+    await apply_relics(party)
     assert low.defense == int(50 * 1.2)
     assert high.defense == 50
 
 
-def test_guardian_charm_stacks():
+@pytest.mark.asyncio
+async def test_guardian_charm_stacks():
     party = Party()
     low = PlayerBase()
     high = PlayerBase()
@@ -106,12 +112,13 @@ def test_guardian_charm_stacks():
     party.members.extend([low, high])
     award_relic(party, "guardian_charm")
     award_relic(party, "guardian_charm")
-    apply_relics(party)
+    await apply_relics(party)
     assert low.defense == int(50 * (1 + 0.2 * 2))
     assert high.defense == 50
 
 
-def test_herbal_charm_heals_each_turn():
+@pytest.mark.asyncio
+async def test_herbal_charm_heals_each_turn():
     event_bus_module.bus._subs.clear()
     party = Party()
     member = PlayerBase()
@@ -119,12 +126,13 @@ def test_herbal_charm_heals_each_turn():
     member.set_base_stat('max_hp', 100)
     party.members.append(member)
     award_relic(party, "herbal_charm")
-    apply_relics(party)
-    BUS.emit("turn_start")
+    await apply_relics(party)
+    await BUS.emit_async("turn_start")
     assert member.hp == 50 + int(100 * 0.005)
 
 
-def test_herbal_charm_stacks():
+@pytest.mark.asyncio
+async def test_herbal_charm_stacks():
     event_bus_module.bus._subs.clear()
     party = Party()
     member = PlayerBase()
@@ -133,12 +141,13 @@ def test_herbal_charm_stacks():
     party.members.append(member)
     award_relic(party, "herbal_charm")
     award_relic(party, "herbal_charm")
-    apply_relics(party)
-    BUS.emit("turn_start")
+    await apply_relics(party)
+    await BUS.emit_async("turn_start")
     assert member.hp == 50 + 2 * int(100 * 0.005)
 
 
-def test_tattered_flag_buffs_survivors_on_death():
+@pytest.mark.asyncio
+async def test_tattered_flag_buffs_survivors_on_death():
     event_bus_module.bus._subs.clear()
     party = Party()
     survivor = PlayerBase()
@@ -147,13 +156,14 @@ def test_tattered_flag_buffs_survivors_on_death():
     victim.hp = victim.set_base_stat('max_hp', 10)
     party.members.extend([survivor, victim])
     award_relic(party, "tattered_flag")
-    apply_relics(party)
+    await apply_relics(party)
     victim.hp = 0
-    BUS.emit("damage_taken", victim, survivor, 10)
+    await BUS.emit_async("damage_taken", victim, survivor, 10)
     assert survivor.atk == int(100 * 1.03)
 
 
-def test_tattered_flag_stacks():
+@pytest.mark.asyncio
+async def test_tattered_flag_stacks():
     event_bus_module.bus._subs.clear()
     party = Party()
     survivor = PlayerBase()
@@ -163,33 +173,35 @@ def test_tattered_flag_stacks():
     party.members.extend([survivor, victim])
     award_relic(party, "tattered_flag")
     award_relic(party, "tattered_flag")
-    apply_relics(party)
+    await apply_relics(party)
     victim.hp = 0
-    BUS.emit("damage_taken", victim, survivor, 10)
+    await BUS.emit_async("damage_taken", victim, survivor, 10)
     assert survivor.atk == int(100 * 1.03 * 1.03)
 
 
-def test_shiny_pebble_first_hit_mitigation():
+@pytest.mark.asyncio
+async def test_shiny_pebble_first_hit_mitigation():
     event_bus_module.bus._subs.clear()
     party = Party()
     ally = PlayerBase()
     enemy = PlayerBase()
     party.members.append(ally)
     award_relic(party, "shiny_pebble")
-    apply_relics(party)
+    await apply_relics(party)
     events: list[tuple] = []
     BUS.subscribe("relic_effect", lambda *a: events.append(a))
-    BUS.emit("damage_taken", ally, enemy, 10)
+    await BUS.emit_async("damage_taken", ally, enemy, 10)
     assert isclose(ally.mitigation, 103)
     assert events[0][0] == "shiny_pebble"
     assert events[0][2] == "mitigation_burst"
     assert events[0][3] == 3
     assert isclose(events[0][4]["mitigation_multiplier"], 1.03)
-    BUS.emit("turn_start")
+    await BUS.emit_async("turn_start")
     assert isclose(ally.mitigation, 100)
 
 
-def test_shiny_pebble_stacks():
+@pytest.mark.asyncio
+async def test_shiny_pebble_stacks():
     event_bus_module.bus._subs.clear()
     party = Party()
     ally = PlayerBase()
@@ -197,35 +209,37 @@ def test_shiny_pebble_stacks():
     party.members.append(ally)
     award_relic(party, "shiny_pebble")
     award_relic(party, "shiny_pebble")
-    apply_relics(party)
+    await apply_relics(party)
     events: list[tuple] = []
     BUS.subscribe("relic_effect", lambda *a: events.append(a))
-    BUS.emit("damage_taken", ally, enemy, 10)
+    await BUS.emit_async("damage_taken", ally, enemy, 10)
     assert isclose(ally.mitigation, 106)
     assert events[0][0] == "shiny_pebble"
     assert events[0][2] == "mitigation_burst"
     assert events[0][3] == 6
     assert isclose(events[0][4]["mitigation_multiplier"], 1.06)
-    BUS.emit("turn_start")
+    await BUS.emit_async("turn_start")
     assert isclose(ally.mitigation, 100)
 
 
-def test_threadbare_cloak_shield_scales_with_stacks():
+@pytest.mark.asyncio
+async def test_threadbare_cloak_shield_scales_with_stacks():
     party = Party()
     a = PlayerBase()
     a.hp = a.set_base_stat('max_hp', 100)
     party.members.append(a)
 
     award_relic(party, "threadbare_cloak")
-    apply_relics(party)
+    await apply_relics(party)
     assert a.hp == 100 + int(100 * 0.03)
 
     award_relic(party, "threadbare_cloak")
-    apply_relics(party)
+    await apply_relics(party)
     assert a.hp == 100 + int(100 * 0.03 * 2)
 
 
-def test_threadbare_cloak_applies_each_battle():
+@pytest.mark.asyncio
+async def test_threadbare_cloak_applies_each_battle():
     event_bus_module.bus._subs.clear()
     party = Party()
     a = PlayerBase()
@@ -233,16 +247,17 @@ def test_threadbare_cloak_applies_each_battle():
     party.members.append(a)
 
     award_relic(party, "threadbare_cloak")
-    apply_relics(party)
+    await apply_relics(party)
     assert a.hp == 100 + int(100 * 0.03)
 
-    BUS.emit("battle_end", a)
+    await BUS.emit_async("battle_end", a)
     a.hp = a.set_base_stat('max_hp', 100)
-    apply_relics(party)
+    await apply_relics(party)
     assert a.hp == 100 + int(100 * 0.03)
 
 
-def test_lucky_button_missed_crit():
+@pytest.mark.asyncio
+async def test_lucky_button_missed_crit():
     event_bus_module.bus._subs.clear()
     party = Party()
     a = PlayerBase()
@@ -250,45 +265,48 @@ def test_lucky_button_missed_crit():
     a.set_base_stat('crit_damage', 2.0)
     party.members.append(a)
     award_relic(party, "lucky_button")
-    apply_relics(party)
-    BUS.emit("crit_missed", a, None)
-    BUS.emit("turn_start")
+    await apply_relics(party)
+    await BUS.emit_async("crit_missed", a, None)
+    await BUS.emit_async("turn_start")
     assert isclose(a.crit_rate, 0.1 * 1.03 + 0.005, rel_tol=1e-4)
     assert isclose(a.crit_damage, 2.0 + 0.05, rel_tol=1e-4)
-    BUS.emit("turn_end")
+    await BUS.emit_async("turn_end")
     assert isclose(a.crit_rate, 0.1 * 1.03, rel_tol=1e-4)
     assert isclose(a.crit_damage, 2.0, rel_tol=1e-4)
 
 
-def test_old_coin_gold_and_discount():
+@pytest.mark.asyncio
+async def test_old_coin_gold_and_discount():
     event_bus_module.bus._subs.clear()
     party = Party()
     award_relic(party, "old_coin")
-    apply_relics(party)
-    BUS.emit("gold_earned", 100)
+    await apply_relics(party)
+    await BUS.emit_async("gold_earned", 100)
     assert party.gold == int(100 * 0.03)
-    BUS.emit("shop_purchase", 100)
+    await BUS.emit_async("shop_purchase", 100)
     assert party.gold == int(100 * 0.03) + int(100 * 0.03)
-    BUS.emit("shop_purchase", 100)
+    await BUS.emit_async("shop_purchase", 100)
     assert party.gold == int(100 * 0.03) + int(100 * 0.03)
 
 
-def test_wooden_idol_resist_buff():
+@pytest.mark.asyncio
+async def test_wooden_idol_resist_buff():
     event_bus_module.bus._subs.clear()
     party = Party()
     a = PlayerBase()
     a.set_base_stat('effect_resistance', 1.0)
     party.members.append(a)
     award_relic(party, "wooden_idol")
-    apply_relics(party)
-    BUS.emit("debuff_resisted", a)
-    BUS.emit("turn_start")
+    await apply_relics(party)
+    await BUS.emit_async("debuff_resisted", a)
+    await BUS.emit_async("turn_start")
     assert isclose(a.effect_resistance, 1.03 + 0.01)
-    BUS.emit("turn_end")
+    await BUS.emit_async("turn_end")
     assert isclose(a.effect_resistance, 1.03)
 
 
-def test_pocket_manual_tenth_hit(monkeypatch):
+@pytest.mark.asyncio
+async def test_pocket_manual_tenth_hit(monkeypatch):
     event_bus_module.bus._subs.clear()
     party = Party()
     a = PlayerBase()
@@ -296,7 +314,7 @@ def test_pocket_manual_tenth_hit(monkeypatch):
     b.hp = b._base_max_hp = 100
     party.members.append(a)
     award_relic(party, "pocket_manual")
-    apply_relics(party)
+    await apply_relics(party)
 
     monkeypatch.setattr(Aftertaste, "rolls", lambda self: [self.base_pot])
 
@@ -309,15 +327,16 @@ def test_pocket_manual_tenth_hit(monkeypatch):
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
     for _ in range(9):
-        BUS.emit("hit_landed", a, b, 100)
+        await BUS.emit_async("hit_landed", a, b, 100)
         loop.run_until_complete(asyncio.sleep(0))
     assert b.hp == 100
-    BUS.emit("hit_landed", a, b, 100)
+    await BUS.emit_async("hit_landed", a, b, 100)
     loop.run_until_complete(asyncio.sleep(0))
     assert b.hp == 100 - int(100 * 0.03)
 
 
-def test_pocket_manual_tenth_hit_stacks(monkeypatch):
+@pytest.mark.asyncio
+async def test_pocket_manual_tenth_hit_stacks(monkeypatch):
     event_bus_module.bus._subs.clear()
     party = Party()
     a = PlayerBase()
@@ -326,7 +345,7 @@ def test_pocket_manual_tenth_hit_stacks(monkeypatch):
     party.members.append(a)
     award_relic(party, "pocket_manual")
     award_relic(party, "pocket_manual")
-    apply_relics(party)
+    await apply_relics(party)
 
     monkeypatch.setattr(Aftertaste, "rolls", lambda self: [self.base_pot])
 
@@ -339,16 +358,17 @@ def test_pocket_manual_tenth_hit_stacks(monkeypatch):
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
     for _ in range(9):
-        BUS.emit("hit_landed", a, b, 100)
+        await BUS.emit_async("hit_landed", a, b, 100)
         loop.run_until_complete(asyncio.sleep(0))
     assert b.hp == 100
-    BUS.emit("hit_landed", a, b, 100)
+    await BUS.emit_async("hit_landed", a, b, 100)
     loop.run_until_complete(asyncio.sleep(0))
     stacks = party.relics.count("pocket_manual")
     assert b.hp == 100 - int(100 * 0.03 * stacks) * stacks
 
 
-def test_arcane_flask_shields():
+@pytest.mark.asyncio
+async def test_arcane_flask_shields():
     event_bus_module.bus._subs.clear()
     party = Party()
     a = DummyPlayer()
@@ -356,7 +376,7 @@ def test_arcane_flask_shields():
     a._base_max_hp = 100
     party.members.append(a)
     award_relic(party, "arcane_flask")
-    apply_relics(party)
+    await apply_relics(party)
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
 
@@ -369,7 +389,8 @@ def test_arcane_flask_shields():
     assert a.hp == 50 + int(100 * 0.2)
 
 
-def test_echo_bell_repeats_first_action():
+@pytest.mark.asyncio
+async def test_echo_bell_repeats_first_action():
     event_bus_module.bus._subs.clear()
     party = Party()
     a = PlayerBase()
@@ -377,11 +398,11 @@ def test_echo_bell_repeats_first_action():
     b.hp = 100
     party.members.append(a)
     award_relic(party, "echo_bell")
-    apply_relics(party)
-    BUS.emit("battle_start")
+    await apply_relics(party)
+    await BUS.emit_async("battle_start")
     b.hp -= 20
-    BUS.emit("action_used", a, b, 20)
+    await BUS.emit_async("action_used", a, b, 20)
     assert b.hp == 100 - 20 - int(20 * 0.15)
     b.hp -= 20
-    BUS.emit("action_used", a, b, 20)
+    await BUS.emit_async("action_used", a, b, 20)
     assert b.hp == 100 - 20 - int(20 * 0.15) - 20

--- a/backend/tests/test_relic_effects_advanced.py
+++ b/backend/tests/test_relic_effects_advanced.py
@@ -33,7 +33,7 @@ async def test_frost_sigil_applies_chill(monkeypatch):
     a.set_base_stat('atk', 100)
     party.members.append(a)
     award_relic(party, "frost_sigil")
-    apply_relics(party)
+    await apply_relics(party)
 
     monkeypatch.setattr(Aftertaste, "rolls", lambda self: [self.base_pot] * self.hits)
 
@@ -43,7 +43,7 @@ async def test_frost_sigil_applies_chill(monkeypatch):
 
     monkeypatch.setattr(Stats, "apply_damage", fake_apply_damage, raising=False)
 
-    BUS.emit("hit_landed", a, b, 10)
+    await BUS.emit_async("hit_landed", a, b, 10)
     await asyncio.sleep(0)
 
     assert b.hp == 100 - int(100 * 0.05)
@@ -60,7 +60,7 @@ async def test_frost_sigil_stacks(monkeypatch):
     party.members.append(a)
     award_relic(party, "frost_sigil")
     award_relic(party, "frost_sigil")
-    apply_relics(party)
+    await apply_relics(party)
 
     monkeypatch.setattr(Aftertaste, "rolls", lambda self: [self.base_pot] * self.hits)
 
@@ -70,7 +70,7 @@ async def test_frost_sigil_stacks(monkeypatch):
 
     monkeypatch.setattr(Stats, "apply_damage", fake_apply_damage, raising=False)
 
-    BUS.emit("hit_landed", a, b, 10)
+    await BUS.emit_async("hit_landed", a, b, 10)
     await asyncio.sleep(0)
 
     assert b.hp == 100 - int(100 * 0.05) * 2
@@ -85,7 +85,7 @@ async def test_killer_instinct_grants_extra_turn():
     b.hp = 10
     party.members.append(a)
     award_relic(party, "killer_instinct")
-    apply_relics(party)
+    await apply_relics(party)
     base = a.atk
     a.add_ultimate_charge(15)
     await a.use_ultimate()
@@ -93,13 +93,14 @@ async def test_killer_instinct_grants_extra_turn():
     turns: list[PlayerBase] = []
     BUS.subscribe("extra_turn", lambda m: turns.append(m))
     b.hp = 0
-    BUS.emit("damage_taken", b, a, 10)
-    BUS.emit("turn_end")
+    await BUS.emit_async("damage_taken", b, a, 10)
+    await BUS.emit_async("turn_end")
     assert turns == [a]
     assert a.atk == base
 
 
-def test_travelers_charm_buff():
+@pytest.mark.asyncio
+async def test_travelers_charm_buff():
     event_bus_module.bus._subs.clear()
     party = Party()
     a = PlayerBase()
@@ -108,47 +109,50 @@ def test_travelers_charm_buff():
     a.set_base_stat('mitigation', 100)
     party.members.append(a)
     award_relic(party, "travelers_charm")
-    apply_relics(party)
-    BUS.emit("damage_taken", a, attacker, 10)
-    BUS.emit("turn_start")
+    await apply_relics(party)
+    await BUS.emit_async("damage_taken", a, attacker, 10)
+    await BUS.emit_async("turn_start")
     assert a.defense == 100 + int(100 * 0.25)
     assert a.mitigation == 110
-    BUS.emit("turn_end")
+    await BUS.emit_async("turn_end")
     assert a.defense == 100
     assert a.mitigation == 100
 
 
-def test_timekeepers_hourglass_extra_turn():
+@pytest.mark.asyncio
+async def test_timekeepers_hourglass_extra_turn():
     event_bus_module.bus._subs.clear()
     party = Party()
     a = PlayerBase()
     party.members.append(a)
     award_relic(party, "timekeepers_hourglass")
-    apply_relics(party)
+    await apply_relics(party)
     turns: list[PlayerBase] = []
     BUS.subscribe("extra_turn", lambda m: turns.append(m))
     orig = random.random
     random.random = lambda: 0.0
-    BUS.emit("turn_start")
+    await BUS.emit_async("turn_start")
     random.random = orig
     assert turns == [a]
 
 
-def test_greed_engine_drains_and_rewards():
+@pytest.mark.asyncio
+async def test_greed_engine_drains_and_rewards():
     event_bus_module.bus._subs.clear()
     party = Party()
     a = PlayerBase()
     a.hp = a.set_base_stat('max_hp', 200)
     party.members.append(a)
     award_relic(party, "greed_engine")
-    apply_relics(party)
-    BUS.emit("turn_start")
+    await apply_relics(party)
+    await BUS.emit_async("turn_start")
     assert a.hp == 200 - int(200 * 0.01)
-    BUS.emit("gold_earned", 100)
+    await BUS.emit_async("gold_earned", 100)
     assert party.gold == int(100 * 0.5)
 
 
-def test_greed_engine_stacks():
+@pytest.mark.asyncio
+async def test_greed_engine_stacks():
     event_bus_module.bus._subs.clear()
     party = Party()
     a = PlayerBase()
@@ -156,28 +160,30 @@ def test_greed_engine_stacks():
     party.members.append(a)
     award_relic(party, "greed_engine")
     award_relic(party, "greed_engine")
-    apply_relics(party)
-    BUS.emit("turn_start")
+    await apply_relics(party)
+    await BUS.emit_async("turn_start")
     assert a.hp == 200 - int(200 * (0.01 + 0.005))
-    BUS.emit("gold_earned", 100)
+    await BUS.emit_async("gold_earned", 100)
     assert party.gold == int(100 * (0.5 + 0.25))
 
 
-def test_stellar_compass_crit_bonus():
+@pytest.mark.asyncio
+async def test_stellar_compass_crit_bonus():
     event_bus_module.bus._subs.clear()
     party = Party()
     a = PlayerBase()
     a.set_base_stat('atk', 100)
     party.members.append(a)
     award_relic(party, "stellar_compass")
-    apply_relics(party)
-    BUS.emit("critical_hit", a, None, 0, "attack")
+    await apply_relics(party)
+    await BUS.emit_async("critical_hit", a, None, 0, "attack")
     assert a.atk == int(100 * (1 + 0.015))
-    BUS.emit("gold_earned", 100)
+    await BUS.emit_async("gold_earned", 100)
     assert party.gold == int(100 * 0.015)
 
 
-def test_stellar_compass_stacks():
+@pytest.mark.asyncio
+async def test_stellar_compass_stacks():
     event_bus_module.bus._subs.clear()
     party = Party()
     a = PlayerBase()
@@ -185,34 +191,36 @@ def test_stellar_compass_stacks():
     party.members.append(a)
     award_relic(party, "stellar_compass")
     award_relic(party, "stellar_compass")
-    apply_relics(party)
-    BUS.emit("critical_hit", a, None, 0, "attack")
+    await apply_relics(party)
+    await BUS.emit_async("critical_hit", a, None, 0, "attack")
     assert a.atk == int(100 * (1 + 0.015 * 2))
-    BUS.emit("gold_earned", 100)
+    await BUS.emit_async("gold_earned", 100)
     assert party.gold == int(100 * 0.03)
 
 
-def test_stellar_compass_multiple_crits():
+@pytest.mark.asyncio
+async def test_stellar_compass_multiple_crits():
     event_bus_module.bus._subs.clear()
     party = Party()
     a = PlayerBase()
     a.set_base_stat('atk', 100)
     party.members.append(a)
     award_relic(party, "stellar_compass")
-    apply_relics(party)
+    await apply_relics(party)
 
-    BUS.emit("critical_hit", a, None, 0, "attack")
-    BUS.emit("gold_earned", 100)
+    await BUS.emit_async("critical_hit", a, None, 0, "attack")
+    await BUS.emit_async("gold_earned", 100)
     assert a.atk == int(100 * (1 + 0.015))
     assert party.gold == int(100 * 0.015)
 
-    BUS.emit("critical_hit", a, None, 0, "attack")
-    BUS.emit("gold_earned", 100)
+    await BUS.emit_async("critical_hit", a, None, 0, "attack")
+    await BUS.emit_async("gold_earned", 100)
     assert a.atk == int(100 * (1 + 0.015 * 2))
     assert party.gold == int(100 * 0.015) + int(100 * 0.03)
 
 
-def test_echoing_drum_repeats_attack():
+@pytest.mark.asyncio
+async def test_echoing_drum_repeats_attack():
     event_bus_module.bus._subs.clear()
     party = Party()
     a = PlayerBase()
@@ -220,17 +228,18 @@ def test_echoing_drum_repeats_attack():
     b.hp = 100
     party.members.append(a)
     award_relic(party, "echoing_drum")
-    apply_relics(party)
-    BUS.emit("battle_start")
+    await apply_relics(party)
+    await BUS.emit_async("battle_start")
     b.hp -= 20
-    BUS.emit("attack_used", a, b, 20)
+    await BUS.emit_async("attack_used", a, b, 20)
     assert b.hp == 100 - 20 - int(20 * 0.25)
     b.hp -= 20
-    BUS.emit("attack_used", a, b, 20)
+    await BUS.emit_async("attack_used", a, b, 20)
     assert b.hp == 100 - 20 - int(20 * 0.25) - 20
 
 
-def test_echoing_drum_stacks():
+@pytest.mark.asyncio
+async def test_echoing_drum_stacks():
     event_bus_module.bus._subs.clear()
     party = Party()
     a = PlayerBase()
@@ -239,8 +248,8 @@ def test_echoing_drum_stacks():
     party.members.append(a)
     award_relic(party, "echoing_drum")
     award_relic(party, "echoing_drum")
-    apply_relics(party)
-    BUS.emit("battle_start")
+    await apply_relics(party)
+    await BUS.emit_async("battle_start")
     b.hp -= 20
-    BUS.emit("attack_used", a, b, 20)
+    await BUS.emit_async("attack_used", a, b, 20)
     assert b.hp == 100 - 20 - int(20 * 0.25) * 2

--- a/backend/tests/test_run_persistence.py
+++ b/backend/tests/test_run_persistence.py
@@ -165,6 +165,7 @@ def test_get_map_endpoint_after_restart():
         enc.FERNET = None
 
         # Test the get_map endpoint
+        @pytest.mark.asyncio
         async def test_endpoint():
             response_json = await get_map(run_id)
             assert "map" in response_json
@@ -240,6 +241,7 @@ def test_enhanced_map_endpoint_current_state():
             )
 
         # Test the enhanced endpoint
+        @pytest.mark.asyncio
         async def test_enhanced_endpoint():
             response_json = await get_map(run_id)
 
@@ -330,6 +332,7 @@ def test_enhanced_map_endpoint_with_awaiting_next():
             )
 
         # Test the enhanced endpoint with awaiting_next
+        @pytest.mark.asyncio
         async def test_awaiting_next():
             response_json = await get_map(run_id)
             current_state = response_json["current_state"]
@@ -381,6 +384,7 @@ def test_run_not_found():
         get_save_manager()
 
         # Test with non-existent run
+        @pytest.mark.asyncio
         async def test_endpoint():
             with pytest.raises(ValueError):
                 await get_map('nonexistent-run')

--- a/backend/tests/test_runs_lifecycle.py
+++ b/backend/tests/test_runs_lifecycle.py
@@ -1,9 +1,11 @@
+import pytest
 import asyncio
 
 from runs.lifecycle import cleanup_battle_state
 from runs.lifecycle import get_battle_state_sizes
 
 
+@pytest.mark.asyncio
 async def test_get_battle_state_sizes():
     sizes = get_battle_state_sizes()
     assert set(sizes.keys()) == {"tasks", "snapshots", "locks"}

--- a/backend/tests/test_spiked_shield.py
+++ b/backend/tests/test_spiked_shield.py
@@ -31,7 +31,7 @@ def test_spiked_shield_retaliates_damage(monkeypatch):
 
     monkeypatch.setattr(Stats, "apply_damage", fake_apply_damage, raising=False)
 
-    BUS.emit("mitigation_triggered", defender, 100, 50, attacker)
+    await BUS.emit_async("mitigation_triggered", defender, 100, 50, attacker)
     loop.run_until_complete(asyncio.sleep(0))
 
     assert attacker.hp == 1000 - int(defender.atk * 0.03)

--- a/backend/tests/test_steel_bangles.py
+++ b/backend/tests/test_steel_bangles.py
@@ -30,7 +30,7 @@ async def test_steel_bangles_applies_attack_debuff(monkeypatch) -> None:
 
     # Force damage reduction to trigger (100% chance)
     monkeypatch.setattr(steel_bangles_module.random, "random", lambda: 0.0)
-    BUS.emit("damage_dealt", defender, attacker, 100, "attack", None, None, "attack")
+    await BUS.emit_async("damage_dealt", defender, attacker, 100, "attack", None, None, "attack")
     await asyncio.sleep(0.1)
 
     # Check that attacker now has reduced attack
@@ -47,4 +47,3 @@ async def test_steel_bangles_applies_attack_debuff(monkeypatch) -> None:
     modifier = attacker.effect_manager.mods[0]
     assert modifier.turns == 1
     assert modifier.name == "steel_bangles_attack_debuff"
-

--- a/backend/tests/test_summons_system.py
+++ b/backend/tests/test_summons_system.py
@@ -146,7 +146,7 @@ async def test_summon_battle_lifecycle(monkeypatch):
         assert len(SummonManager.get_summons("test_summoner")) == 1
 
         # Emit battle end - temporary summons should be cleaned up
-        BUS.emit("battle_end", FoeBase())
+        await BUS.emit_async("battle_end", FoeBase())
 
         # Should be removed
         assert len(SummonManager.get_summons("test_summoner")) == 0
@@ -178,12 +178,12 @@ async def test_summon_turn_expiration(monkeypatch):
         assert len(SummonManager.get_summons("test_summoner")) == 1
 
         # First turn
-        BUS.emit("turn_start", summoner)
+        await BUS.emit_async("turn_start", summoner)
         assert len(SummonManager.get_summons("test_summoner")) == 1
         assert summon.turns_remaining == 1
 
         # Second turn - should expire
-        BUS.emit("turn_start", summoner)
+        await BUS.emit_async("turn_start", summoner)
         assert len(SummonManager.get_summons("test_summoner")) == 0
     finally:
         BUS.set_async_preference(True)

--- a/backend/tests/test_wind_ultimate_dot_transfer.py
+++ b/backend/tests/test_wind_ultimate_dot_transfer.py
@@ -48,23 +48,23 @@ async def test_wind_ultimate_transfers_from_foes():
 
     player.use_ultimate = _use_ultimate.__get__(player, Stats)
 
-    BUS.emit("battle_start", player)
-    BUS.emit("battle_start", foe1)
-    BUS.emit("battle_start", foe2)
+    await BUS.emit_async("battle_start", player)
+    await BUS.emit_async("battle_start", foe1)
+    await BUS.emit_async("battle_start", foe2)
 
     player.add_ultimate_charge(15)
     assert await player.use_ultimate()
 
-    BUS.emit("hit_landed", player, foe1, 0, "attack")
+    await BUS.emit_async("hit_landed", player, foe1, 0, "attack")
     await asyncio.sleep(0.01)
 
     assert foe2.effect_manager.dots == []
     assert foe2.dots == []
     assert foe1.hp == 99
 
-    BUS.emit("battle_end", player)
-    BUS.emit("battle_end", foe1)
-    BUS.emit("battle_end", foe2)
+    await BUS.emit_async("battle_end", player)
+    await BUS.emit_async("battle_end", foe1)
+    await BUS.emit_async("battle_end", foe2)
 
 
 @pytest.mark.asyncio
@@ -97,20 +97,20 @@ async def test_wind_foe_ultimate_transfers_from_allies():
 
     foe.use_ultimate = _use_ultimate.__get__(foe, Stats)
 
-    BUS.emit("battle_start", foe)
-    BUS.emit("battle_start", p1)
-    BUS.emit("battle_start", p2)
+    await BUS.emit_async("battle_start", foe)
+    await BUS.emit_async("battle_start", p1)
+    await BUS.emit_async("battle_start", p2)
 
     foe.add_ultimate_charge(15)
     assert await foe.use_ultimate()
 
-    BUS.emit("hit_landed", foe, p1, 0, "attack")
+    await BUS.emit_async("hit_landed", foe, p1, 0, "attack")
     await asyncio.sleep(0.01)
 
     assert p2.effect_manager.dots == []
     assert p2.dots == []
     assert p1.hp == 99
 
-    BUS.emit("battle_end", foe)
-    BUS.emit("battle_end", p1)
-    BUS.emit("battle_end", p2)
+    await BUS.emit_async("battle_end", foe)
+    await BUS.emit_async("battle_end", p1)
+    await BUS.emit_async("battle_end", p2)


### PR DESCRIPTION
## Summary
- convert card and relic plugins to await BUS.emit_async and adopt async handlers
- update relic application utilities and battle setup to await async relic setup
- adjust tests and routes to drive the async event bus APIs

## Testing
- uv run pytest tests/test_relic_awards.py -k stack *(fails: ModuleNotFoundError: No module named 'llms')*

------
https://chatgpt.com/codex/tasks/task_b_68caa0dfd224832c936596d1d10be086