### PR TITLE
Add LadyLightning roster and Stormsurge passive

### DIFF
--- a/.codex/implementation/player-foe-reference.md
+++ b/.codex/implementation/player-foe-reference.md
@@ -51,6 +51,7 @@ Passives generally shouldn't be capped unless a designer explicitly specifies a 
 - **Lady Echo** (B, Lightning) – baseline fighter themed around echoes.
 - **Lady Fire and Ice** (B, Fire or Ice) – baseline fighter themed around fire and ice. Duality Engine alternates elements to build Flux and reduces foe mitigation when repeating an element.
 - **Lady Light** (B, Light) – baseline fighter themed around light.
+- **Lady Lightning** (B, Lightning) – 5★ gacha recruit whose Stormsurge stacks add +3 Speed and +5% effect hit per action, then discharge into two-turn shocks that slow foes and cut 3% effect resistance while granting her a brief attack overload.
 - **Lady of Fire** (B, Fire) – baseline fighter themed around fire.
 - **Luna** (B, Generic) – applies `luna_passive`.
 - **Mezzy** (B, random) – raises Max HP, takes less damage, and siphons stats from healthy allies each turn.

--- a/backend/plugins/passives/lady_lightning_stormsurge.py
+++ b/backend/plugins/passives/lady_lightning_stormsurge.py
@@ -1,0 +1,127 @@
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+from typing import ClassVar
+
+from autofighter.stat_effect import StatEffect
+
+if TYPE_CHECKING:
+    from autofighter.stats import Stats
+
+
+@dataclass
+class LadyLightningStormsurge:
+    """Lady Lightning's Stormsurge passive - accelerates tempo and overloads shocks."""
+
+    plugin_type = "passive"
+    id = "lady_lightning_stormsurge"
+    name = "Stormsurge"
+    trigger = ["action_taken", "hit_landed"]
+    max_stacks = 1
+    stack_display = "spinner"
+
+    _tempo_stacks: ClassVar[dict[int, int]] = {}
+    _shock_stacks: ClassVar[dict[tuple[int, int], int]] = {}
+
+    async def apply(self, target: "Stats", event: str | None = None, **kwargs) -> None:
+        """Ensure tempo tracking exists for the owning combatant."""
+
+        entity_id = id(target)
+        if entity_id not in self._tempo_stacks:
+            self._tempo_stacks[entity_id] = 0
+
+    async def on_action_taken(self, target: "Stats", **kwargs) -> None:
+        """Build tempo stacks whenever Lady Lightning acts."""
+
+        entity_id = id(target)
+        current = self._tempo_stacks.get(entity_id, 0)
+        tempo = min(current + 1, 4)
+        self._tempo_stacks[entity_id] = tempo
+
+        tempo_effect = StatEffect(
+            name=f"{self.id}_tempo",
+            stat_modifiers={
+                "spd": tempo * 3,
+                "effect_hit_rate": tempo * 0.05,
+            },
+            duration=2,
+            source=self.id,
+        )
+        target.add_effect(tempo_effect)
+
+    async def on_hit_landed(
+        self,
+        attacker: "Stats",
+        target_hit: "Stats",
+        damage: int,
+        action_type: str,
+        **kwargs,
+    ) -> None:
+        """Apply shock slow and attack overload after landing a hit."""
+
+        await self.on_hit_target(attacker, target_hit, damage=damage)
+
+    async def on_hit_target(
+        self,
+        attacker: "Stats",
+        target_hit: "Stats",
+        damage: int | None = None,
+    ) -> None:
+        if target_hit is None:
+            return
+
+        attacker_id = id(attacker)
+        tempo = self._tempo_stacks.get(attacker_id, 0)
+        if tempo <= 0:
+            return
+
+        key = (attacker_id, id(target_hit))
+        shock = min(self._shock_stacks.get(key, 0) + 1, 5)
+        self._shock_stacks[key] = shock
+
+        slow_amount = -2 * max(1, tempo)
+        resistance_penalty = -0.03 * shock
+
+        shock_effect = StatEffect(
+            name=f"{self.id}_shock_{attacker_id}",
+            stat_modifiers={
+                "spd": slow_amount,
+                "effect_resistance": resistance_penalty,
+            },
+            duration=2,
+            source=self.id,
+        )
+        target_hit.add_effect(shock_effect)
+
+        attack_bonus = int(attacker.atk * 0.04 * min(tempo, 3))
+        if attack_bonus > 0:
+            overload_effect = StatEffect(
+                name=f"{self.id}_overload",
+                stat_modifiers={"atk": attack_bonus},
+                duration=1,
+                source=self.id,
+            )
+            attacker.add_effect(overload_effect)
+
+    async def on_defeat(self, target: "Stats") -> None:
+        """Clear tempo and shock tracking when Lady Lightning is defeated."""
+
+        entity_id = id(target)
+        self._tempo_stacks.pop(entity_id, None)
+        to_delete = [key for key in self._shock_stacks if key[0] == entity_id]
+        for key in to_delete:
+            del self._shock_stacks[key]
+
+    @classmethod
+    def get_stacks(cls, target: "Stats") -> int:
+        """Expose current tempo stacks for UI display."""
+
+        return cls._tempo_stacks.get(id(target), 0)
+
+    @classmethod
+    def get_description(cls) -> str:
+        return (
+            "Acts charge up to four Stormsurge stacks, granting +3 Speed and +5% effect "
+            "hit per stack. Landing hits consumes the stored charge to inflict a "
+            "two-turn shock that slows foes and strips 3% effect resistance per stack "
+            "while briefly overloading Lady Lightning's attack."
+        )

--- a/backend/plugins/players/__init__.py
+++ b/backend/plugins/players/__init__.py
@@ -10,6 +10,7 @@ from .lady_darkness import LadyDarkness
 from .lady_echo import LadyEcho
 from .lady_fire_and_ice import LadyFireAndIce
 from .lady_light import LadyLight
+from .lady_lightning import LadyLightning
 from .lady_of_fire import LadyOfFire
 from .luna import Luna
 from .mezzy import Mezzy
@@ -29,6 +30,7 @@ __all__ = [
     "LadyEcho",
     "LadyFireAndIce",
     "LadyLight",
+    "LadyLightning",
     "LadyOfFire",
     "Luna",
     "Mezzy",

--- a/backend/plugins/players/lady_lightning.py
+++ b/backend/plugins/players/lady_lightning.py
@@ -1,0 +1,30 @@
+from dataclasses import dataclass
+from dataclasses import field
+
+from autofighter.character import CharacterType
+from plugins.damage_types._base import DamageTypeBase
+from plugins.damage_types.lightning import Lightning
+from plugins.players._base import PlayerBase
+
+
+@dataclass
+class LadyLightning(PlayerBase):
+    id = "lady_lightning"
+    name = "LadyLightning"
+    about = (
+        "An aasimar who answers to Electra—the storm-tossed twin of Lady Wind. "
+        "Though she looks about thirty, her sunburst hair is permanently "
+        "overcharged and her bright yellow eyes never stop darting. Electra broke "
+        "out of the lab that laced her nerves with conductive implants, and the "
+        "ordeal left her with disorganized thoughts, paranoia about whoever was "
+        "pulling the switches, and manic surges that collapse into exhaustion. She "
+        "insists she can hear every current humming around her, cobbling together "
+        "unstable inventions or weaponizing the sparks when cornered. Even while "
+        "certain the authorities are still hunting her, she fights beside the few "
+        "people who believe her, channeling lightning like a prophet who cannot "
+        "tell divine guidance from delusion."
+    )
+    char_type: CharacterType = CharacterType.B
+    gacha_rarity = 5
+    damage_type: DamageTypeBase = field(default_factory=Lightning)
+    passives: list[str] = field(default_factory=lambda: ["lady_lightning_stormsurge"])


### PR DESCRIPTION
## Summary
- add a LadyLightning player plugin with biography aligning with Electra's official lore, lightning typing, and 5★ gacha rarity
- implement the LadyLightningStormsurge passive that builds tempo stacks and discharges shock debuffs while cleaning up state on defeat
- register the new player in the roster and document her entry in the player/foe reference guide

## Testing
- `uv run ruff check plugins/players/lady_lightning.py plugins/passives/lady_lightning_stormsurge.py`
- `uv run pytest tests/test_gacha.py` *(fails: missing gacha ticket safeguards and upgrade_items table expectations in current branch)*

------
https://chatgpt.com/codex/tasks/task_b_68cc28cbf9dc832c9e84a689310e2168