### PR TITLE
Add LadyLightning roster and Stormsurge passive

### DIFF
--- a/backend/plugins/passives/lady_lightning_stormsurge.py
+++ b/backend/plugins/passives/lady_lightning_stormsurge.py
@@ -102,6 +102,10 @@ class LadyLightningStormsurge:
             )
             attacker.add_effect(overload_effect)
 
+        # Consuming the stored tempo charge ensures new actions are required to
+        # rebuild Stormsurge stacks, matching the passive description.
+        self._tempo_stacks[attacker_id] = 0
+
     async def on_defeat(self, target: "Stats") -> None:
         """Clear tempo and shock tracking when Lady Lightning is defeated."""
 


### PR DESCRIPTION
## Summary
- add a LadyLightning player plugin with biography aligning with Electra's official lore, lightning typing, and 5★ gacha rarity
- implement the LadyLightningStormsurge passive that builds tempo stacks and discharges shock debuffs while cleaning up state on defeat
- register the new player in the roster and document her entry in the player/foe reference guide
- reset Stormsurge tempo stacks after applying shocks so hits consume their stored charge

## Testing
- `uv run ruff check plugins/players/lady_lightning.py plugins/passives/lady_lightning_stormsurge.py`
- `uv run pytest tests/test_gacha.py` *(fails: missing gacha ticket safeguards and upgrade_items table expectations in current branch)*
- `uv run ruff check backend/plugins/passives/lady_lightning_stormsurge.py`

------
https://chatgpt.com/codex/tasks/task_b_68cc319f7e6c832cbc9b1dd036c403d6