### PR TITLE
refactor: remove sync event bus emit and update tests

### DIFF
--- a/backend/tests/test_100_fallback_effects_stress.py
+++ b/backend/tests/test_100_fallback_effects_stress.py
@@ -14,7 +14,8 @@ from autofighter.stats import Stats
 class TestEventBusStressWithFallbackEffects:
     """Stress test simulating 100 fallback effects during combat."""
 
-    def test_100_fallback_effects_sync_performance(self):
+    @pytest.mark.asyncio
+    async def test_100_fallback_effects_sync_performance(self):
         """Test current sync performance with 100 fallback effects subscribed to damage events."""
         # Simulate 100 entities with fallback effects (like Aftertaste)
         fallback_count = 100
@@ -175,7 +176,8 @@ class TestEventBusStressWithFallbackEffects:
             for handler in async_handlers:
                 BUS.unsubscribe("damage_dealt", handler)
 
-    def test_event_bus_batching_performance(self):
+    @pytest.mark.asyncio
+    async def test_event_bus_batching_performance(self):
         """Test the new batching functionality for high-frequency events."""
         fallback_count = 50  # Smaller number for batching test
         batched_events = []
@@ -219,7 +221,8 @@ class TestEventBusStressWithFallbackEffects:
             for handler in handlers:
                 BUS.unsubscribe("damage_dealt", handler)
 
-    def test_performance_metrics_collection(self):
+    @pytest.mark.asyncio
+    async def test_performance_metrics_collection(self):
         """Test that performance metrics are being collected properly."""
         print("\n=== Performance Metrics Test ===")
 

--- a/backend/tests/test_arc_lightning.py
+++ b/backend/tests/test_arc_lightning.py
@@ -1,14 +1,40 @@
 import asyncio
+import sys
+import types
 from unittest.mock import patch
 
 import pytest
 
 from autofighter.party import Party
 from autofighter.stats import BUS
+from autofighter.stats import set_battle_active
 from plugins.cards.arc_lightning import ArcLightning
 import plugins.event_bus as event_bus_module
 from plugins.foes._base import FoeBase
 from plugins.players._base import PlayerBase
+
+
+@pytest.fixture(autouse=True)
+def disable_llms(monkeypatch):
+    stub = types.ModuleType("llms")
+    torch_checker = types.ModuleType("llms.torch_checker")
+    torch_checker.is_torch_available = lambda: False
+    stub.torch_checker = torch_checker
+    original_llms = sys.modules.get("llms")
+    original_checker = sys.modules.get("llms.torch_checker")
+    monkeypatch.setitem(sys.modules, "llms", stub)
+    monkeypatch.setitem(sys.modules, "llms.torch_checker", torch_checker)
+    try:
+        yield
+    finally:
+        if original_llms is not None:
+            monkeypatch.setitem(sys.modules, "llms", original_llms)
+        else:
+            monkeypatch.delitem(sys.modules, "llms", raising=False)
+        if original_checker is not None:
+            monkeypatch.setitem(sys.modules, "llms.torch_checker", original_checker)
+        else:
+            monkeypatch.delitem(sys.modules, "llms.torch_checker", raising=False)
 
 
 @pytest.mark.asyncio
@@ -20,11 +46,15 @@ async def test_arc_lightning_chains_damage() -> None:
     party = Party([attacker])
     card = ArcLightning()
     await card.apply(party)
-    await BUS.emit_async("battle_start", foe1)
-    await BUS.emit_async("battle_start", foe2)
-    await BUS.emit_async("battle_start", attacker)
-    initial = foe2.hp
-    with patch("plugins.cards.arc_lightning.random.choice", return_value=foe2):
-        await BUS.emit_async("hit_landed", attacker, foe1, 100, "attack")
-        await asyncio.sleep(0)
-    assert foe2.hp < initial
+    set_battle_active(True)
+    try:
+        await BUS.emit_async("battle_start", foe1)
+        await BUS.emit_async("battle_start", foe2)
+        await BUS.emit_async("battle_start", attacker)
+        initial = foe2.hp
+        with patch("plugins.cards.arc_lightning.random.choice", return_value=foe2):
+            await BUS.emit_async("hit_landed", attacker, foe1, 100, "attack")
+            await asyncio.sleep(0.05)
+        assert foe2.hp < initial
+    finally:
+        set_battle_active(False)

--- a/backend/tests/test_async_dot_optimizations.py
+++ b/backend/tests/test_async_dot_optimizations.py
@@ -5,6 +5,8 @@ Test to verify async optimization improvements for DOT effects.
 
 import pytest
 
+import autofighter.stats as stats
+
 from autofighter.effects import DamageOverTime
 from autofighter.effects import EffectManager
 from autofighter.effects import HealingOverTime
@@ -171,3 +173,10 @@ async def test_living_characters_can_still_receive_effects():
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])
+
+
+@pytest.fixture(autouse=True)
+def battle_active():
+    stats.set_battle_active(True)
+    yield
+    stats.set_battle_active(False)

--- a/backend/tests/test_cost_damage.py
+++ b/backend/tests/test_cost_damage.py
@@ -8,7 +8,6 @@ from plugins.event_bus import EventBus
 @pytest.fixture
 def bus(monkeypatch):
     bus = EventBus()
-    bus._prefer_async = False
     monkeypatch.setattr(stats, "BUS", bus)
     return bus
 

--- a/backend/tests/test_event_bus.py
+++ b/backend/tests/test_event_bus.py
@@ -2,8 +2,84 @@ import asyncio
 import importlib.util
 import logging
 from pathlib import Path
+import sys
+import types
+
+import pytest
+
+if "battle_logging" not in sys.modules:
+    _battle_logging = types.ModuleType("battle_logging")
+    _battle_logging.writers = types.ModuleType("battle_logging.writers")
+
+    class _StubBattleLogger:
+        def __init__(self, *args, **kwargs):
+            return None
+
+        async def log(self, *args, **kwargs) -> None:
+            return None
+
+    _battle_logging.writers.BattleLogger = _StubBattleLogger
+    async def _noop_async(*args, **kwargs):
+        return None
+
+    _battle_logging.writers.BattleLogger = _StubBattleLogger
+    _battle_logging.writers.end_battle_logging = lambda *args, **kwargs: None
+    _battle_logging.writers.start_battle_logging = _noop_async
+    _battle_logging.writers.end_run_logging = _noop_async
+    sys.modules["battle_logging"] = _battle_logging
+    sys.modules["battle_logging.writers"] = _battle_logging.writers
+
+if "services.user_level_service" not in sys.modules:
+    services_module = types.ModuleType("services")
+    user_level_service = types.ModuleType("services.user_level_service")
+    user_level_service.gain_user_exp = lambda *args, **kwargs: None
+    user_level_service.get_user_level = lambda *args, **kwargs: 1
+    services_module.user_level_service = user_level_service
+    sys.modules["services"] = services_module
+    sys.modules["services.user_level_service"] = user_level_service
+
+    if "services.room_service" not in sys.modules:
+        room_service = types.ModuleType("services.room_service")
+        room_service.get_room = lambda *args, **kwargs: None
+        services_module.room_service = room_service
+        sys.modules["services.room_service"] = room_service
+
+if "options" not in sys.modules:
+    _options = types.ModuleType("options")
+    class OptionKey:
+        pass
+
+    def get_option(key, default=None):
+        return default
+
+    _options.OptionKey = OptionKey
+    _options.get_option = get_option
+    sys.modules["options"] = _options
+
+if "llms.loader" not in sys.modules:
+    llms_module = types.ModuleType("llms")
+    loader_module = types.ModuleType("llms.loader")
+    loader_module.ModelName = type("ModelName", (), {})
+    loader_module.load_llm = lambda *args, **kwargs: None
+    loader_module._IMPORT_ERROR = None
+    torch_checker_module = types.ModuleType("llms.torch_checker")
+    torch_checker_module.is_torch_available = lambda: False
+    llms_module.loader = loader_module
+    llms_module.torch_checker = torch_checker_module
+    sys.modules["llms"] = llms_module
+    sys.modules["llms.loader"] = loader_module
+    sys.modules["llms.torch_checker"] = torch_checker_module
+
+if "tts" not in sys.modules:
+    tts_module = types.ModuleType("tts")
+    async def _generate_voice(*args, **kwargs):
+        return None
+
+    tts_module.generate_voice = _generate_voice
+    sys.modules["tts"] = tts_module
 
 from autofighter.rooms.battle.pacing import YIELD_DELAY
+
 
 spec = importlib.util.spec_from_file_location(
     "event_bus", Path(__file__).resolve().parents[1] / "plugins" / "event_bus.py"
@@ -14,61 +90,85 @@ spec.loader.exec_module(event_bus_module)
 EventBus = event_bus_module.EventBus
 
 
-def test_event_bus_emit_and_unsubscribe():
+@pytest.mark.asyncio
+async def test_event_bus_emit_async_and_unsubscribe():
     bus = EventBus()
-    received = []
+    received: list[tuple[str, int]] = []
 
-    def handler(value):
-        received.append(value)
+    async def async_handler(value: int) -> None:
+        received.append(("async", value))
 
-    bus.subscribe("test", handler)
-    bus.emit("test", 1)
-    assert received == [1]
-    bus.unsubscribe("test", handler)
-    bus.emit("test", 2)
-    assert received == [1]
+    def sync_handler(value: int) -> None:
+        received.append(("sync", value))
+
+    bus.subscribe("test", async_handler)
+    bus.subscribe("test", sync_handler)
+
+    await bus.emit_async("test", 1)
+
+    assert {tuple(event) for event in received} == {("async", 1), ("sync", 1)}
+
+    bus.unsubscribe("test", async_handler)
+    bus.unsubscribe("test", sync_handler)
+    received.clear()
+
+    await bus.emit_async("test", 2)
+
+    assert received == []
 
 
-def test_emit_batched_within_subscriber():
+@pytest.mark.asyncio
+async def test_emit_batched_within_subscriber():
     bus = EventBus()
-    received = []
+    received: list[int] = []
+    inner_seen = asyncio.Event()
 
-    def inner_handler(value):
+    async def inner_handler(value: int) -> None:
         received.append(value)
+        inner_seen.set()
 
-    def outer_handler(value):
+    def outer_handler(value: int) -> None:
         bus.emit_batched("inner", value + 1)
 
     bus.subscribe("inner", inner_handler)
     bus.subscribe("outer", outer_handler)
 
-    bus.emit_batched("outer", 1)
+    await bus.emit_async("outer", 1)
+    await asyncio.wait_for(inner_seen.wait(), timeout=1)
+
     assert received == [2]
 
     bus.unsubscribe("inner", inner_handler)
     bus.unsubscribe("outer", outer_handler)
 
 
-def test_dynamic_batch_interval_thresholds():
+@pytest.mark.asyncio
+async def test_dynamic_batch_interval_thresholds():
     async def run_scenario(existing: int) -> float:
         bus = EventBus()
         internal = event_bus_module.bus
-        intervals = []
+        intervals: list[float] = []
 
         async def capture(interval: float) -> None:
             intervals.append(interval)
 
-        internal._process_batches_with_interval = capture  # type: ignore[assignment]
-        internal._batched_events["test"] = [()] * existing
-        bus.emit_batched("test", ())
-        await asyncio.sleep(0)
-        internal._batch_timer = None
+        original = internal._process_batches_with_interval
+        try:
+            internal._process_batches_with_interval = capture  # type: ignore[assignment]
+            internal._batched_events["test"] = [()] * existing
+            bus.emit_batched("test", ())
+            await asyncio.sleep(0)
+            internal._batch_timer = None
+        finally:
+            internal._process_batches_with_interval = original
+            internal._batched_events.clear()
+
         return intervals[0]
 
-    interval_51 = asyncio.run(run_scenario(50))
+    interval_51 = await run_scenario(50)
     assert interval_51 == max(0.005, 0.016 * 0.5)
 
-    interval_101 = asyncio.run(run_scenario(100))
+    interval_101 = await run_scenario(100)
     assert interval_101 == YIELD_DELAY
 
 
@@ -82,53 +182,39 @@ def test_emit_batched_without_loop_logs_debug(caplog):
     assert all("RuntimeError" not in msg for msg in messages)
 
 
-def test_async_callback_without_loop_avoids_runtime_error(caplog):
-    bus = EventBus()
-
-    async def handler(value):
-        pass
-
-    bus.subscribe("test", handler)
-
-    with caplog.at_level(logging.WARNING, logger=event_bus_module.__name__):
-        bus.emit("test", 1)
-
-    messages = [record.getMessage() for record in caplog.records]
-    assert any("called from sync context with no event loop" in msg for msg in messages)
-    assert all("RuntimeError" not in msg for msg in messages)
-
-
-def test_emit_async_triggers_nested_batched_event_on_loop():
+@pytest.mark.asyncio
+async def test_emit_async_triggers_nested_batched_event_on_loop():
     bus = EventBus()
     internal = event_bus_module.bus
-    # Restore the batch processing coroutine in case other tests monkeypatched it.
-    internal._process_batches_with_interval = event_bus_module._Bus._process_batches_with_interval.__get__(internal, event_bus_module._Bus)
-    internal._process_batches = event_bus_module._Bus._process_batches.__get__(internal, event_bus_module._Bus)
-    internal._process_batches_internal = event_bus_module._Bus._process_batches_internal.__get__(internal, event_bus_module._Bus)
+    internal._process_batches_with_interval = event_bus_module._Bus._process_batches_with_interval.__get__(
+        internal, event_bus_module._Bus
+    )
+    internal._process_batches = event_bus_module._Bus._process_batches.__get__(
+        internal, event_bus_module._Bus
+    )
+    internal._process_batches_internal = event_bus_module._Bus._process_batches_internal.__get__(
+        internal, event_bus_module._Bus
+    )
     internal._batched_events.clear()
     internal._batch_timer = None
 
-    async def runner() -> None:
-        loop = asyncio.get_running_loop()
-        outer_complete = asyncio.Event()
-        inner_seen = asyncio.Event()
+    outer_complete = asyncio.Event()
+    inner_seen = asyncio.Event()
 
-        async def inner_handler(value):
-            inner_seen.set()
+    async def inner_handler(value: int) -> None:
+        inner_seen.set()
 
-        def outer_handler(value):
-            bus.emit_batched("inner", value + 1)
-            loop.call_soon_threadsafe(outer_complete.set)
+    def outer_handler(value: int) -> None:
+        bus.emit_batched("inner", value + 1)
+        outer_complete.set()
 
-        bus.subscribe("inner", inner_handler)
-        bus.subscribe("outer", outer_handler)
+    bus.subscribe("inner", inner_handler)
+    bus.subscribe("outer", outer_handler)
 
-        await bus.emit_async("outer", 1)
+    await bus.emit_async("outer", 1)
 
-        await asyncio.wait_for(outer_complete.wait(), timeout=1)
-        await asyncio.wait_for(inner_seen.wait(), timeout=1)
+    await asyncio.wait_for(outer_complete.wait(), timeout=1)
+    await asyncio.wait_for(inner_seen.wait(), timeout=1)
 
-        bus.unsubscribe("inner", inner_handler)
-        bus.unsubscribe("outer", outer_handler)
-
-    asyncio.run(runner())
+    bus.unsubscribe("inner", inner_handler)
+    bus.unsubscribe("outer", outer_handler)

--- a/backend/tests/test_summons_system.py
+++ b/backend/tests/test_summons_system.py
@@ -126,32 +126,28 @@ async def test_summon_battle_lifecycle(monkeypatch):
     monkeypatch.setattr(torch_checker, "is_torch_available", lambda: False)
 
     SummonManager.cleanup()
-    BUS.set_async_preference(False)
 
-    try:
-        summoner = Ally()
-        summoner.id = "test_summoner"
-        summoner.ensure_permanent_summon_slots(1)
+    summoner = Ally()
+    summoner.id = "test_summoner"
+    summoner.ensure_permanent_summon_slots(1)
 
-        # Create temporary summon
-        summon = SummonManager.create_summon(
-            summoner=summoner,
-            summon_type="temporary",
-            source="test_source",
-            turns_remaining=1
-        )
-        assert summon is not None
+    # Create temporary summon
+    summon = SummonManager.create_summon(
+        summoner=summoner,
+        summon_type="temporary",
+        source="test_source",
+        turns_remaining=1
+    )
+    assert summon is not None
 
-        # Should be tracked
-        assert len(SummonManager.get_summons("test_summoner")) == 1
+    # Should be tracked
+    assert len(SummonManager.get_summons("test_summoner")) == 1
 
-        # Emit battle end - temporary summons should be cleaned up
-        await BUS.emit_async("battle_end", FoeBase())
+    # Emit battle end - temporary summons should be cleaned up
+    await BUS.emit_async("battle_end", FoeBase())
 
-        # Should be removed
-        assert len(SummonManager.get_summons("test_summoner")) == 0
-    finally:
-        BUS.set_async_preference(True)
+    # Should be removed
+    assert len(SummonManager.get_summons("test_summoner")) == 0
 
 
 @pytest.mark.asyncio
@@ -160,33 +156,29 @@ async def test_summon_turn_expiration(monkeypatch):
     monkeypatch.setattr(torch_checker, "is_torch_available", lambda: False)
 
     SummonManager.cleanup()
-    BUS.set_async_preference(False)
 
-    try:
-        summoner = Ally()
-        summoner.id = "test_summoner"
-        summoner.ensure_permanent_summon_slots(1)
+    summoner = Ally()
+    summoner.id = "test_summoner"
+    summoner.ensure_permanent_summon_slots(1)
 
-        # Create summon with 2 turn duration
-        summon = SummonManager.create_summon(
-            summoner=summoner,
-            summon_type="timed",
-            source="test_source",
-            turns_remaining=2
-        )
+    # Create summon with 2 turn duration
+    summon = SummonManager.create_summon(
+        summoner=summoner,
+        summon_type="timed",
+        source="test_source",
+        turns_remaining=2
+    )
 
-        assert len(SummonManager.get_summons("test_summoner")) == 1
+    assert len(SummonManager.get_summons("test_summoner")) == 1
 
-        # First turn
-        await BUS.emit_async("turn_start", summoner)
-        assert len(SummonManager.get_summons("test_summoner")) == 1
-        assert summon.turns_remaining == 1
+    # First turn
+    await BUS.emit_async("turn_start", summoner)
+    assert len(SummonManager.get_summons("test_summoner")) == 1
+    assert summon.turns_remaining == 1
 
-        # Second turn - should expire
-        await BUS.emit_async("turn_start", summoner)
-        assert len(SummonManager.get_summons("test_summoner")) == 0
-    finally:
-        BUS.set_async_preference(True)
+    # Second turn - should expire
+    await BUS.emit_async("turn_start", summoner)
+    assert len(SummonManager.get_summons("test_summoner")) == 0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- drop the synchronous EventBus.emit implementation so only async pathways remain
- update event bus related tests to use the async interface and stub missing modules for isolation
- refresh dependent tests (relic, summons, stress, etc.) to await BUS.emit_async, provide fixtures, and flush async work

## Testing
- uv run pytest tests/test_event_bus.py
- uv run pytest tests/test_rusty_buckle.py
- uv run pytest tests/test_cost_damage.py
- uv run pytest tests/test_effect_resisted_cards.py
- uv run pytest tests/test_summons_system.py
- uv run pytest tests/test_100_fallback_effects_stress.py
- uv run pytest tests/test_async_dot_optimizations.py
- uv run pytest tests/test_arc_lightning.py

------
https://chatgpt.com/codex/tasks/task_b_68caa983ab4c832ca9440db5c4cf3f14