### PR TITLE
[FIX] reality split handler cleanup

### DIFF
--- a/backend/tests/test_five_star_cards.py
+++ b/backend/tests/test_five_star_cards.py
@@ -10,6 +10,7 @@ import llms.torch_checker as torch_checker
 
 from autofighter.party import Party
 from autofighter.stats import BUS
+from autofighter.stats import set_battle_active
 from plugins.cards.phantom_ally import PhantomAlly
 from plugins.cards.reality_split import RealitySplit
 from plugins.cards.temporal_shield import TemporalShield
@@ -71,13 +72,92 @@ async def test_reality_split_afterimage(monkeypatch):
     f1.id = "f1"
     f2 = FoeBase()
     f2.id = "f2"
-    await BUS.emit_async("battle_start", f1)
-    await BUS.emit_async("battle_start", f2)
-    monkeypatch.setattr(random, "choice", lambda seq: a1)
+    events: list[tuple[int, object]] = []
+
+    async def _on_card_effect(card_id, _attacker, effect, amount, extra):
+        if card_id == RealitySplit.id and effect == "afterimage_echo":
+            events.append((amount, extra))
+
+    BUS.subscribe("card_effect", _on_card_effect)
+    set_battle_active(True)
+    try:
+        await BUS.emit_async("battle_start", f1)
+        await BUS.emit_async("battle_start", f2)
+        monkeypatch.setattr(random, "choice", lambda seq: a1)
+        monkeypatch.setattr(random, "random", lambda: 1.0)
+        await BUS.emit_async("turn_start")
+        await BUS.emit_async("hit_landed", a1, f1, 100, "attack", "test")
+        await asyncio.sleep(0)
+        new_events = events[:]
+        assert len(new_events) == 2
+        for amount, _extra in new_events:
+            assert amount == 25
+    finally:
+        BUS.unsubscribe("card_effect", _on_card_effect)
+        await BUS.emit_async("battle_end", f1)
+        await BUS.emit_async("battle_end", f2)
+        set_battle_active(False)
+
+
+@pytest.mark.asyncio
+async def test_reality_split_single_echo_after_back_to_back_battles(monkeypatch):
+    monkeypatch.setattr(torch_checker, "is_torch_available", lambda: False)
+    a1 = Ally()
+    a1.id = "a1"
+    a2 = Becca()
+    a2.id = "a2"
+    party = Party(members=[a1, a2])
+    card = RealitySplit()
+    await card.apply(party)
+    monkeypatch.setattr(random, "choice", lambda seq: seq[0])
     monkeypatch.setattr(random, "random", lambda: 1.0)
-    await BUS.emit_async("turn_start")
-    await BUS.emit_async("hit_landed", a1, f1, 100, "attack", "test")
-    await asyncio.sleep(0)
-    loss1 = f1.max_hp - f1.hp
-    loss2 = f2.max_hp - f2.hp
-    assert loss1 > 0 and loss1 == loss2
+    foes: list[FoeBase] = []
+    foes_round_two: list[FoeBase] = []
+    events: list[int] = []
+
+    async def _on_card_effect(card_id, _attacker, effect, amount, _extra):
+        if card_id == RealitySplit.id and effect == "afterimage_echo":
+            events.append(amount)
+
+    BUS.subscribe("card_effect", _on_card_effect)
+    set_battle_active(True)
+    try:
+        # First battle
+        foes = [FoeBase(), FoeBase()]
+        for index, foe in enumerate(foes, start=1):
+            foe.id = f"f{index}"
+            await BUS.emit_async("battle_start", foe)
+        await BUS.emit_async("turn_start")
+        await BUS.emit_async("hit_landed", a1, foes[0], 100, "attack", "test")
+        await asyncio.sleep(0)
+        first_batch = events[:]
+        assert len(first_batch) == len(foes)
+        for amount in first_batch:
+            assert amount == 25
+        for foe in foes:
+            await BUS.emit_async("battle_end", foe)
+
+        await asyncio.sleep(0)
+
+        # Second battle immediately after cleanup
+        foes_round_two = [FoeBase(), FoeBase()]
+        await card.apply(party)
+        for index, foe in enumerate(foes_round_two, start=1):
+            foe.id = f"s{index}"
+            await BUS.emit_async("battle_start", foe)
+        await BUS.emit_async("turn_start")
+        await BUS.emit_async("hit_landed", a1, foes_round_two[0], 100, "attack", "test")
+        await asyncio.sleep(0)
+        second_batch = events[len(first_batch) :]
+        assert len(second_batch) == len(foes_round_two)
+        for amount in second_batch:
+            assert amount == 25
+        for foe in foes_round_two:
+            await BUS.emit_async("battle_end", foe)
+    finally:
+        BUS.unsubscribe("card_effect", _on_card_effect)
+        for foe in foes_round_two:
+            await BUS.emit_async("battle_end", foe)
+        for foe in foes:
+            await BUS.emit_async("battle_end", foe)
+        set_battle_active(False)


### PR DESCRIPTION
## Summary
- track Reality Split handlers on the party and tear them down at battle end to prevent duplicate subscriptions
- ensure the card only emits a single afterimage echo per hit and cover the regression with back-to-back battle tests

## Testing
- [x] Backend tests (`uv run pytest tests/test_five_star_cards.py -k reality_split -vv`)
- [ ] Frontend tests
- [x] Linting (`uv run ruff check plugins/cards/reality_split.py tests/test_five_star_cards.py --fix`)
- [ ] Doc sync updates (README and `.codex/implementation` docs; link tasks below)

## Checklist
- [ ] Linked or updated relevant `.codex/tasks` entries
- [ ] Updated player roster and foe docs if adding or modifying fighters or enemies
- [ ] Referenced `.codex/implementation/ui-animation-guidelines.md` when adding UI animations

------
https://chatgpt.com/codex/tasks/task_b_68cbeddb52c4832cb6257cb5282e06fa