### PR TITLE
Add warp info overlay for pulls menu

### DIFF
--- a/frontend/src/lib/components/OverlayHost.svelte
+++ b/frontend/src/lib/components/OverlayHost.svelte
@@ -239,6 +239,36 @@
   </OverlaySurface>
 {/if}
 
+{#if $overlayView === 'warp-info'}
+  <OverlaySurface zIndex={1350}>
+    <PopupWindow
+      title="Warp Mechanics"
+      maxWidth="640px"
+      zIndex={1350}
+      on:close={() => dispatch('back')}
+    >
+      <div class="warp-info-body">
+        <p>
+          Warps spend gacha tickets to roll from the current banner. Each pull advances pity,
+          steadily improving the odds of 5★ and 6★ rewards until a top rarity is found.
+        </p>
+        <ul class="warp-info-list">
+          <li>Single pulls cost 1 ticket, while ×5 and ×10 options spend 5 or 10 at once.</li>
+          <li>Pity carries across banners of the same type and resets only after a 6★ reward.</li>
+          <li>Duplicate characters grant upgrade materials instead of extra copies.</li>
+        </ul>
+        <p class="warp-info-note">
+          Tip: Saving up for larger batches guarantees the animation plays once per session while still
+          honoring your current pity level.
+        </p>
+        <div class="stained-glass-row" style="justify-content: flex-end; margin-top: 0.75rem;">
+          <button class="icon-btn" on:click={() => dispatch('back')}>Back to pulls</button>
+        </div>
+      </div>
+    </PopupWindow>
+  </OverlaySurface>
+{/if}
+
   {#if $overlayView === 'pull-results'}
   <OverlaySurface zIndex={1400}>
     <PullResultsOverlay {sfxVolume} results={$overlayData.results || []} on:close={() => dispatch('back')} />
@@ -390,6 +420,27 @@
 {/each}
 
 <style>
+  .warp-info-body {
+    padding: 0.5rem 0.25rem;
+    line-height: 1.5;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+
+  .warp-info-list {
+    margin: 0;
+    padding-left: 1.2rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+  }
+
+  .warp-info-note {
+    font-size: 0.9rem;
+    color: rgba(255,255,255,0.75);
+  }
+
   .overlay-inset {
     position: absolute;
     inset: 0;

--- a/frontend/src/lib/components/PullsMenu.svelte
+++ b/frontend/src/lib/components/PullsMenu.svelte
@@ -1,7 +1,7 @@
 <script>
   import { onMount } from 'svelte';
   import { createEventDispatcher } from 'svelte';
-  import { PackageOpen, Star, Users, RotateCcw } from 'lucide-svelte';
+  import { PackageOpen, Star, Users, RotateCcw, Info } from 'lucide-svelte';
   import MenuPanel from './MenuPanel.svelte';
   import { getGacha, pullGacha } from '../systems/api.js';
   import { browser, dev } from '$app/environment';
@@ -200,6 +200,16 @@
     </div>
     
     <div class="header-actions">
+      <button
+        class="info-btn"
+        type="button"
+        aria-label="Warp info"
+        title="Warp info"
+        on:click={() => openOverlay('warp-info')}
+      >
+        <svelte:component this={Info} size={16} aria-hidden="true" />
+        <span class="info-label">Info</span>
+      </button>
       <button class="reload-btn" on:click={reloadData} disabled={loading}>
         <svelte:component this={RotateCcw} size={16} />
         Refresh
@@ -357,7 +367,7 @@
     gap: 0.75rem;
   }
 
-  .reload-btn {
+  .header-actions button {
     display: inline-flex;
     align-items: center;
     gap: 0.35rem;
@@ -370,14 +380,22 @@
     font-size: 0.9rem;
   }
 
-  .reload-btn:hover {
+  .header-actions button:hover {
     background: rgba(255,255,255,0.15);
     border-color: rgba(120,180,255,0.5);
   }
 
-  .reload-btn:disabled {
+  .header-actions button:disabled {
     opacity: 0.5;
     cursor: not-allowed;
+  }
+
+  .info-btn {
+    border-radius: 6px;
+  }
+
+  .info-label {
+    font-weight: 500;
   }
 
   /* Content area */

--- a/frontend/tests/pullsmenu.test.js
+++ b/frontend/tests/pullsmenu.test.js
@@ -35,4 +35,28 @@ describe('PullsMenu component', () => {
     expect(content).toMatch(/async function reloadData[\s\S]*ensureActiveTabValid\(\)/);
     expect(content).toMatch(/async function pull\([^)]*\)[\s\S]*ensureActiveTabValid\(\)/);
   });
+
+  test('exposes warp info control with accessible label', () => {
+    const content = readFileSync(
+      join(import.meta.dir, '../src/lib/components/PullsMenu.svelte'),
+      'utf8'
+    );
+    expect(content).toContain("import { PackageOpen, Star, Users, RotateCcw, Info }");
+    expect(content).toContain('aria-label="Warp info"');
+    expect(content).toContain("on:click={() => openOverlay('warp-info')}");
+    expect(content).toContain('<span class="info-label">Info</span>');
+  });
+});
+
+describe('OverlayHost warp info overlay', () => {
+  test('ships warp info popup with explanatory text', () => {
+    const overlayHost = readFileSync(
+      join(import.meta.dir, '../src/lib/components/OverlayHost.svelte'),
+      'utf8'
+    );
+    expect(overlayHost).toContain("$overlayView === 'warp-info'");
+    expect(overlayHost).toContain('title="Warp Mechanics"');
+    expect(overlayHost).toContain('warp-info-list');
+    expect(overlayHost).toContain('Back to pulls');
+  });
 });


### PR DESCRIPTION
## Summary
- add an accessible warp info button to the pulls menu header
- introduce a warp mechanics popup overlay including descriptive copy and styles
- extend pullsmenu tests to cover the new control and overlay markup

## Testing
- bun test tests/pullsmenu.test.js
- bun test *(fails: stat-tabs-persistence expectations are not met in current tree)*

------
https://chatgpt.com/codex/tasks/task_b_68cc3d298d18832c8993ddf49eb94ae8