### PR TITLE
feat: refresh stat upgrade interactions

### DIFF
--- a/frontend/.codex/implementation/party-ui.md
+++ b/frontend/.codex/implementation/party-ui.md
@@ -26,14 +26,13 @@ Implementation details:
   skipped entirely when Reduced Motion is enabled.
 - `PartyPicker.svelte` propagates `reducedMotion` to the roster so the effect
   can be disabled via Settings.
-- `StatTabs.svelte` uses flexible sizing so the panel fills its side.
-- `StatTabs.svelte` now embeds an `UpgradePanel` beneath the stats list,
-  showing upgrade level and per-star item counts with a button disabled until
-  enough materials are available (20×4★ or 100×3★ or 500×2★ or 1000×1★).
-- `StatTabs.svelte` caches per-character stat editor values in a module-scoped
-  `Map` keyed by character ID and persists allocations through
-  `/players/<id>/editor` so non-player tweaks are saved across sessions and
-  restored when reopening the editor or switching characters.
+- `StatTabs.svelte` uses flexible sizing so the panel fills its side and now
+  surfaces a read-only stat summary alongside upgrade controls rather than
+  embedding the inline Character Editor.
+- The stat upgrade section pulls `/players/<id>/upgrade` to show remaining
+  points, per-stat totals, and next costs, dispatches `open-upgrade-mode` /
+  `close-upgrade-mode` events for `PartyPicker.svelte`, and issues upgrade
+  requests through the API helper that lets the server determine point costs.
 - `PartyPicker.svelte` tracks the preview pane mode in a local store. Upgrade
   interactions toggle an inline upgrade sheet, which bubbles events back to the
   overlay so stat spend requests can be handled alongside the existing upgrade

--- a/frontend/src/lib/components/PartyPicker.svelte
+++ b/frontend/src/lib/components/PartyPicker.svelte
@@ -168,18 +168,11 @@
         on:request-upgrade={(e) => forwardUpgradeRequest(e.detail)}
       />
       <div class="right-col">
-        <StatTabs {roster} {previewId} {selected} {userBuffPercent}
+        <StatTabs {roster} {previewId} {selected} {userBuffPercent} previewMode={$previewMode}
           on:toggle={(e) => toggleMember(e.detail)}
-          on:preview-element={(e) => {
-            const el = e.detail.element;
-            previewElementOverride = el;
-            // Also update the player's element in the roster so the left list reflects it
-            roster = roster.map(r => r.is_player ? { ...r, element: el } : r);
-            // Bubble an editor change so top-level editorState stays in sync for Start Run
-            try { dispatch('editorChange', { damageType: el }); } catch {}
-          }}
-          on:editor-change={(e) => dispatch('editorChange', e.detail)}
           on:refresh-roster={refreshRoster}
+          on:open-upgrade-mode={(e) => handlePreviewMode(e.detail, 'upgrade')}
+          on:close-upgrade-mode={(e) => handlePreviewMode(e.detail, 'portrait')}
         />
         <div class="party-actions-inline">
           {#if actionLabel === 'Start Run'}

--- a/frontend/src/lib/systems/api.js
+++ b/frontend/src/lib/systems/api.js
@@ -147,9 +147,8 @@ export async function upgradeCharacter(id, starLevel, itemCount = 1) {
 }
 
 // Spend upgrade points on a specific stat for the given character
-export async function upgradeStat(id, points, statName = 'atk') {
-  return httpPost(`/players/${id}/upgrade-stat`, { 
-    points, 
-    stat_name: statName 
+export async function upgradeStat(id, statName) {
+  return httpPost(`/players/${id}/upgrade-stat`, {
+    stat_name: statName
   });
 }

--- a/frontend/tests/api.test.js
+++ b/frontend/tests/api.test.js
@@ -159,8 +159,17 @@ describe('api calls', () => {
   });
 
   test('upgradeStat spends points', async () => {
-    global.fetch = createFetch({ stat_upgraded: 'atk', points_spent: 1 });
-    const result = await upgradeStat('player', 1, 'atk');
+    const fetchMock = mock(async (url, options) => {
+      expect(url).toBe('http://backend.test/players/player/upgrade-stat');
+      expect(JSON.parse(options.body)).toEqual({ stat_name: 'atk' });
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ stat_upgraded: 'atk', points_spent: 1 })
+      };
+    });
+    global.fetch = fetchMock;
+    const result = await upgradeStat('player', 'atk');
     expect(result).toEqual({ stat_upgraded: 'atk', points_spent: 1 });
   });
 });


### PR DESCRIPTION
## Summary
- replace the inline character editor in the party stats panel with an upgrade summary that shows totals, remaining points, and per-stat controls backed by `/players/<id>/upgrade`
- wire the stats panel and party picker together with explicit upgrade mode events and update the API helper to let the server determine upgrade costs
- refresh the legacy upgrade panel and party UI documentation to reflect the new workflow

## Testing
- bun run lint

------
https://chatgpt.com/codex/tasks/task_b_68cbfe6ad188832cbf7ed9cffabd5b10