### PR TITLE
feat: balance gacha banner rotation

### DIFF
--- a/backend/.codex/implementation/gacha-endpoint.md
+++ b/backend/.codex/implementation/gacha-endpoint.md
@@ -15,5 +15,11 @@ Exposes gacha pulls and state through Quart.
   element. It accepts `{ "enabled": true | false }` and returns the updated
   flag.
 
+## Banner rotation
+- Two rotating `custom` banners operate on a three-day cadence. Each cycle
+  selects one featured character from the owned pool and one from the unowned
+  pool when both buckets contain options, avoiding duplicate assignments unless
+  no other choices remain.
+
 ## Testing
 - `uv run pytest tests/test_gacha.py`


### PR DESCRIPTION
## Summary
- ensure gacha banner creation splits featured pools into owned and unowned buckets and assigns one of each to custom banners
- update banner rotation updates to respect owned/unowned pools while avoiding duplicate feature assignments
- cover the new rotation behavior with banner rotation tests and document the cadence in the gacha endpoint notes

## Testing
- uv run pytest tests/test_gacha.py

------
https://chatgpt.com/codex/tasks/task_b_68cc3796fb6c832ca1ad60e858d90cf8