### PR TITLE
feat: surface critical hits in battle floaters

### DIFF
--- a/backend/autofighter/rooms/battle/turns.py
+++ b/backend/autofighter/rooms/battle/turns.py
@@ -246,6 +246,9 @@ def _on_damage_taken(
     target: Stats | None,
     attacker: Stats | None = None,
     amount: int | None = None,
+    pre_damage_hp: int | None = None,
+    post_damage_hp: int | None = None,
+    is_critical: bool | None = None,
     *_: Any,
 ) -> None:
     run_id = _resolve_run_id(target, attacker)
@@ -255,6 +258,11 @@ def _on_damage_taken(
     damage_type_id = _resolve_damage_type_id(attacker)
     if damage_type_id:
         metadata = {"damage_type_id": damage_type_id}
+    if is_critical is not None:
+        if metadata is None:
+            metadata = {"is_critical": bool(is_critical)}
+        else:
+            metadata = {**metadata, "is_critical": bool(is_critical)}
     _record_event(
         run_id,
         event_type="damage_taken",

--- a/backend/autofighter/stats.py
+++ b/backend/autofighter/stats.py
@@ -732,6 +732,7 @@ class Stats:
             original_amount,
             old_hp,
             post_hit_hp,
+            critical,
         )
         if attacker is not None:
             attacker.damage_dealt += original_amount
@@ -760,7 +761,15 @@ class Stats:
             except Exception as e:  # pragma: no cover - defensive
                 log.warning("Error triggering damage_taken passives: %s", e)
         post_hit_hp = self.hp
-        BUS.emit_batched("damage_taken", self, None, amount, old_hp, post_hit_hp)
+        BUS.emit_batched(
+            "damage_taken",
+            self,
+            None,
+            amount,
+            old_hp,
+            post_hit_hp,
+            False,
+        )
         return amount
 
     async def apply_healing(self, amount: int, healer: Optional["Stats"] = None, source_type: str = "heal", source_name: Optional[str] = None) -> int:
@@ -859,7 +868,10 @@ def _reset_temporary_slots_on_battle_end(*_args, **__):
 BUS.subscribe("battle_end", _reset_temporary_slots_on_battle_end)
 
 def _log_damage_taken(
-    target: "Stats", attacker: Optional["Stats"], amount: int
+    target: "Stats",
+    attacker: Optional["Stats"],
+    amount: int,
+    *_: object,
 ) -> None:
     attacker_id = getattr(attacker, "id", "unknown")
     log.info("%s takes %s from %s", target.id, amount, attacker_id)

--- a/backend/battle_logging/writers.py
+++ b/backend/battle_logging/writers.py
@@ -245,7 +245,7 @@ class BattleLogger:
                 self.summary.damage_by_action[attacker_id] = {}
             self.summary.damage_by_action[attacker_id][action_name] = self.summary.damage_by_action[attacker_id].get(action_name, 0) + amount
 
-    def _on_damage_taken(self, target, attacker, amount):
+    def _on_damage_taken(self, target, attacker, amount, *_: object) -> None:
         """Handle damage taken event."""
         attacker_id = getattr(attacker, 'id', str(attacker)) if attacker else None
         target_id = getattr(target, 'id', str(target))

--- a/backend/plugins/cards/adamantine_band.py
+++ b/backend/plugins/cards/adamantine_band.py
@@ -18,7 +18,7 @@ class AdamantineBand(CardBase):
     async def apply(self, party) -> None:  # type: ignore[override]
         await super().apply(party)
 
-        async def _on_damage_taken(target, attacker, damage):
+        async def _on_damage_taken(target, attacker, damage, *_: object):
             # Check if target is one of our party members
             if target in party.members:
                 current_hp = getattr(target, "hp", 0)

--- a/backend/plugins/cards/bulwark_totem.py
+++ b/backend/plugins/cards/bulwark_totem.py
@@ -21,7 +21,14 @@ class BulwarkTotem(CardBase):
     async def apply(self, party) -> None:  # type: ignore[override]
         await super().apply(party)
 
-        async def _on_damage_taken(target, attacker, damage, pre_damage_hp=None, post_damage_hp=None):
+        async def _on_damage_taken(
+            target,
+            attacker,
+            damage,
+            pre_damage_hp=None,
+            post_damage_hp=None,
+            *_: object,
+        ):
             if target not in party.members:
                 return
 

--- a/backend/plugins/cards/enduring_charm.py
+++ b/backend/plugins/cards/enduring_charm.py
@@ -68,7 +68,7 @@ class EnduringCharm(CardBase):
 
         BUS.subscribe("turn_start", _check_low_hp)
 
-        def _on_damage_taken(target, attacker, damage):
+        def _on_damage_taken(target, attacker, damage, *_: object):
             _check_low_hp()
 
         BUS.subscribe("damage_taken", _on_damage_taken)

--- a/backend/plugins/cards/fortified_plating.py
+++ b/backend/plugins/cards/fortified_plating.py
@@ -19,7 +19,7 @@ class FortifiedPlating(CardBase):
         # Track which members have used their first hit reduction this turn
         first_hit_used = set()
 
-        async def _on_damage_taken(target, attacker, damage):
+        async def _on_damage_taken(target, attacker, damage, *_: object):
             # Check if target is one of our party members
             if target in party.members:
                 target_id = id(target)

--- a/backend/plugins/cards/iron_resolve.py
+++ b/backend/plugins/cards/iron_resolve.py
@@ -25,7 +25,7 @@ class IronResolve(CardBase):
 
         cooldowns: dict[int, int] = {id(m): 0 for m in party.members}
 
-        async def _damage_taken(target, attacker, amount) -> None:
+        async def _damage_taken(target, attacker, amount, *_: object) -> None:
             pid = id(target)
             if target not in party.members:
                 return

--- a/backend/plugins/cards/vital_core.py
+++ b/backend/plugins/cards/vital_core.py
@@ -67,7 +67,7 @@ class VitalCore(CardBase):
 
                     loop.call_soon_threadsafe(lambda: loop.call_later(20, _remove_boost))
 
-        def _on_damage_taken(target, attacker, damage):
+        def _on_damage_taken(target, attacker, damage, *_: object):
             _check_low_hp()
 
         def _cleanup(*_: object) -> None:

--- a/backend/plugins/relics/bent_dagger.py
+++ b/backend/plugins/relics/bent_dagger.py
@@ -21,7 +21,7 @@ class BentDagger(RelicBase):
 
         stacks = party.relics.count(self.id)
 
-        async def _on_death(target, attacker, amount) -> None:
+        async def _on_death(target, attacker, amount, *_: object) -> None:
             if target in party.members or target.hp > 0:
                 return
 

--- a/backend/plugins/relics/ember_stone.py
+++ b/backend/plugins/relics/ember_stone.py
@@ -21,7 +21,7 @@ class EmberStone(RelicBase):
         stacks = party.relics.count(self.id)
 
         if state is None:
-            async def _burn(target, attacker, amount) -> None:
+            async def _burn(target, attacker, amount, *_: object) -> None:
                 if attacker is None or target not in party.members:
                     return
                 current_stacks = state.get("stacks", 0)

--- a/backend/plugins/relics/killer_instinct.py
+++ b/backend/plugins/relics/killer_instinct.py
@@ -54,7 +54,7 @@ class KillerInstinct(RelicBase):
                 user.effect_manager.add_modifier(mod)
                 buffs[id(user)] = (user, mod)
 
-            async def _damage(target, attacker, amount) -> None:
+            async def _damage(target, attacker, amount, *_: object) -> None:
                 if attacker is None:
                     return
                 if target.hp <= 0 and id(attacker) in buffs:

--- a/backend/plugins/relics/rusty_buckle.py
+++ b/backend/plugins/relics/rusty_buckle.py
@@ -67,7 +67,7 @@ class RustyBuckle(RelicBase):
 
                     safe_async_task(entity.apply_cost_damage(dmg))
 
-            async def _damage(target, attacker, _original) -> None:
+            async def _damage(target, attacker, _original, *_: object) -> None:
                 if target not in party.members:
                     return
                 current_stacks = state.get("stacks", 0)

--- a/backend/plugins/relics/shiny_pebble.py
+++ b/backend/plugins/relics/shiny_pebble.py
@@ -26,7 +26,7 @@ class ShinyPebble(RelicBase):
             state = {"active": {}, "triggered": set()}
             party._shiny_pebble_state = state
 
-            async def _first_hit(target, attacker, amount) -> None:
+            async def _first_hit(target, attacker, amount, *_: object) -> None:
                 if target not in party.members or id(target) in state["triggered"]:
                     return
                 state["triggered"].add(id(target))

--- a/backend/plugins/relics/tattered_flag.py
+++ b/backend/plugins/relics/tattered_flag.py
@@ -19,7 +19,7 @@ class TatteredFlag(RelicBase):
     async def apply(self, party) -> None:
         await super().apply(party)
 
-        async def _fallen(target, attacker, amount) -> None:
+        async def _fallen(target, attacker, amount, *_: object) -> None:
             if target not in party.members or target.hp > 0:
                 return
             survivors = [member for member in party.members if member is not target and member.hp > 0]

--- a/backend/plugins/relics/travelers_charm.py
+++ b/backend/plugins/relics/travelers_charm.py
@@ -23,7 +23,7 @@ class TravelersCharm(RelicBase):
         pending: dict[int, tuple[float, float]] = {}
         active: dict[int, tuple[PlayerBase, object]] = {}
 
-        async def _hit(target, attacker, amount) -> None:
+        async def _hit(target, attacker, amount, *_: object) -> None:
             if target not in party.members:
                 return
             pid = id(target)

--- a/backend/plugins/relics/vengeful_pendant.py
+++ b/backend/plugins/relics/vengeful_pendant.py
@@ -23,7 +23,7 @@ class VengefulPendant(RelicBase):
         state = getattr(party, "_vengeful_pendant_state", None)
 
         if state is None:
-            async def _reflect(target, attacker, amount) -> None:
+            async def _reflect(target, attacker, amount, *_: object) -> None:
                 if attacker is None or target not in party.members:
                     return
                 current_stacks = state.get("stacks", 0)

--- a/backend/tests/test_effects.py
+++ b/backend/tests/test_effects.py
@@ -45,7 +45,7 @@ async def test_damage_and_heal_events():
     bus = EventBus()
     events = []
 
-    def _dmg(target, attacker, amount):
+    def _dmg(target, attacker, amount, *_: object):
         events.append(("dmg", amount))
 
     def _heal(target, healer, amount):
@@ -69,7 +69,7 @@ async def test_hot_ticks_before_dot():
     bus = EventBus()
     events = []
 
-    def _dmg(target, attacker, amount):
+    def _dmg(target, attacker, amount, *_: object):
         events.append(("dmg", amount))
 
     def _heal(target, healer, amount):

--- a/backend/tests/test_status_phase_events.py
+++ b/backend/tests/test_status_phase_events.py
@@ -288,7 +288,7 @@ async def test_status_phase_events_update_snapshot_queue(monkeypatch):
     assert dot_effects and dot_effects[0].get("id") == "dot_1"
     assert dot_effects[0].get("type") == "dot"
 
-    record_damage_taken_event(target, target, 77)
+    record_damage_taken_event(target, target, 77, None, None, True)
     record_heal_received_event(target, target, 33)
 
     events = battle_snapshots[run_id]["recent_events"]
@@ -303,7 +303,9 @@ async def test_status_phase_events_update_snapshot_queue(monkeypatch):
     assert heal_event.get("metadata", {}).get("damage_type_id") == "Generic"
 
     damage_event = events_by_type["damage_taken"][-1]
-    assert damage_event.get("metadata", {}).get("damage_type_id") == "Generic"
+    damage_metadata = damage_event.get("metadata", {})
+    assert damage_metadata.get("damage_type_id") == "Generic"
+    assert damage_metadata.get("is_critical") is True
 
     status_phase = snapshot.get("status_phase")
     assert status_phase is not None

--- a/frontend/src/lib/components/BattleEventFloaters.svelte
+++ b/frontend/src/lib/components/BattleEventFloaters.svelte
@@ -74,6 +74,7 @@
         const anchor = (anchors && target && anchors[target]) ? anchors[target] : null;
         const x = anchor && Number.isFinite(anchor.x) ? anchor.x : 0.5;
         const y = anchor && Number.isFinite(anchor.y) ? anchor.y : 0.52;
+        const critical = Boolean(raw.isCritical || raw.metadata?.is_critical);
         floaters = [
           ...floaters,
           {
@@ -88,6 +89,7 @@
             y,
             tone: variant === 'heal' || variant === 'hot' ? 'heal' : 'damage',
             type: raw.type,
+            critical,
           }
         ];
         scheduleRemoval(id, duration);
@@ -131,6 +133,7 @@
         </span>
         <span class="amount" data-variant={entry.variant}>
           {entry.variant === 'heal' || entry.variant === 'hot' ? '+' : '-'}{Math.round(entry.amount)}
+          {entry.critical && entry.variant === 'damage' ? '!' : ''}
         </span>
         {#if entry.label}
           <span class="label">{entry.label}</span>

--- a/frontend/src/lib/components/BattleView.svelte
+++ b/frontend/src/lib/components/BattleView.svelte
@@ -242,11 +242,15 @@
       }
     }
     const amount = Number(evt.amount ?? 0);
+    const isCritical = Boolean(
+      metadata?.is_critical ?? metadata?.isCritical ?? metadata?.critical ?? evt.isCritical
+    );
     return {
       ...evt,
       amount,
       damageTypeId,
       metadata,
+      isCritical,
       effectLabel: extractEffectLabel(metadata),
     };
   }
@@ -270,6 +274,7 @@
       evt.source_id || '',
       evt.amount ?? '',
       metadata.damage_type_id || '',
+      metadata.is_critical ? 'crit' : '',
       effectIds,
       effectDetails,
     ].join('::');

--- a/frontend/tests/battle-floaters.test.js
+++ b/frontend/tests/battle-floaters.test.js
@@ -1,0 +1,25 @@
+import { describe, test, expect } from 'bun:test';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+describe('Battle event floaters', () => {
+  const viewSource = readFileSync(
+    join(import.meta.dir, '../src/lib/components/BattleView.svelte'),
+    'utf8'
+  );
+  const floaterSource = readFileSync(
+    join(import.meta.dir, '../src/lib/components/BattleEventFloaters.svelte'),
+    'utf8'
+  );
+
+  test('records critical hit metadata on recent events', () => {
+    expect(viewSource).toContain('metadata?.is_critical');
+    expect(viewSource).toContain('evt.isCritical');
+    expect(viewSource).toContain("metadata.is_critical ? 'crit' : ''");
+  });
+
+  test('renders an exclamation mark for critical damage floaters', () => {
+    expect(floaterSource).toContain("entry.critical && entry.variant === 'damage'");
+    expect(floaterSource).toContain('critical = Boolean');
+  });
+});


### PR DESCRIPTION
## Summary
- include a critical-hit flag in damage_taken bus payloads and propagate it through battle snapshots
- update battle event floaters to highlight critical hits and extend subscriptions to accept the new argument
- add coverage for critical event metadata and floater rendering

## Testing
- uv run pytest tests/test_status_phase_events.py::test_status_phase_events_update_snapshot_queue
- bun test battle-floaters.test.js

------
https://chatgpt.com/codex/tasks/task_b_68cb980505c8832c82ed41142583f1a7