### PR TITLE
Sync party upgrade data and conversion UI

### DIFF
--- a/frontend/src/lib/components/PartyPicker.svelte
+++ b/frontend/src/lib/components/PartyPicker.svelte
@@ -56,11 +56,11 @@
     if (previewId) refreshUpgradeData(previewId, { force: true });
     try { dispatch('previewMode', { mode: 'portrait', id: previewId ?? null }); } catch {}
   }
-  $: previewUpgradeState = readUpgradeState(previewId);
+  $: previewUpgradeState = readUpgradeState(previewId, upgradeCache);
 
-  function readUpgradeState(id) {
+  function readUpgradeState(id, cache = upgradeCache) {
     const key = id == null ? null : String(id);
-    return key && upgradeCache[key] ? upgradeCache[key] : EMPTY_UPGRADE_STATE;
+    return key && cache[key] ? cache[key] : EMPTY_UPGRADE_STATE;
   }
 
   async function refreshUpgradeData(id, { force = false } = {}) {


### PR DESCRIPTION
## Summary
- cache per-character upgrade info in PartyPicker and refresh it after stat or item conversions
- extend PlayerPreview with live upgrade summaries and item-to-point conversion controls that respect pending actions
- share upgrade formatting helpers via a new utility module and reuse them in the existing upgrade panel
- ensure the player preview reacts to upgrade cache refreshes so fetched totals appear in the UI

## Testing
- bun run lint *(fails: Script not found "lint")*

------
https://chatgpt.com/codex/tasks/task_b_68cc3fc51090832c8952af637f21f128