### PR TITLE
fix: preserve floater labels in dedupe token

### DIFF
--- a/frontend/src/lib/components/BattleView.svelte
+++ b/frontend/src/lib/components/BattleView.svelte
@@ -364,6 +364,23 @@
     if (!evt) return '';
     const metadata = evt.metadata || {};
     const effectIds = Array.isArray(metadata.effect_ids) ? metadata.effect_ids.join('|') : '';
+    const cardIdentifiers = [
+      metadata.card_id,
+      metadata.cardId,
+      metadata.card_name,
+      metadata.cardName,
+    ]
+      .map(value => (value === undefined || value === null ? '' : String(value)))
+      .join('~');
+    const relicIdentifiers = [
+      metadata.relic_id,
+      metadata.relicId,
+      metadata.relic_name,
+      metadata.relicName,
+    ]
+      .map(value => (value === undefined || value === null ? '' : String(value)))
+      .join('~');
+    const label = evt.effectLabel === undefined || evt.effectLabel === null ? '' : String(evt.effectLabel);
     const effectDetails = Array.isArray(metadata.effects)
       ? metadata.effects
           .map(e =>
@@ -381,6 +398,9 @@
       metadata.damage_type_id || '',
       metadata.is_critical ? 'crit' : '',
       effectIds,
+      label,
+      cardIdentifiers,
+      relicIdentifiers,
       effectDetails,
     ].join('::');
   }


### PR DESCRIPTION
## Summary
- add resolved effect labels and card/relic identifiers to the recent-event dedupe token
- ensure card and relic floaters with distinct metadata no longer collapse into the same token

## Testing
- bun test tests/battle-floaters.test.js

------
https://chatgpt.com/codex/tasks/task_b_68cbd869ffc0832c80b37f6b1be06f6f