### PR TITLE
feat: enrich battle floater metadata

### DIFF
--- a/frontend/src/lib/components/BattleView.svelte
+++ b/frontend/src/lib/components/BattleView.svelte
@@ -76,7 +76,14 @@
   let recentEventCounts = new Map();
   let lastRecentEventTokens = [];
   let floaterDuration = 1200;
-  const relevantRecentEventTypes = new Set(['damage_taken', 'heal_received', 'dot_tick', 'hot_tick']);
+  const relevantRecentEventTypes = new Set([
+    'damage_taken',
+    'heal_received',
+    'dot_tick',
+    'hot_tick',
+    'card_effect',
+    'relic_effect',
+  ]);
   let lastRunId = runId;
 
   // Slow down floater animation a bit for readability
@@ -247,12 +254,19 @@
     }
     const fallbackKeys = [
       'effect_name',
+      'effect',
+      'effect_type',
+      'effectType',
       'action_name',
       'actionName',
       'source_name',
       'sourceName',
       'source_type',
       'sourceType',
+      'card_name',
+      'cardName',
+      'relic_name',
+      'relicName',
     ];
     for (const key of fallbackKeys) {
       const value = metadata[key];
@@ -260,12 +274,33 @@
         return String(value);
       }
     }
+    const details = metadata.details;
+    if (details && typeof details === 'object') {
+      const detailKeys = [
+        'label',
+        'name',
+        'effect_name',
+        'effect',
+        'effect_type',
+        'effectType',
+        'action_name',
+        'actionName',
+        'source_name',
+        'sourceName',
+      ];
+      for (const key of detailKeys) {
+        const value = details[key];
+        if (value !== undefined && value !== null && String(value).trim() !== '') {
+          return String(value);
+        }
+      }
+    }
     return '';
   }
 
   function normalizeRecentEvent(evt) {
     if (!evt || typeof evt !== 'object') return null;
-    const metadata = (evt.metadata && typeof evt.metadata === 'object') ? evt.metadata : {};
+    const metadata = (evt.metadata && typeof evt.metadata === 'object') ? { ...evt.metadata } : {};
     let damageTypeId = metadata.damage_type_id;
     if (!damageTypeId) {
       const effects = Array.isArray(metadata.effects) ? metadata.effects : [];
@@ -279,17 +314,49 @@
         if (damageTypeId) break;
       }
     }
+    if (!damageTypeId) {
+      const fallbacks = [
+        metadata.effect,
+        metadata.effect_type,
+        metadata.effectType,
+        metadata.element,
+      ];
+      for (const candidate of fallbacks) {
+        if (candidate !== undefined && candidate !== null && String(candidate).trim() !== '') {
+          damageTypeId = candidate;
+          break;
+        }
+      }
+    }
     const amount = Number(evt.amount ?? 0);
     const isCritical = Boolean(
       metadata?.is_critical ?? metadata?.isCritical ?? metadata?.critical ?? evt.isCritical
     );
+    let effectLabel = extractEffectLabel(metadata);
+    if (!effectLabel) {
+      const fallbackCandidates = [
+        metadata.card_name,
+        metadata.cardName,
+        metadata.relic_name,
+        metadata.relicName,
+        metadata.effect,
+        metadata.effect_type,
+        metadata.effectType,
+      ];
+      for (const candidate of fallbackCandidates) {
+        if (candidate !== undefined && candidate !== null && String(candidate).trim() !== '') {
+          effectLabel = String(candidate);
+          break;
+        }
+      }
+    }
     return {
       ...evt,
       amount,
       damageTypeId,
       metadata,
       isCritical,
-      effectLabel: extractEffectLabel(metadata),
+      effectLabel,
     };
   }
 

--- a/frontend/src/lib/systems/assetLoader.js
+++ b/frontend/src/lib/systems/assetLoader.js
@@ -321,10 +321,10 @@ export function getDamageTypeColor(typeId, options = {}) {
   const key = normalizeDamageTypeId(typeId);
   const base = ELEMENT_COLORS[key] || '#cccccc';
   const variant = (options.variant || '').toLowerCase();
-  if (variant === 'heal' || variant === 'hot') {
+  if (variant === 'heal' || variant === 'hot' || variant === 'buff') {
     return shiftColor(base, 0.4);
   }
-  if (variant === 'dot') {
+  if (variant === 'dot' || variant === 'drain') {
     return shiftColor(base, -0.25);
   }
   return base;

--- a/frontend/tests/__snapshots__/battle-floaters.test.js.snap
+++ b/frontend/tests/__snapshots__/battle-floaters.test.js.snap
@@ -1,0 +1,49 @@
+// Bun Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Battle event floaters staggered floater scheduling uses index-based offsets: floater-stagger-block 1`] = `
+"list.forEach((raw, i) => {
+      if (!raw || typeof raw !== 'object') return;
+      const handle = setTimeout(() => {
+        addTimers.delete(handle);
+        const metadata = raw && typeof raw.metadata === 'object' ? raw.metadata : {};
+        const amountValue = Number(raw.amount ?? metadata?.amount);
+        const hasAmount = Number.isFinite(amountValue);
+        const amount = hasAmount ? Math.abs(amountValue) : 0;
+        const label = (raw.effectLabel || resolveLabel(metadata) || '').trim();
+        const variant = resolveVariant(raw.type, metadata, amountValue);
+        const damageType = raw.damageTypeId || metadata?.damage_type_id || '';
+        const { icon: Icon, color } = getDamageTypeVisual(damageType, { variant });
+        const showAmount = hasAmount && amount > 0;
+        if (!showAmount && !label) return;
+        const id = \`\${Date.now()}-\${counter++}\`;
+        const offset = Math.random() * RANDOM_OFFSETS - RANDOM_OFFSETS / 2;
+        const target = String(raw.target_id || '');
+        const anchor = (anchors && target && anchors[target]) ? anchors[target] : null;
+        const x = anchor && Number.isFinite(anchor.x) ? anchor.x : 0.5;
+        const y = anchor && Number.isFinite(anchor.y) ? anchor.y : 0.52;
+        const critical = Boolean(raw.isCritical || metadata?.is_critical);
+        const prefix =
+          variant === 'damage' || variant === 'dot' || variant === 'drain' ? '-' : '+';
+        floaters = [
+          ...floaters,
+          {
+            id,
+            Icon,
+            color,
+            amount,
+            variant,
+            label,
+            offset,
+            x,
+            y,
+            tone: resolveTone(variant),
+            type: raw.type,
+            critical,
+            showAmount,
+            prefix,
+          }
+        ];
+        scheduleRemoval(id, duration);
+      }, i * step);
+      addTimers.add(handle);"
+`;

--- a/frontend/tests/battle-floaters.test.js
+++ b/frontend/tests/battle-floaters.test.js
@@ -19,7 +19,22 @@ describe('Battle event floaters', () => {
   });
 
   test('renders an exclamation mark for critical damage floaters', () => {
-    expect(floaterSource).toContain("entry.critical && entry.variant === 'damage'");
+    expect(floaterSource).toContain(
+      "entry.critical && (entry.variant === 'damage' || entry.variant === 'drain')"
+    );
     expect(floaterSource).toContain('critical = Boolean');
+  });
+
+  test('staggered floater scheduling uses index-based offsets', () => {
+    const anchor = 'list.forEach((raw, i) => {';
+    const start = floaterSource.indexOf(anchor);
+    expect(start).toBeGreaterThan(-1);
+    const endMarker = 'addTimers.add(handle);';
+    const end = floaterSource.indexOf(endMarker, start);
+    expect(end).toBeGreaterThan(start);
+    const snippet = floaterSource
+      .slice(start, end + endMarker.length)
+      .replace(/\s+$/g, '');
+    expect(snippet).toMatchSnapshot('floater-stagger-block');
   });
 });


### PR DESCRIPTION
## Summary
- include card and relic effect events when normalizing battle snapshots and derive labels from fallback metadata
- map card/relic floater variants, expose metadata badges even at zero amounts, and tune damage-type visuals for new tones
- add a snapshot-backed floater test that verifies stagger timing remains intact

## Testing
- bun test tests/battle-floaters.test.js --update-snapshots
- bun test tests/battle-floaters.test.js
- bun run lint

------
https://chatgpt.com/codex/tasks/task_b_68cbcc37d5ac832c9d77ea78f1e9fab5