### PR TITLE
Emit immediate enrage snapshot updates

### DIFF
--- a/backend/autofighter/rooms/battle/turn_loop/player_turn.py
+++ b/backend/autofighter/rooms/battle/turn_loop/player_turn.py
@@ -51,7 +51,7 @@ async def execute_player_phase(context: TurnLoopContext) -> bool:
                 await pace_sleep(YIELD_MULTIPLIER)
                 break
             context.turn += 1
-            await update_enrage_state(
+            enrage_update = await update_enrage_state(
                 context.turn,
                 context.enrage_state,
                 context.foes,
@@ -59,6 +59,19 @@ async def execute_player_phase(context: TurnLoopContext) -> bool:
                 context.enrage_mods,
                 context.combat_party.members,
             )
+            if enrage_update:
+                await push_progress_update(
+                    context.progress,
+                    context.combat_party.members,
+                    context.foes,
+                    context.enrage_state,
+                    context.temp_rdr,
+                    _EXTRA_TURNS,
+                    run_id=context.run_id,
+                    active_id=getattr(member, "id", None),
+                    active_target_id=None,
+                )
+                await pace_sleep(YIELD_MULTIPLIER)
             await context.registry.trigger("turn_start", member)
             if context.run_id is not None:
                 await _abort_other_runs(context, context.run_id)

--- a/backend/autofighter/rooms/battle/turns.py
+++ b/backend/autofighter/rooms/battle/turns.py
@@ -736,8 +736,11 @@ async def update_enrage_state(
     foe_effects: Sequence["EffectManager"],
     enrage_mods: list[Any],
     party_members: Sequence[Stats],
-) -> None:
+) -> dict[str, Any] | None:
     """Update enrage modifiers and catastrophic damage thresholds."""
+
+    previous_active = state.active
+    previous_stacks = state.stacks
 
     if turn > state.threshold:
         if not state.active:
@@ -781,6 +784,10 @@ async def update_enrage_state(
                         await foe_obj.apply_damage(extra_damage)
     else:
         await asyncio.to_thread(set_enrage_percent, 0.0)
+
+    if state.active != previous_active or state.stacks != previous_stacks:
+        return state.as_payload()
+    return None
 
 
 async def apply_enrage_bleed(

--- a/backend/tests/test_enrage_progress_updates.py
+++ b/backend/tests/test_enrage_progress_updates.py
@@ -1,0 +1,227 @@
+# ruff: noqa: E402, I001
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+_PROJECT_ROOT = str(Path(__file__).resolve().parents[1])
+if _PROJECT_ROOT not in sys.path:
+    sys.path.append(_PROJECT_ROOT)
+
+from autofighter.rooms.battle import turns
+from autofighter.rooms.battle.turn_loop import player_turn
+from autofighter.rooms.battle.turns import EnrageState
+
+
+class DummyMod:
+    def __init__(self, mod_id: str = "enrage_atk"):
+        self.id = mod_id
+        self.removed = False
+
+    def remove(self) -> None:  # pragma: no cover - simple flag for diagnostics
+        self.removed = True
+
+
+class DummyEffectManager:
+    def __init__(self) -> None:
+        self.mods: list[DummyMod] = []
+
+    async def tick(self, *_: object) -> None:  # pragma: no cover - unused
+        return None
+
+    async def on_action(self, *_: object) -> bool:  # pragma: no cover - unused
+        return True
+
+    def add_modifier(self, mod: DummyMod) -> None:
+        self.mods.append(mod)
+
+
+class DummyRegistry:
+    async def trigger(self, *_: object, **__: object) -> None:
+        return None
+
+    async def trigger_turn_start(self, *_: object, **__: object) -> None:
+        return None
+
+    async def trigger_turn_end(self, *_: object, **__: object) -> None:
+        return None
+
+    async def trigger_hit_landed(self, *_: object, **__: object) -> None:
+        return None
+
+
+class DummyParty:
+    def __init__(self, members: list[DummyMember]) -> None:
+        self.members = list(members)
+
+
+class DummyDamageType:
+    id = "test"
+
+    async def on_action(self, *_: object, **__: object) -> bool:
+        return True
+
+
+class DummyMember:
+    def __init__(self, member_id: str = "ally") -> None:
+        self.id = member_id
+        self.hp = 10
+        self.max_hp = 10
+        self.action_points = 1
+        self.actions_per_turn = 1
+        self.damage_type = DummyDamageType()
+        self.effect_manager = DummyEffectManager()
+        self.ultimate_charge = 0
+        self.ultimate_ready = False
+
+    async def maybe_regain(self, *_: object) -> None:
+        return None
+
+    async def apply_damage(self, amount: int, **_: object) -> int:  # pragma: no cover
+        self.hp = max(0, self.hp - amount)
+        return amount
+
+    def add_ultimate_charge(self, amount: int) -> None:  # pragma: no cover - unused
+        self.ultimate_charge += amount
+
+    def handle_ally_action(self, *_: object) -> None:  # pragma: no cover - unused
+        return None
+
+
+class DummyFoe:
+    def __init__(self, foe_id: str = "foe") -> None:
+        self.id = foe_id
+        self.hp = 10
+        self.max_hp = 10
+        self.passives: list[str] = []
+        self.mods: list[str] = []
+
+    async def apply_damage(self, amount: int, **_: object) -> int:  # pragma: no cover
+        self.hp = max(0, self.hp - amount)
+        return amount
+
+
+async def _noop_async(*_: object, **__: object) -> None:
+    return None
+
+
+@pytest.mark.asyncio
+async def test_update_enrage_state_returns_payload(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Enrage activation should report changes for snapshot updates."""
+
+    monkeypatch.setattr(turns, "create_stat_buff", lambda *_, **__: DummyMod())
+    monkeypatch.setattr(turns, "set_enrage_percent", lambda value: None)
+
+    state = EnrageState(threshold=0)
+    foe = DummyFoe()
+    manager = DummyEffectManager()
+    enrage_mods: list[DummyMod | None] = [None]
+
+    payload = await turns.update_enrage_state(
+        turn=1,
+        state=state,
+        foes=[foe],
+        foe_effects=[manager],
+        enrage_mods=enrage_mods,
+        party_members=[],
+    )
+
+    assert payload == state.as_payload()
+    assert state.active is True
+    assert state.stacks == 1
+    assert "Enraged" in foe.passives
+    assert isinstance(enrage_mods[0], DummyMod)
+
+
+@pytest.mark.asyncio
+async def test_player_phase_emits_snapshot_on_enrage(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Player turns should push an update immediately when enrage changes."""
+
+    monkeypatch.setattr(turns, "create_stat_buff", lambda *_, **__: DummyMod())
+    monkeypatch.setattr(turns, "set_enrage_percent", lambda value: None)
+
+    updates: list[dict[str, object]] = []
+    pace_calls: list[float] = []
+
+    async def record_progress(
+        _progress_cb,
+        party_members,
+        foes,
+        enrage_state,
+        rdr,
+        extra_turns,
+        *,
+        run_id,
+        active_id,
+        active_target_id=None,
+        include_summon_foes=False,
+        ended=None,
+    ) -> None:
+        updates.append(
+            {
+                "party": [getattr(member, "id", None) for member in party_members],
+                "foes": [getattr(foe, "id", None) for foe in foes],
+                "enrage": enrage_state.as_payload(),
+                "active_id": active_id,
+                "active_target_id": active_target_id,
+                "include_summon_foes": include_summon_foes,
+                "ended": ended,
+            }
+        )
+
+    async def capture_sleep(delay: float) -> None:
+        pace_calls.append(delay)
+
+    monkeypatch.setattr(player_turn, "push_progress_update", record_progress)
+    monkeypatch.setattr(player_turn, "pace_sleep", capture_sleep)
+    monkeypatch.setattr(player_turn, "impact_pause", _noop_async)
+    monkeypatch.setattr(player_turn, "_pace", _noop_async)
+    monkeypatch.setattr(player_turn, "queue_log", lambda *_, **__: None)
+    monkeypatch.setattr(player_turn, "_handle_ultimate", _noop_async)
+    monkeypatch.setattr(player_turn, "apply_enrage_bleed", _noop_async)
+    monkeypatch.setattr(player_turn, "credit_if_dead", lambda **kwargs: (kwargs["exp_reward"], kwargs["temp_rdr"]))
+    monkeypatch.setattr(player_turn, "remove_dead_foes", lambda **__: None)
+    monkeypatch.setattr(player_turn, "SummonManager", SimpleNamespace(add_summons_to_party=lambda *_: 0, get_summons=lambda *_: []))
+    monkeypatch.setattr(player_turn, "register_snapshot_entities", lambda *_, **__: None)
+    monkeypatch.setattr(player_turn, "mutate_snapshot_overlay", lambda *_, **__: None)
+    monkeypatch.setattr(player_turn, "BUS", SimpleNamespace(emit_async=_noop_async))
+    monkeypatch.setattr(player_turn, "calc_animation_time", lambda *_, **__: 0)
+    monkeypatch.setattr(player_turn, "_any_foes_alive", lambda *_: False)
+
+    member = DummyMember()
+    foe = DummyFoe()
+    manager = DummyEffectManager()
+    context = player_turn.TurnLoopContext(
+        room=SimpleNamespace(),
+        party=DummyParty([member]),
+        combat_party=DummyParty([member]),
+        registry=DummyRegistry(),
+        foes=[foe],
+        foe_effects=[manager],
+        enrage_mods=[None],
+        enrage_state=EnrageState(threshold=0),
+        progress=None,
+        visual_queue=None,
+        temp_rdr=0.0,
+        exp_reward=0,
+        run_id="run",
+        battle_tasks={},
+        abort=lambda *_: None,
+        credited_foe_ids=set(),
+        turn=0,
+    )
+
+    result = await player_turn.execute_player_phase(context)
+
+    assert result is True
+    assert updates, "Expected progress update when enrage activates"
+    snapshot = updates[0]
+    assert snapshot["enrage"]["active"] is True
+    assert snapshot["enrage"]["stacks"] == 1
+    assert snapshot["active_id"] == member.id
+    assert snapshot["active_target_id"] is None
+    assert pace_calls == [player_turn.YIELD_MULTIPLIER]
+    assert context.enrage_mods[0] is not None


### PR DESCRIPTION
## Summary
- return enrage payload when the state toggles or stacks change so the caller can react immediately
- trigger an immediate progress update during player turns when enrage updates fire and pause so the client can render the change
- add regression tests that cover enrage payload emission and the new snapshot behaviour

## Testing
- `uv run pytest backend/tests/test_enrage_progress_updates.py`
- `uv run pytest backend/tests/test_turn_loop_summon_updates.py`
- `uv run ruff check backend/autofighter/rooms/battle/turns.py backend/autofighter/rooms/battle/turn_loop/player_turn.py backend/tests/test_enrage_progress_updates.py`

------
https://chatgpt.com/codex/tasks/task_b_68cba01428a4832c8231626baf1a8434