### PR TITLE
Add per-run shop tax persistence and coverage

### DIFF
--- a/backend/services/room_service.py
+++ b/backend/services/room_service.py
@@ -226,11 +226,14 @@ async def shop_room(run_id: str, data: dict[str, Any]) -> dict[str, Any]:
     node_stock = stock_state.get(str(node.room_id))
     if node_stock is not None:
         setattr(node, "stock", node_stock)
+    items_bought = int(state.get("shop_items_bought", 0))
+    setattr(node, "items_bought", items_bought)
     room = ShopRoom(node)
     party = await asyncio.to_thread(load_party, run_id)
     result = await room.resolve(party, data)
     stock_state[str(node.room_id)] = getattr(node, "stock", [])
     state["shop_stock"] = stock_state
+    state["shop_items_bought"] = int(getattr(node, "items_bought", items_bought))
     action = data.get("action", "")
     next_type = None
     if action == "leave":


### PR DESCRIPTION
## Summary
- persist the per-run shop purchase counter in saved map state and expose it to ShopRoom
- update shop stock pricing to track base prices, apply pressure-based tax, and include surcharge data in responses
- expand shop room tests to cover tax scaling, persistence, and room-service driven flows

## Testing
- PYTHONPATH=. uv run pytest tests/test_shop_room.py

------
https://chatgpt.com/codex/tasks/task_b_68cb85a98964832cb52aeaca531fcb55