### PR TITLE
feat: include source metadata in battle events

### DIFF
--- a/backend/autofighter/rooms/battle/turns.py
+++ b/backend/autofighter/rooms/battle/turns.py
@@ -261,27 +261,28 @@ def _on_damage_taken(
     pre_damage_hp: int | None = None,
     post_damage_hp: int | None = None,
     is_critical: bool | None = None,
+    action_name: str | None = None,
     *_: Any,
 ) -> None:
     run_id = _resolve_run_id(target, attacker)
     if not run_id:
         return
-    metadata: dict[str, Any] | None = None
+    metadata: dict[str, Any] = {}
     damage_type_id = _resolve_damage_type_id(attacker)
     if damage_type_id:
-        metadata = {"damage_type_id": damage_type_id}
+        metadata["damage_type_id"] = damage_type_id
     if is_critical is not None:
-        if metadata is None:
-            metadata = {"is_critical": bool(is_critical)}
-        else:
-            metadata = {**metadata, "is_critical": bool(is_critical)}
+        metadata["is_critical"] = bool(is_critical)
+    if action_name:
+        metadata["action_name"] = str(action_name)
+    metadata_payload = metadata or None
     _record_event(
         run_id,
         event_type="damage_taken",
         source=attacker,
         target=target,
         amount=amount,
-        metadata=metadata,
+        metadata=metadata_payload,
     )
     kwargs: dict[str, Any] = {}
     if attacker is not None:
@@ -296,22 +297,29 @@ def _on_heal_received(
     target: Stats | None,
     healer: Stats | None = None,
     amount: int | None = None,
+    source_type: str | None = None,
+    source_name: str | None = None,
     *_: Any,
 ) -> None:
     run_id = _resolve_run_id(target, healer)
     if not run_id:
         return
-    metadata: dict[str, Any] | None = None
+    metadata: dict[str, Any] = {}
     damage_type_id = _resolve_damage_type_id(healer)
     if damage_type_id:
-        metadata = {"damage_type_id": damage_type_id}
+        metadata["damage_type_id"] = damage_type_id
+    if source_type:
+        metadata["source_type"] = str(source_type)
+    if source_name:
+        metadata["source_name"] = str(source_name)
+    metadata_payload = metadata or None
     _record_event(
         run_id,
         event_type="heal_received",
         source=healer,
         target=target,
         amount=amount,
-        metadata=metadata,
+        metadata=metadata_payload,
     )
     kwargs: dict[str, Any] = {}
     if healer is not None:

--- a/backend/autofighter/stats.py
+++ b/backend/autofighter/stats.py
@@ -733,6 +733,7 @@ class Stats:
             old_hp,
             post_hit_hp,
             critical,
+            action_name,
         )
         if attacker is not None:
             attacker.damage_dealt += original_amount
@@ -769,6 +770,7 @@ class Stats:
             old_hp,
             post_hit_hp,
             False,
+            None,
         )
         return amount
 
@@ -825,7 +827,7 @@ class Stats:
             self.hp = min(self.hp + amount, self.max_hp)
 
         # Use batched emission for high-frequency healing events
-        BUS.emit_batched("heal_received", self, healer, amount)
+        BUS.emit_batched("heal_received", self, healer, amount, source_type, source_name)
         if healer is not None:
             BUS.emit_batched("heal", healer, self, amount, source_type, source_name)
         return amount
@@ -878,7 +880,10 @@ def _log_damage_taken(
 
 
 def _log_heal_received(
-    target: "Stats", healer: Optional["Stats"], amount: int
+    target: "Stats",
+    healer: Optional["Stats"],
+    amount: int,
+    *_: object,
 ) -> None:
     healer_id = getattr(healer, "id", "unknown")
     log.info("%s heals %s from %s", target.id, amount, healer_id)

--- a/backend/plugins/cards/balanced_diet.py
+++ b/backend/plugins/cards/balanced_diet.py
@@ -18,7 +18,7 @@ class BalancedDiet(CardBase):
     async def apply(self, party) -> None:  # type: ignore[override]
         await super().apply(party)
 
-        async def _on_heal_received(target, healer, heal_amount):
+        async def _on_heal_received(target, healer, heal_amount, *_args):
             # Check if target is one of our party members
             if target in party.members:
                 # Grant +2% DEF for 1 turn

--- a/backend/plugins/relics/rusty_buckle.py
+++ b/backend/plugins/relics/rusty_buckle.py
@@ -107,7 +107,7 @@ class RustyBuckle(RelicBase):
                             foe = random.choice(state["foes"])
                             safe_async_task(Aftertaste(base_pot=dmg).apply(target, foe))
 
-            def _heal(target, healer, _amount) -> None:
+            def _heal(target, healer, _amount, *_args) -> None:
                 if target in party.members:
                     state["prev_hp"][id(target)] = target.hp
 

--- a/backend/tests/test_card_rewards.py
+++ b/backend/tests/test_card_rewards.py
@@ -250,7 +250,7 @@ async def test_vital_surge_low_hp_bonus():
     await BUS.emit_async("turn_start")
     assert member.atk == int(200 * 1.55)
     member.hp = member.max_hp
-    await BUS.emit_async("heal_received", member, member, 100)
+    await BUS.emit_async("heal_received", member, member, 100, None, None)
     assert member.atk == 200
 
 

--- a/backend/tests/test_effects.py
+++ b/backend/tests/test_effects.py
@@ -48,7 +48,7 @@ async def test_damage_and_heal_events():
     def _dmg(target, attacker, amount, *_: object):
         events.append(("dmg", amount))
 
-    def _heal(target, healer, amount):
+    def _heal(target, healer, amount, *_args):
         events.append(("heal", amount))
 
     bus.subscribe("damage_taken", _dmg)
@@ -72,7 +72,7 @@ async def test_hot_ticks_before_dot():
     def _dmg(target, attacker, amount, *_: object):
         events.append(("dmg", amount))
 
-    def _heal(target, healer, amount):
+    def _heal(target, healer, amount, *_args):
         events.append(("heal", amount))
 
     bus.subscribe("damage_taken", _dmg)

--- a/backend/tests/test_passives.py
+++ b/backend/tests/test_passives.py
@@ -54,7 +54,7 @@ async def test_room_heal_event_and_enrage(monkeypatch):
     player.passives = ["room_heal"]
     amounts: list[int] = []
 
-    def _heal(target, healer, amount):
+    def _heal(target, healer, amount, *_args):
         amounts.append(amount)
 
     BUS.subscribe("heal_received", _heal)

--- a/backend/tests/test_rusty_buckle.py
+++ b/backend/tests/test_rusty_buckle.py
@@ -38,7 +38,7 @@ def bus(monkeypatch):
 
     async def simple_heal(self, amount, healer=None):
         self.hp = min(self.hp + int(amount), self.max_hp)
-        await bus.emit_async("heal_received", self, healer, amount)
+        await bus.emit_async("heal_received", self, healer, amount, None, None)
         return int(amount)
 
     monkeypatch.setattr(PlayerBase, "apply_damage", simple_damage)

--- a/backend/tests/test_status_phase_events.py
+++ b/backend/tests/test_status_phase_events.py
@@ -339,8 +339,22 @@ async def test_status_phase_events_update_snapshot_queue(monkeypatch):
     assert resist_metadata.get("source_id") == attacker.id
     assert resist_metadata.get("target_id") == target.id
 
-    record_damage_taken_event(target, target, 77)
-    record_heal_received_event(target, target, 33)
+    record_damage_taken_event(
+        target,
+        target,
+        77,
+        None,
+        None,
+        True,
+        "test_action",
+    )
+    record_heal_received_event(
+        target,
+        target,
+        33,
+        "test_source_type",
+        "Test Source",
+    )
 
     final_events = list(battle_snapshots[run_id]["recent_events"])
     events_by_type = _group_by_type(final_events)
@@ -355,6 +369,11 @@ async def test_status_phase_events_update_snapshot_queue(monkeypatch):
     damage_metadata = damage_event.get("metadata", {})
     assert damage_metadata.get("damage_type_id") == "Generic"
     assert damage_metadata.get("is_critical") is True
+    assert damage_metadata.get("action_name") == "test_action"
+
+    heal_metadata = heal_event.get("metadata", {})
+    assert heal_metadata.get("source_type") == "test_source_type"
+    assert heal_metadata.get("source_name") == "Test Source"
 
     status_phase = snapshot.get("status_phase")
     assert status_phase is not None

--- a/frontend/src/lib/components/BattleEventFloaters.svelte
+++ b/frontend/src/lib/components/BattleEventFloaters.svelte
@@ -36,6 +36,21 @@
       if (entry.name) return String(entry.name);
       if (entry.id) return String(entry.id);
     }
+    const fallbackKeys = [
+      'effect_name',
+      'action_name',
+      'actionName',
+      'source_name',
+      'sourceName',
+      'source_type',
+      'sourceType',
+    ];
+    for (const key of fallbackKeys) {
+      const value = metadata[key];
+      if (value !== undefined && value !== null && String(value).trim() !== '') {
+        return String(value);
+      }
+    }
     return '';
   }
 

--- a/frontend/src/lib/components/BattleView.svelte
+++ b/frontend/src/lib/components/BattleView.svelte
@@ -245,6 +245,21 @@
       if (entry.name) return String(entry.name);
       if (entry.id) return String(entry.id);
     }
+    const fallbackKeys = [
+      'effect_name',
+      'action_name',
+      'actionName',
+      'source_name',
+      'sourceName',
+      'source_type',
+      'sourceType',
+    ];
+    for (const key of fallbackKeys) {
+      const value = metadata[key];
+      if (value !== undefined && value !== null && String(value).trim() !== '') {
+        return String(value);
+      }
+    }
     return '';
   }
 


### PR DESCRIPTION
## Summary
- append action and heal source context to `damage_taken` / `heal_received` emissions and record them in battle snapshots
- teach backend subscribers, fixtures, and tests to accept the extra batched arguments and assert the new metadata
- ensure battle floaters fall back to action or source names when effect metadata is absent

## Testing
- [x] Backend tests
- [x] Frontend tests
- [x] Linting
- [ ] Doc sync updates (README and `.codex/implementation` docs; link tasks below)

## Checklist
- [ ] Linked or updated relevant `.codex/tasks` entries
- [ ] Updated player roster and foe docs if adding or modifying fighters or enemies
- [ ] Referenced `.codex/implementation/ui-animation-guidelines.md` when adding UI animations

------
https://chatgpt.com/codex/tasks/task_b_68cb9f9f3024832c8b4d9fe5e148b4f9