### PR TITLE
Fix Tempest Guard gust refresh on stack consumption

### DIFF
--- a/backend/plugins/passives/lady_wind_tempest_guard.py
+++ b/backend/plugins/passives/lady_wind_tempest_guard.py
@@ -127,17 +127,27 @@ class LadyWindTempestGuard:
             # Healing is best-effort—if the battle context rejects it, continue.
             pass
 
-        self._gust_stacks[entity_id] = max(0, stacks - 1)
+        remaining = max(0, stacks - 1)
+        self._gust_stacks[entity_id] = remaining
+
+        gust_effect_name = f"{self.id}_turn_gust"
+        if remaining > 0:
+            self._apply_turn_gust(target, remaining)
+        else:
+            target.remove_effect_by_name(gust_effect_name)
 
     def _apply_turn_gust(self, target: "Stats", stacks: int) -> None:
         """Apply the turn-based gust bonus derived from accumulated stacks."""
+        gust_effect_name = f"{self.id}_turn_gust"
+        target.remove_effect_by_name(gust_effect_name)
+
         dodge_bonus = 0.03 + (stacks * 0.01)
         mitigation_bonus = 0.04 + (stacks * 0.015)
         speed_bonus = stacks * 6
         attack_bonus = max(1, int(target.atk * 0.01 * stacks))
 
         gust_effect = StatEffect(
-            name=f"{self.id}_turn_gust",
+            name=gust_effect_name,
             stat_modifiers={
                 "dodge_odds": dodge_bonus,
                 "mitigation": mitigation_bonus,


### PR DESCRIPTION
## Summary
- refresh Tempest Guard's gust effect whenever stacks are consumed mid-turn so mitigation reflects the remaining stacks
- clear the existing gust effect before recalculating bonuses to avoid inflated attack scaling when reapplying

## Testing
- uvx ruff check backend/plugins/players/lady_wind.py backend/plugins/passives/lady_wind_tempest_guard.py
- uv run --directory backend pytest tests/test_gacha.py *(fails: upgrade_items gating and pity scaling remain unresolved upstream)*

------
https://chatgpt.com/codex/tasks/task_b_68cc31f1af54832cb39075193b686637