### PR TITLE
[ENH] Surface status effect identifiers

### DIFF
--- a/backend/.codex/implementation/battle-logging.md
+++ b/backend/.codex/implementation/battle-logging.md
@@ -73,6 +73,8 @@ Both events provide the same argument signature as other battle bus events:
    - `effect_count`: active effect total at the start/end of the phase.
    - `expired_count`: number of effects that ended during the phase (zero on start events).
    - `has_effects`: convenience boolean indicating whether any effects remain.
+   - `effect_ids`: ordered identifiers for every status evaluated in the phase, matching the combatant's HoT/DoT trackers.
+   - `effect_names`: human-friendly labels for each entry when available (falls back to identifiers when names are missing).
    - `target_id`: the combatant identifier (if available).
 
 Phases always fire in HoT → DoT order even when a combatant has no active statuses, and the manager yields via `pace_sleep(YIELD_MULTIPLIER)` between phases to create a short, predictable beat for UI animations and log snapshots.

--- a/backend/tests/test_status_phase_events.py
+++ b/backend/tests/test_status_phase_events.py
@@ -26,7 +26,6 @@ from autofighter.stats import Stats
 from autofighter.stats import set_battle_active
 from plugins.event_bus import bus
 
-
 STUB_PASSIVE_ID = "stub_passive"
 
 
@@ -112,24 +111,32 @@ async def test_status_phase_events_emit_with_pacing(monkeypatch):
     assert start_hot_args[2]["effect_count"] == 1
     assert start_hot_args[2]["order"] == 0
     assert start_hot_args[2]["has_effects"] is True
+    assert start_hot_args[2]["effect_ids"] == [hot.id]
+    assert start_hot_args[2]["effect_names"] == [hot.name]
 
     end_hot_name, end_hot_args = status_events[1]
     assert end_hot_args[2]["phase"] == "hot"
     assert end_hot_args[2]["effect_count"] == 0
     assert end_hot_args[2]["expired_count"] == 1
     assert end_hot_args[2]["order"] == 0
+    assert end_hot_args[2]["effect_ids"] == []
+    assert end_hot_args[2]["effect_names"] == []
 
     start_dot_name, start_dot_args = status_events[2]
     assert start_dot_args[0] == "dot"
     assert start_dot_args[2]["phase"] == "dot"
     assert start_dot_args[2]["effect_count"] == 1
     assert start_dot_args[2]["order"] == 1
+    assert start_dot_args[2]["effect_ids"] == [dot.id]
+    assert start_dot_args[2]["effect_names"] == [dot.name]
 
     end_dot_name, end_dot_args = status_events[3]
     assert end_dot_args[2]["phase"] == "dot"
     assert end_dot_args[2]["effect_count"] == 0
     assert end_dot_args[2]["expired_count"] == 1
     assert end_dot_args[2]["order"] == 1
+    assert end_dot_args[2]["effect_ids"] == []
+    assert end_dot_args[2]["effect_names"] == []
 
     start_mod_name, start_mod_args = status_events[4]
     assert start_mod_name == "status_phase_start"

--- a/frontend/src/lib/components/BattleView.svelte
+++ b/frontend/src/lib/components/BattleView.svelte
@@ -486,6 +486,15 @@
     const existing = statusEntryMap.get(entryKey);
     const entry = existing || { key: entryKey, createdAt: Date.now() };
 
+    const rawIds = Array.isArray(phase.effect_ids) ? phase.effect_ids : [];
+    const rawNames = Array.isArray(phase.effect_names) ? phase.effect_names : [];
+    const effectIds = rawIds
+      .map((value) => String(value ?? '').trim())
+      .filter((value) => value.length > 0);
+    const effectNames = rawNames
+      .map((value) => String(value ?? '').trim())
+      .filter((value) => value.length > 0);
+
     entry.phase = normalizedPhase;
     entry.label = label || (normalizedPhase ? normalizedPhase.toUpperCase() : '');
     entry.state = state;
@@ -497,6 +506,11 @@
     entry.order = orderValue;
     entry.color = resolveStatusColor(normalizedPhase);
     entry.updatedAt = Date.now();
+    entry.effectIds = effectIds;
+    entry.effectNames = effectNames;
+    entry.effectSummary = effectNames.length
+      ? effectNames.join(', ')
+      : effectIds.join(', ');
 
     statusEntryMap.set(entryKey, entry);
 
@@ -893,6 +907,14 @@
           <span class="chip-phase">{chip.label}</span>
           {#if chip.targetName}
             <span class="chip-target">→ {chip.targetName}</span>
+          {/if}
+          {#if chip.effectIds?.length}
+            <span
+              class="chip-effects"
+              title={chip.effectSummary || chip.effectIds.join(', ')}
+            >
+              IDs: {chip.effectIds.join(', ')}
+            </span>
           {/if}
           <span class="chip-meta">{describeStatusChip(chip)}</span>
         </div>
@@ -1477,6 +1499,15 @@
     font-size: 0.78rem;
     opacity: 0.85;
     text-transform: none;
+  }
+
+  .status-timeline .timeline-chip .chip-effects {
+    font-size: 0.72rem;
+    opacity: 0.85;
+    text-transform: none;
+    font-family: 'JetBrains Mono', 'Fira Mono', monospace;
+    letter-spacing: 0.02em;
+    white-space: nowrap;
   }
 
   .status-timeline .timeline-chip .chip-meta {


### PR DESCRIPTION
## Summary
- include explicit effect identifiers and labels in HoT/DoT phase payloads and propagate them through status events
- assert the new metadata in status phase tests and document the payload contract for log consumers
- surface processed effect IDs in the battle status timeline UI for clearer feedback

## Testing
- uv tool run ruff check backend/autofighter/effects.py backend/tests/test_status_phase_events.py
- uv run pytest tests/test_status_phase_events.py
- bun run lint


------
https://chatgpt.com/codex/tasks/task_b_68cb9bc2f5bc832c8e3b674c9991ab81