### PR TITLE
feat: persist floor boss selection

### DIFF
--- a/backend/autofighter/rooms/__init__.py
+++ b/backend/autofighter/rooms/__init__.py
@@ -23,6 +23,7 @@ from .battle.enrage import ENRAGE_TURNS_NORMAL  # noqa: E402
 from .boss import BossRoom  # noqa: E402
 from .chat import ChatRoom  # noqa: E402
 from .shop import ShopRoom  # noqa: E402
+from .utils import calculate_rank_probabilities  # noqa: E402
 from .utils import _build_foes  # noqa: E402
 from .utils import _choose_foe  # noqa: E402
 from .utils import _scale_stats  # noqa: E402
@@ -40,4 +41,5 @@ __all__ = [
     '_choose_foe',
     '_scale_stats',
     '_serialize',
+    'calculate_rank_probabilities',
 ]

--- a/backend/autofighter/rooms/utils.py
+++ b/backend/autofighter/rooms/utils.py
@@ -4,6 +4,7 @@ from dataclasses import fields
 import math
 import random
 from typing import Any
+from typing import Collection
 
 from plugins import foes as foe_plugins
 from plugins import players as player_plugins
@@ -468,7 +469,12 @@ def _choose_foe(party: Party) -> FoeBase:
     return foe_cls()
 
 
-def _build_foes(node: MapNode, party: Party) -> list[FoeBase]:
+def _build_foes(
+    node: MapNode,
+    party: Party,
+    *,
+    exclude_ids: Collection[str] | None = None,
+) -> list[FoeBase]:
     """Build a list of foes for the given room node.
 
     Ensures no duplicate foe IDs within a single encounter. If the available
@@ -496,6 +502,8 @@ def _build_foes(node: MapNode, party: Party) -> list[FoeBase]:
 
     # Build a candidate pool of foe classes that are not members of the party
     party_ids = {p.id for p in party.members}
+    if exclude_ids:
+        party_ids.update(eid for eid in exclude_ids if eid)
     candidates: list[type[FoeBase]] = []
     try:
         for name in getattr(foe_plugins, "__all__", []):

--- a/backend/services/room_service.py
+++ b/backend/services/room_service.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 import copy
-from types import SimpleNamespace
 from typing import Any
 
 from battle_logging.writers import get_current_run_logger
@@ -208,19 +207,12 @@ async def battle_room(run_id: str, data: dict[str, Any]) -> dict[str, Any]:
         await asyncio.to_thread(save_map, run_id, state)
         room = BattleRoom(node)
         boss_info = state.get("floor_boss")
-        build_party = party
+        exclude_ids = None
         if _boss_matches_node(boss_info, node):
             boss_id = boss_info.get("id") if isinstance(boss_info, dict) else None
             if boss_id:
-                dummy = SimpleNamespace(id=boss_id)
-                build_party = Party(
-                    members=[*party.members, dummy],
-                    gold=party.gold,
-                    relics=party.relics,
-                    cards=party.cards,
-                    rdr=party.rdr,
-                )
-        foes = _build_foes(node, build_party)
+                exclude_ids = {boss_id}
+        foes = _build_foes(node, party, exclude_ids=exclude_ids)
         for f in foes:
             _scale_stats(f, node, room.strength)
         combat_party = Party(

--- a/backend/tests/test_boss_room_single_foe.py
+++ b/backend/tests/test_boss_room_single_foe.py
@@ -32,5 +32,5 @@ def test_boss_rooms_spawn_one_foe(size: int, pressure: int) -> None:
     node = _make_node(pressure)
     foes = utils._build_foes(node, party)
     assert len(foes) == 1
-    assert foes[0].rank == "boss"
+    assert foes[0].rank in {"boss", "prime boss", "glitched boss", "glitched prime boss"}
 

--- a/backend/tests/test_floor_boss_rotation.py
+++ b/backend/tests/test_floor_boss_rotation.py
@@ -1,0 +1,57 @@
+import asyncio
+from pathlib import Path
+import sys
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))  # noqa: E402
+
+from runs.lifecycle import load_map  # noqa: E402
+from runs.lifecycle import save_map  # noqa: E402
+from services.run_service import advance_room  # noqa: E402
+from services.run_service import start_run  # noqa: E402
+from test_app import app_with_db as _app_with_db  # noqa: F401
+
+app_with_db = _app_with_db
+
+
+class DummyFoe:
+    def __init__(self, ident: str) -> None:
+        self.id = ident
+        self.name = ident
+        self.rank = "boss"
+
+
+@pytest.mark.asyncio
+async def test_floor_boss_refreshes_per_floor(app_with_db, monkeypatch):
+    _, _ = app_with_db
+
+    picks: list[str] = []
+
+    def choose_once(party):  # noqa: ANN001
+        ident = f"boss-{len(picks)}"
+        picks.append(ident)
+        return DummyFoe(ident)
+
+    monkeypatch.setattr("services.run_service._choose_foe", choose_once)
+    monkeypatch.setattr("services.room_service._choose_foe", choose_once)
+
+    run_info = await start_run(["player"])
+    run_id = run_info["run_id"]
+    first_record = run_info["map"].get("floor_boss")
+    assert first_record is not None
+    assert first_record["id"] == "boss-0"
+
+    state, rooms = await asyncio.to_thread(load_map, run_id)
+    state["current"] = len(rooms) - 1
+    state["awaiting_next"] = False
+    await asyncio.to_thread(save_map, run_id, state)
+
+    await advance_room(run_id)
+
+    updated_state, _ = await asyncio.to_thread(load_map, run_id)
+    refreshed = updated_state.get("floor_boss")
+    assert refreshed is not None
+    assert refreshed["id"] == "boss-1"
+    assert refreshed["id"] != first_record["id"]
+    assert len(picks) == 2

--- a/backend/tests/test_rank_progression.py
+++ b/backend/tests/test_rank_progression.py
@@ -1,0 +1,101 @@
+import importlib.util
+from pathlib import Path
+import random
+import sys
+import types
+
+import pytest
+
+sys.modules.setdefault("llms.torch_checker", types.SimpleNamespace(is_torch_available=lambda: False))
+
+from autofighter.mapgen import MapNode
+from autofighter.party import Party
+from plugins.players import Player
+
+spec = importlib.util.spec_from_file_location(
+    "autofighter.rooms.utils",
+    Path(__file__).resolve().parents[1] / "autofighter/rooms/utils.py",
+)
+assert spec.loader is not None
+utils = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(utils)
+
+
+def _make_party(size: int = 1) -> Party:
+    return Party(members=[Player() for _ in range(size)])
+
+
+def _make_node(room_type: str = "battle-normal", pressure: int = 0) -> MapNode:
+    return MapNode(
+        room_id=0,
+        room_type=room_type,
+        floor=1,
+        index=1,
+        loop=1,
+        pressure=pressure,
+    )
+
+
+def test_rank_probability_progression_scaling() -> None:
+    base = utils.calculate_rank_probabilities(0, 0, 0)
+    assert base == (0.0, 0.0)
+
+    mid = utils.calculate_rank_probabilities(500, 1, 0)
+    assert mid == pytest.approx((0.001, 0.001))
+
+    pressure_boost = utils.calculate_rank_probabilities(100, 0, 2)
+    assert pressure_boost == pytest.approx((0.0201, 0.0201))
+
+    capped = utils.calculate_rank_probabilities(2_000_000, 3, 10)
+    assert capped == (1.0, 1.0)
+
+
+def test_build_foes_prime_with_seed(monkeypatch) -> None:
+    party = _make_party()
+    node = _make_node(pressure=0)
+    progression = {
+        "total_rooms_cleared": 2_000,
+        "floors_cleared": 1,
+        "current_pressure": 1,
+    }
+
+    rng = random.Random(15)
+    monkeypatch.setattr(utils, "random", rng)
+
+    foes = utils._build_foes(node, party, progression=progression)
+    assert foes
+    assert foes[0].rank == "prime"
+
+
+def test_build_foes_glitched_with_seed(monkeypatch) -> None:
+    party = _make_party()
+    node = _make_node(pressure=0)
+    progression = {
+        "total_rooms_cleared": 2_000,
+        "floors_cleared": 1,
+        "current_pressure": 1,
+    }
+
+    rng = random.Random(71)
+    monkeypatch.setattr(utils, "random", rng)
+
+    foes = utils._build_foes(node, party, progression=progression)
+    assert foes
+    assert foes[0].rank == "glitched"
+
+
+def test_build_foes_glitched_prime_high_progression(monkeypatch) -> None:
+    party = _make_party(3)
+    node = _make_node(pressure=0)
+    progression = {
+        "total_rooms_cleared": 1_000_000,
+        "floors_cleared": 5,
+        "current_pressure": 10,
+    }
+
+    rng = random.Random(123)
+    monkeypatch.setattr(utils, "random", rng)
+
+    foes = utils._build_foes(node, party, progression=progression)
+    assert foes
+    assert all(foe.rank == "glitched prime" for foe in foes)

--- a/backend/tests/test_recent_foe_cooldown.py
+++ b/backend/tests/test_recent_foe_cooldown.py
@@ -1,0 +1,174 @@
+import asyncio
+import importlib.util
+from pathlib import Path
+import random
+import sys
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from runs.lifecycle import RECENT_FOE_COOLDOWN
+from runs.lifecycle import battle_snapshots
+from runs.lifecycle import battle_tasks
+from runs.lifecycle import load_map
+from runs.lifecycle import save_map
+from services.room_service import battle_room
+from services.run_service import start_run
+
+from autofighter.mapgen import MapNode
+from autofighter.party import Party
+from autofighter.rooms import BattleRoom
+from autofighter.rooms import utils
+from autofighter.stats import Stats
+from plugins.players import Player
+
+
+@pytest.fixture()
+def app_module(tmp_path, monkeypatch):
+    db_path = tmp_path / "save.db"
+    monkeypatch.setenv("AF_DB_PATH", str(db_path))
+    monkeypatch.setenv("AF_DB_KEY", "testkey")
+    monkeypatch.syspath_prepend(Path(__file__).resolve().parents[1])
+    spec = importlib.util.spec_from_file_location(
+        "app", Path(__file__).resolve().parents[1] / "app.py",
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_build_foes_reduces_recent_weights(monkeypatch):
+    class FakeFoeA:
+        id = "alpha"
+
+        def __init__(self):
+            self.id = "alpha"
+
+    class FakeFoeB:
+        id = "beta"
+
+        def __init__(self):
+            self.id = "beta"
+
+    monkeypatch.setattr("plugins.foes.__all__", ["FakeFoeA", "FakeFoeB"], raising=False)
+    monkeypatch.setattr("plugins.foes.FakeFoeA", FakeFoeA, raising=False)
+    monkeypatch.setattr("plugins.foes.FakeFoeB", FakeFoeB, raising=False)
+    monkeypatch.setattr("plugins.foes.Slime", FakeFoeB, raising=False)
+    monkeypatch.setattr("plugins.foes.PLAYER_FOES", {}, raising=False)
+
+    captured_weights: list[list[float]] = []
+
+    def fake_choices(candidates, weights, k):
+        captured_weights.append(list(weights))
+        return [candidates[0]]
+
+    monkeypatch.setattr(random, "random", lambda: 0.99)
+    monkeypatch.setattr(random, "choices", fake_choices)
+
+    node = MapNode(room_id=0, room_type="battle-normal", floor=1, index=1, loop=1, pressure=0)
+    party = Party(members=[Player()])
+
+    utils._build_foes(node, party, recent_ids={"alpha"})
+
+    assert captured_weights, "random.choices should be invoked"
+    weights = captured_weights[0]
+    assert weights[0] < weights[1]
+    assert weights[0] > 0
+
+
+@pytest.mark.asyncio
+async def test_battle_room_passes_recent_ids(app_module, monkeypatch):
+    run_info = await start_run(["player"])
+    run_id = run_info["run_id"]
+
+    state, _ = await asyncio.to_thread(load_map, run_id)
+    state["recent_foes"] = [
+        {"id": "stale", "cooldown": 0},
+        {"id": "keep", "cooldown": 2},
+        {"id": None, "cooldown": 5},
+    ]
+    await asyncio.to_thread(save_map, run_id, state)
+
+    captured_recent: set[str] | None = None
+
+    def fake_build(node, party, *, exclude_ids=None, recent_ids=None):
+        nonlocal captured_recent
+        captured_recent = {str(r) for r in (recent_ids or set())}
+        foe = Stats()
+        foe.id = "dummy"
+        return [foe]
+
+    async def fake_run_battle(run_id_param, room, foes, party, data, state_param, rooms_param, progress):
+        battle_snapshots[run_id_param] = {"result": "battle", "ended": True}
+
+    monkeypatch.setattr("services.room_service._build_foes", fake_build)
+    monkeypatch.setattr("services.room_service._run_battle", fake_run_battle)
+    monkeypatch.setattr("services.room_service._scale_stats", lambda foe, node, strength: None)
+
+    await battle_room(run_id, {})
+
+    task = battle_tasks.pop(run_id, None)
+    if task is not None:
+        await task
+
+    assert captured_recent == {"keep"}
+
+    state_after, _ = await asyncio.to_thread(load_map, run_id)
+    assert state_after.get("recent_foes") == [{"id": "keep", "cooldown": 2}]
+
+
+@pytest.mark.asyncio
+async def test_run_battle_updates_recent_foe_cooldowns(app_module, monkeypatch):
+    run_info = await start_run(["player"])
+    run_id = run_info["run_id"]
+
+    state, _ = await asyncio.to_thread(load_map, run_id)
+    state["recent_foes"] = [
+        {"id": "gamma", "cooldown": 2},
+        {"id": "alpha", "cooldown": 1},
+        {"id": "stale", "cooldown": 0},
+    ]
+    await asyncio.to_thread(save_map, run_id, state)
+
+    battle_result = {
+        "result": "battle",
+        "loot": {"items": [], "gold": 0},
+        "card_choices": [],
+        "relic_choices": [],
+        "foes": [{"id": "alpha"}, {"id": "beta"}],
+        "foe_summons": {},
+        "party": [],
+        "party_summons": {},
+        "gold": 0,
+        "relics": [],
+        "cards": [],
+        "enrage": {"active": False, "stacks": 0},
+        "rdr": 0,
+        "action_queue": {},
+        "ended": True,
+    }
+
+    async def fake_resolve(self, party, data, progress, foes, run_id=None):
+        return {
+            **battle_result,
+            "foes": [dict(entry) for entry in battle_result["foes"]],
+        }
+
+    monkeypatch.setattr(BattleRoom, "resolve", fake_resolve)
+
+    await battle_room(run_id, {})
+
+    task = battle_tasks.get(run_id)
+    if task is not None:
+        await task
+    else:
+        await asyncio.sleep(0)
+
+    state_after, _ = await asyncio.to_thread(load_map, run_id)
+    assert state_after.get("recent_foes") == [
+        {"id": "gamma", "cooldown": 1},
+        {"id": "alpha", "cooldown": RECENT_FOE_COOLDOWN},
+        {"id": "beta", "cooldown": RECENT_FOE_COOLDOWN},
+    ]

--- a/frontend/.codex/implementation/battle-review-ui.md
+++ b/frontend/.codex/implementation/battle-review-ui.md
@@ -3,7 +3,7 @@
 The Battle Review interface uses a vertical icon column and a persistent side panel:
 
 - Navigation icons appear in a left-side column. The overview uses a Swords icon, while party and foe entries show their portraits.
-- Foe tabs append the foe's rank after its name using an em dash (e.g., `Slime — Prime`).
+- Foe tabs keep the label to the foe's name; rank badges render inside the portrait via `LegacyFighterPortrait` while the tab's aria-label still includes the rank for screen readers.
 - Selecting an icon swaps the main content without hiding statistics; the right-side stats panel updates for the active entry.
 - `.battle-review-tabs` arranges three columns: `icon-column`, `content-area`, and `stats-panel`.
 - `.icon-btn` provides a square click target with hover and active states.

--- a/frontend/.codex/implementation/rank-badges.md
+++ b/frontend/.codex/implementation/rank-badges.md
@@ -1,29 +1,33 @@
-# Rank Badge Plan
+# Rank Badge Implementation
 
-Fighter portraits now accept an optional `rankTag` property reserved for future badge rendering. The component currently ignores the tag until a design is finalized.
+Rank badges are rendered by `src/lib/battle/RankBadge.svelte`. The component consumes a rank string and maps it through `rankStyles.js` to produce a themed overlay that can be reused anywhere a fighter portrait is rendered.
 
-## Badge Tiers
-- Bronze `#cd7f32`
-- Silver `#c0c0c0`
-- Gold `#ffd700`
-- Platinum `#e5e4e2`
-- Diamond `#b9f2ff`
+## Rank Mapping
 
-## Backend Rank Mapping
-| Backend Rank   | Badge Tier | Notes |
-|---------------|------------|-------|
-| `normal`      | Bronze     | |
-| `prime`       | Silver     | |
-| `boss`        | Platinum   | |
-| `glitched prime` | Gold     | Glitchy outline effect |
-| `glitched boss`  | Diamond  | Glitchy outline effect |
+`rankStyles.js` normalises backend rank strings to the following presets:
 
-## Badge Style
-- Small circular badge overlay anchored to a portrait corner.
-- Star icons for Bronze through Gold.
-- Laurel wreath for Platinum.
-- Diamond glyph for Diamond tier.
-- Subtle drop shadow to distinguish from the portrait.
-- Glitched ranks reuse the same tier color but add a jittering, glitchy outline.
+| Backend Rank        | Tier      | Icon | Notes |
+|---------------------|-----------|------|-------|
+| `prime`             | Silver    | ★    | Standard Prime foes |
+| `glitched prime`    | Gold      | ★    | Adds the animated glitch halo |
+| `boss`              | Platinum  | ♛    | Laurel-inspired glyph |
+| `glitched boss`     | Diamond   | ◆    | Platinum styling plus glitch halo |
 
-These guidelines outline future UI work for rank badges.
+Unknown ranks fall back to a bronze star with a short, auto-generated label. Common ranks such as `normal` are ignored so they do not clutter the UI.
+
+## Component Behaviour
+
+- The badge renders as a circular overlay with `role="img"` and an accessible `aria-label`.
+- Glitched ranks layer the provided glitch animation colours on top of the icon, inspired by the CSS reference shared with the task request.
+- `size` and `className` props allow parents to anchor the badge wherever they need it; both fighter cards and review portraits position it in the upper-left corner.
+- Styling tokens (`data-rank`, `data-rank-tier`, `is-glitched`) are exposed so tests and future stylesheets can key off the active rank.
+
+## Integration Points
+
+- `BattleFighterCard.svelte` now drops a `RankBadge` into each combat card, reading the rank directly from `fighter.rank`.
+- `LegacyFighterPortrait.svelte` accepts a `rankTag` override so review tabs can show badges even when tab labels omit the rank text.
+- `BattleReview.svelte` stores the foe rank alongside tab metadata and forwards it into `LegacyFighterPortrait` for both the icon column and the detailed breakdown portrait.
+
+## Tests
+
+`tests/rank-badges.vitest.js` renders Prime, Glitched Prime, and Boss foes through `BattleFighterCard` to ensure the corresponding badges and glitch state are present. The suite runs via Vitest (`bun x vitest run --config vitest.config.js`) and relies on lightweight mocks for `assetLoader`.

--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -21,6 +21,7 @@
         "svelte": "^5.0.0",
         "vite": "^7.0.4",
         "vite-plugin-static-copy": "^3.1.2",
+        "vitest": "^2.1.4",
       },
     },
   },
@@ -197,6 +198,20 @@
 
     "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
 
+    "@vitest/expect": ["@vitest/expect@2.1.9", "", { "dependencies": { "@vitest/spy": "2.1.9", "@vitest/utils": "2.1.9", "chai": "^5.1.2", "tinyrainbow": "^1.2.0" } }, "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw=="],
+
+    "@vitest/mocker": ["@vitest/mocker@2.1.9", "", { "dependencies": { "@vitest/spy": "2.1.9", "estree-walker": "^3.0.3", "magic-string": "^0.30.12" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^5.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg=="],
+
+    "@vitest/pretty-format": ["@vitest/pretty-format@2.1.9", "", { "dependencies": { "tinyrainbow": "^1.2.0" } }, "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ=="],
+
+    "@vitest/runner": ["@vitest/runner@2.1.9", "", { "dependencies": { "@vitest/utils": "2.1.9", "pathe": "^1.1.2" } }, "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g=="],
+
+    "@vitest/snapshot": ["@vitest/snapshot@2.1.9", "", { "dependencies": { "@vitest/pretty-format": "2.1.9", "magic-string": "^0.30.12", "pathe": "^1.1.2" } }, "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ=="],
+
+    "@vitest/spy": ["@vitest/spy@2.1.9", "", { "dependencies": { "tinyspy": "^3.0.2" } }, "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ=="],
+
+    "@vitest/utils": ["@vitest/utils@2.1.9", "", { "dependencies": { "@vitest/pretty-format": "2.1.9", "loupe": "^3.1.2", "tinyrainbow": "^1.2.0" } }, "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ=="],
+
     "@zaniar/effekseer-webgl-wasm": ["@zaniar/effekseer-webgl-wasm@1.62.5000", "", {}, "sha512-+oXXo7BmjA9qv4YcJIAHLZR3NB7Zk24ROimbsZ7ss+k9Y6/QJr4b0Rcdp2aPCGzOsU7RcG01TrUV/bYzVOm/XA=="],
 
     "acorn": ["acorn@8.15.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg=="],
@@ -217,6 +232,8 @@
 
     "aria-query": ["aria-query@5.3.2", "", {}, "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw=="],
 
+    "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
+
     "axobject-query": ["axobject-query@4.1.0", "", {}, "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ=="],
 
     "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
@@ -227,9 +244,15 @@
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
+    "cac": ["cac@6.7.14", "", {}, "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ=="],
+
     "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
 
+    "chai": ["chai@5.3.3", "", { "dependencies": { "assertion-error": "^2.0.1", "check-error": "^2.1.1", "deep-eql": "^5.0.1", "loupe": "^3.1.0", "pathval": "^2.0.0" } }, "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw=="],
+
     "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
+
+    "check-error": ["check-error@2.1.1", "", {}, "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw=="],
 
     "chokidar": ["chokidar@3.6.0", "", { "dependencies": { "anymatch": "~3.1.2", "braces": "~3.0.2", "glob-parent": "~5.1.2", "is-binary-path": "~2.1.0", "is-glob": "~4.0.1", "normalize-path": "~3.0.0", "readdirp": "~3.6.0" }, "optionalDependencies": { "fsevents": "~2.3.2" } }, "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw=="],
 
@@ -253,6 +276,8 @@
 
     "decimal.js": ["decimal.js@10.6.0", "", {}, "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg=="],
 
+    "deep-eql": ["deep-eql@5.0.2", "", {}, "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q=="],
+
     "deep-is": ["deep-is@0.1.4", "", {}, "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="],
 
     "deepmerge": ["deepmerge@4.3.1", "", {}, "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A=="],
@@ -264,6 +289,8 @@
     "dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
 
     "entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
+
+    "es-module-lexer": ["es-module-lexer@1.7.0", "", {}, "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA=="],
 
     "esbuild": ["esbuild@0.25.8", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.8", "@esbuild/android-arm": "0.25.8", "@esbuild/android-arm64": "0.25.8", "@esbuild/android-x64": "0.25.8", "@esbuild/darwin-arm64": "0.25.8", "@esbuild/darwin-x64": "0.25.8", "@esbuild/freebsd-arm64": "0.25.8", "@esbuild/freebsd-x64": "0.25.8", "@esbuild/linux-arm": "0.25.8", "@esbuild/linux-arm64": "0.25.8", "@esbuild/linux-ia32": "0.25.8", "@esbuild/linux-loong64": "0.25.8", "@esbuild/linux-mips64el": "0.25.8", "@esbuild/linux-ppc64": "0.25.8", "@esbuild/linux-riscv64": "0.25.8", "@esbuild/linux-s390x": "0.25.8", "@esbuild/linux-x64": "0.25.8", "@esbuild/netbsd-arm64": "0.25.8", "@esbuild/netbsd-x64": "0.25.8", "@esbuild/openbsd-arm64": "0.25.8", "@esbuild/openbsd-x64": "0.25.8", "@esbuild/openharmony-arm64": "0.25.8", "@esbuild/sunos-x64": "0.25.8", "@esbuild/win32-arm64": "0.25.8", "@esbuild/win32-ia32": "0.25.8", "@esbuild/win32-x64": "0.25.8" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-vVC0USHGtMi8+R4Kz8rt6JhEWLxsv9Rnu/lGYbPR8u47B+DCBksq9JarW0zOO7bs37hyOK1l2/oqtbciutL5+Q=="],
 
@@ -287,7 +314,11 @@
 
     "estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
 
+    "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
+
     "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
+
+    "expect-type": ["expect-type@1.2.2", "", {}, "sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA=="],
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
@@ -375,6 +406,8 @@
 
     "lodash.merge": ["lodash.merge@4.6.2", "", {}, "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="],
 
+    "loupe": ["loupe@3.2.1", "", {}, "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ=="],
+
     "lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
     "lucide-svelte": ["lucide-svelte@0.539.0", "", { "peerDependencies": { "svelte": "^3 || ^4 || ^5.0.0-next.42" } }, "sha512-p4k3GOje/9Si1eIkg1W1OQUhozeja5Ka5shjVpfyP5X2ye+B7sfyMnX3d5D2et+MYJwUFGrMna5MIYgq6bLfqw=="],
@@ -415,6 +448,10 @@
 
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
 
+    "pathe": ["pathe@1.1.2", "", {}, "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ=="],
+
+    "pathval": ["pathval@2.0.1", "", {}, "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ=="],
+
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
     "picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
@@ -449,9 +486,15 @@
 
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
 
+    "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
+
     "sirv": ["sirv@3.0.1", "", { "dependencies": { "@polka/url": "^1.0.0-next.24", "mrmime": "^2.0.0", "totalist": "^3.0.0" } }, "sha512-FoqMu0NCGBLCcAkS1qA+XJIQTR6/JHfQXl+uGteNCQ76T91DMUjPa9xfmeqMY3z80nLSg9yQmNjK0Px6RWsH/A=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
+
+    "std-env": ["std-env@3.9.0", "", {}, "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw=="],
 
     "strip-json-comments": ["strip-json-comments@3.1.1", "", {}, "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="],
 
@@ -461,7 +504,17 @@
 
     "symbol-tree": ["symbol-tree@3.2.4", "", {}, "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="],
 
+    "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
+
+    "tinyexec": ["tinyexec@0.3.2", "", {}, "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA=="],
+
     "tinyglobby": ["tinyglobby@0.2.14", "", { "dependencies": { "fdir": "^6.4.4", "picomatch": "^4.0.2" } }, "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ=="],
+
+    "tinypool": ["tinypool@1.1.1", "", {}, "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg=="],
+
+    "tinyrainbow": ["tinyrainbow@1.2.0", "", {}, "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ=="],
+
+    "tinyspy": ["tinyspy@3.0.2", "", {}, "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q=="],
 
     "tldts": ["tldts@6.1.86", "", { "dependencies": { "tldts-core": "^6.1.86" }, "bin": { "tldts": "bin/cli.js" } }, "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ=="],
 
@@ -483,9 +536,13 @@
 
     "vite": ["vite@7.1.1", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.4.6", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.14" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-yJ+Mp7OyV+4S+afWo+QyoL9jFWD11QFH0i5i7JypnfTcA1rmgxCbiA8WwAICDEtZ1Z1hzrVhN8R8rGTqkTY8ZQ=="],
 
+    "vite-node": ["vite-node@2.1.9", "", { "dependencies": { "cac": "^6.7.14", "debug": "^4.3.7", "es-module-lexer": "^1.5.4", "pathe": "^1.1.2", "vite": "^5.0.0" }, "bin": { "vite-node": "vite-node.mjs" } }, "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA=="],
+
     "vite-plugin-static-copy": ["vite-plugin-static-copy@3.1.2", "", { "dependencies": { "chokidar": "^3.6.0", "fs-extra": "^11.3.0", "p-map": "^7.0.3", "picocolors": "^1.1.1", "tinyglobby": "^0.2.14" }, "peerDependencies": { "vite": "^5.0.0 || ^6.0.0 || ^7.0.0" } }, "sha512-aVmYOzptLVOI2b1jL+cmkF7O6uhRv1u5fvOkQgbohWZp2CbR22kn9ZqkCUIt9umKF7UhdbsEpshn1rf4720QFg=="],
 
     "vitefu": ["vitefu@1.1.1", "", { "peerDependencies": { "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0-beta.0" }, "optionalPeers": ["vite"] }, "sha512-B/Fegf3i8zh0yFbpzZ21amWzHmuNlLlmJT6n7bu5e+pCHUKQIfXSYokrqOBGEMMe9UG2sostKQF9mml/vYaWJQ=="],
+
+    "vitest": ["vitest@2.1.9", "", { "dependencies": { "@vitest/expect": "2.1.9", "@vitest/mocker": "2.1.9", "@vitest/pretty-format": "^2.1.9", "@vitest/runner": "2.1.9", "@vitest/snapshot": "2.1.9", "@vitest/spy": "2.1.9", "@vitest/utils": "2.1.9", "chai": "^5.1.2", "debug": "^4.3.7", "expect-type": "^1.1.0", "magic-string": "^0.30.12", "pathe": "^1.1.2", "std-env": "^3.8.0", "tinybench": "^2.9.0", "tinyexec": "^0.3.1", "tinypool": "^1.0.1", "tinyrainbow": "^1.2.0", "vite": "^5.0.0", "vite-node": "2.1.9", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@types/node": "^18.0.0 || >=20.0.0", "@vitest/browser": "2.1.9", "@vitest/ui": "2.1.9", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@types/node", "@vitest/browser", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q=="],
 
     "w3c-xmlserializer": ["w3c-xmlserializer@5.0.0", "", { "dependencies": { "xml-name-validator": "^5.0.0" } }, "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA=="],
 
@@ -498,6 +555,8 @@
     "whatwg-url": ["whatwg-url@14.2.0", "", { "dependencies": { "tr46": "^5.1.0", "webidl-conversions": "^7.0.0" } }, "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw=="],
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
 
     "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
 
@@ -528,5 +587,105 @@
     "pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
 
     "readdirp/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
+
+    "vite-node/vite": ["vite@5.4.20", "", { "dependencies": { "esbuild": "^0.21.3", "postcss": "^8.4.43", "rollup": "^4.20.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || >=20.0.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.4.0" }, "optionalPeers": ["@types/node", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser"], "bin": { "vite": "bin/vite.js" } }, "sha512-j3lYzGC3P+B5Yfy/pfKNgVEg4+UtcIJcVRt2cDjIOmhLourAqPqf8P7acgxeiSgUB7E3p2P8/3gNIgDLpwzs4g=="],
+
+    "vitest/vite": ["vite@5.4.20", "", { "dependencies": { "esbuild": "^0.21.3", "postcss": "^8.4.43", "rollup": "^4.20.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || >=20.0.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.4.0" }, "optionalPeers": ["@types/node", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser"], "bin": { "vite": "bin/vite.js" } }, "sha512-j3lYzGC3P+B5Yfy/pfKNgVEg4+UtcIJcVRt2cDjIOmhLourAqPqf8P7acgxeiSgUB7E3p2P8/3gNIgDLpwzs4g=="],
+
+    "vite-node/vite/esbuild": ["esbuild@0.21.5", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.21.5", "@esbuild/android-arm": "0.21.5", "@esbuild/android-arm64": "0.21.5", "@esbuild/android-x64": "0.21.5", "@esbuild/darwin-arm64": "0.21.5", "@esbuild/darwin-x64": "0.21.5", "@esbuild/freebsd-arm64": "0.21.5", "@esbuild/freebsd-x64": "0.21.5", "@esbuild/linux-arm": "0.21.5", "@esbuild/linux-arm64": "0.21.5", "@esbuild/linux-ia32": "0.21.5", "@esbuild/linux-loong64": "0.21.5", "@esbuild/linux-mips64el": "0.21.5", "@esbuild/linux-ppc64": "0.21.5", "@esbuild/linux-riscv64": "0.21.5", "@esbuild/linux-s390x": "0.21.5", "@esbuild/linux-x64": "0.21.5", "@esbuild/netbsd-x64": "0.21.5", "@esbuild/openbsd-x64": "0.21.5", "@esbuild/sunos-x64": "0.21.5", "@esbuild/win32-arm64": "0.21.5", "@esbuild/win32-ia32": "0.21.5", "@esbuild/win32-x64": "0.21.5" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw=="],
+
+    "vitest/vite/esbuild": ["esbuild@0.21.5", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.21.5", "@esbuild/android-arm": "0.21.5", "@esbuild/android-arm64": "0.21.5", "@esbuild/android-x64": "0.21.5", "@esbuild/darwin-arm64": "0.21.5", "@esbuild/darwin-x64": "0.21.5", "@esbuild/freebsd-arm64": "0.21.5", "@esbuild/freebsd-x64": "0.21.5", "@esbuild/linux-arm": "0.21.5", "@esbuild/linux-arm64": "0.21.5", "@esbuild/linux-ia32": "0.21.5", "@esbuild/linux-loong64": "0.21.5", "@esbuild/linux-mips64el": "0.21.5", "@esbuild/linux-ppc64": "0.21.5", "@esbuild/linux-riscv64": "0.21.5", "@esbuild/linux-s390x": "0.21.5", "@esbuild/linux-x64": "0.21.5", "@esbuild/netbsd-x64": "0.21.5", "@esbuild/openbsd-x64": "0.21.5", "@esbuild/sunos-x64": "0.21.5", "@esbuild/win32-arm64": "0.21.5", "@esbuild/win32-ia32": "0.21.5", "@esbuild/win32-x64": "0.21.5" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw=="],
+
+    "vite-node/vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.21.5", "", { "os": "aix", "cpu": "ppc64" }, "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ=="],
+
+    "vite-node/vite/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.21.5", "", { "os": "android", "cpu": "arm" }, "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg=="],
+
+    "vite-node/vite/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.21.5", "", { "os": "android", "cpu": "arm64" }, "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A=="],
+
+    "vite-node/vite/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.21.5", "", { "os": "android", "cpu": "x64" }, "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA=="],
+
+    "vite-node/vite/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.21.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ=="],
+
+    "vite-node/vite/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.21.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw=="],
+
+    "vite-node/vite/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.21.5", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g=="],
+
+    "vite-node/vite/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.21.5", "", { "os": "freebsd", "cpu": "x64" }, "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ=="],
+
+    "vite-node/vite/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.21.5", "", { "os": "linux", "cpu": "arm" }, "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA=="],
+
+    "vite-node/vite/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.21.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q=="],
+
+    "vite-node/vite/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.21.5", "", { "os": "linux", "cpu": "ia32" }, "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg=="],
+
+    "vite-node/vite/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg=="],
+
+    "vite-node/vite/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg=="],
+
+    "vite-node/vite/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.21.5", "", { "os": "linux", "cpu": "ppc64" }, "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w=="],
+
+    "vite-node/vite/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA=="],
+
+    "vite-node/vite/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.21.5", "", { "os": "linux", "cpu": "s390x" }, "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A=="],
+
+    "vite-node/vite/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.21.5", "", { "os": "linux", "cpu": "x64" }, "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ=="],
+
+    "vite-node/vite/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.21.5", "", { "os": "none", "cpu": "x64" }, "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg=="],
+
+    "vite-node/vite/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.21.5", "", { "os": "openbsd", "cpu": "x64" }, "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow=="],
+
+    "vite-node/vite/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.21.5", "", { "os": "sunos", "cpu": "x64" }, "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg=="],
+
+    "vite-node/vite/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.21.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A=="],
+
+    "vite-node/vite/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.21.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA=="],
+
+    "vite-node/vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.21.5", "", { "os": "win32", "cpu": "x64" }, "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw=="],
+
+    "vitest/vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.21.5", "", { "os": "aix", "cpu": "ppc64" }, "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ=="],
+
+    "vitest/vite/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.21.5", "", { "os": "android", "cpu": "arm" }, "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg=="],
+
+    "vitest/vite/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.21.5", "", { "os": "android", "cpu": "arm64" }, "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A=="],
+
+    "vitest/vite/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.21.5", "", { "os": "android", "cpu": "x64" }, "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA=="],
+
+    "vitest/vite/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.21.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ=="],
+
+    "vitest/vite/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.21.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw=="],
+
+    "vitest/vite/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.21.5", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g=="],
+
+    "vitest/vite/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.21.5", "", { "os": "freebsd", "cpu": "x64" }, "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ=="],
+
+    "vitest/vite/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.21.5", "", { "os": "linux", "cpu": "arm" }, "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA=="],
+
+    "vitest/vite/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.21.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q=="],
+
+    "vitest/vite/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.21.5", "", { "os": "linux", "cpu": "ia32" }, "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg=="],
+
+    "vitest/vite/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg=="],
+
+    "vitest/vite/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg=="],
+
+    "vitest/vite/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.21.5", "", { "os": "linux", "cpu": "ppc64" }, "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w=="],
+
+    "vitest/vite/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA=="],
+
+    "vitest/vite/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.21.5", "", { "os": "linux", "cpu": "s390x" }, "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A=="],
+
+    "vitest/vite/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.21.5", "", { "os": "linux", "cpu": "x64" }, "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ=="],
+
+    "vitest/vite/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.21.5", "", { "os": "none", "cpu": "x64" }, "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg=="],
+
+    "vitest/vite/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.21.5", "", { "os": "openbsd", "cpu": "x64" }, "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow=="],
+
+    "vitest/vite/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.21.5", "", { "os": "sunos", "cpu": "x64" }, "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg=="],
+
+    "vitest/vite/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.21.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A=="],
+
+    "vitest/vite/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.21.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA=="],
+
+    "vitest/vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.21.5", "", { "os": "win32", "cpu": "x64" }, "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw=="],
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,6 +22,7 @@
     "jsdom": "^26.1.0",
     "svelte": "^5.0.0",
     "vite": "^7.0.4",
+    "vitest": "^2.1.4",
     "vite-plugin-static-copy": "^3.1.2"
   },
   "dependencies": {

--- a/frontend/src/lib/battle/BattleFighterCard.svelte
+++ b/frontend/src/lib/battle/BattleFighterCard.svelte
@@ -1,6 +1,7 @@
 <script>
   import { Circle as PipCircle } from 'lucide-svelte';
   import TripleRingSpinner from '../components/TripleRingSpinner.svelte';
+  import RankBadge from './RankBadge.svelte';
   import { getCharacterImage, getElementColor, getElementIcon, hasCharacterGallery, advanceCharacterImage } from '../systems/assetLoader.js';
 
   export let fighter = {};
@@ -170,6 +171,11 @@
         <div class="element-effect {elementGlow.effect}"></div>
       {/if}
     </div>
+      <RankBadge
+        rank={fighter?.rank}
+        className="card-rank-badge"
+        size="calc(var(--portrait-size) * 0.28)"
+      />
     <!-- Overlay UI: pips (left), passives (middle), ult gauge (right) -->
     <div class="overlay-ui">
       <!-- Old "action pips" removed to avoid confusion with passive pips. -->
@@ -273,6 +279,13 @@
     transition: border-color 0.3s ease;
   }
   .fighter-portrait.can-cycle { cursor: pointer; }
+  .fighter-portrait :global(.card-rank-badge) {
+    position: absolute;
+    top: clamp(0.35rem, calc(var(--portrait-size) * 0.08), 0.75rem);
+    left: clamp(0.35rem, calc(var(--portrait-size) * 0.08), 0.75rem);
+    pointer-events: none;
+    z-index: 4;
+  }
 
   /* External highlight (e.g., hovering the action queue) */
   .modern-fighter-card.highlight .fighter-portrait {

--- a/frontend/src/lib/battle/LegacyFighterPortrait.svelte
+++ b/frontend/src/lib/battle/LegacyFighterPortrait.svelte
@@ -2,11 +2,11 @@
   // Renders a fighter portrait with HP bar, element chip, and status icons.
   import { getCharacterImage, getElementColor, getElementIcon } from '../systems/assetLoader.js';
   import StatusIcons from './StatusIcons.svelte';
+  import RankBadge from './RankBadge.svelte';
 
   export let fighter = {};
   export let reducedMotion = false;
-  // Optional rank identifier; reserved for future badge rendering
-  // eslint-disable-next-line no-unused-vars
+  // Optional rank identifier used for badge rendering
   export let rankTag = null;
   function getStackCount(p) {
     const stacks = p?.stacks;
@@ -86,6 +86,8 @@
     return isLowBrightness(elColor);
   })();
 
+  $: badgeRank = rankTag != null ? rankTag : fighter?.rank;
+
   // NOTE: Do not add ult icon pulse/size logic here.
   // The Fighter UI overlays and ult gauge behavior live in BattleFighterCard.svelte.
   // This portrait component is used in multiple contexts; keep it minimal.
@@ -98,6 +100,11 @@
     title={passiveTip}
     style={`--el-color: ${elColor}`}
   >
+    <RankBadge
+      rank={badgeRank}
+      className="rank-badge-slot"
+      size="calc(var(--portrait-size) * 0.32)"
+    />
     <img
       src={getCharacterImage((fighter?.summon_type === 'phantom' && fighter?.summoner_id) ? fighter.summoner_id : (fighter?.summon_type || fighter?.id))}
       alt=""
@@ -198,6 +205,13 @@
     /* Allow pips to scale across views while staying small */
     --pip-size: clamp(4px, calc(var(--portrait-size) * 0.11), 10px);
     --pip-gap: clamp(1px, calc(var(--portrait-size) * 0.02), 3px);
+  }
+  .portrait-frame :global(.rank-badge-slot) {
+    position: absolute;
+    top: clamp(0.25rem, calc(var(--portrait-size) * 0.08), 0.6rem);
+    left: clamp(0.25rem, calc(var(--portrait-size) * 0.08), 0.6rem);
+    pointer-events: none;
+    z-index: 3;
   }
   .portrait {
     width: 100%;

--- a/frontend/src/lib/battle/RankBadge.svelte
+++ b/frontend/src/lib/battle/RankBadge.svelte
@@ -1,0 +1,228 @@
+<script>
+  import { getRankStyle } from './rankStyles.js';
+
+  export let rank = null;
+  export let size = '1.75rem';
+  export let className = '';
+  export let style = '';
+
+  $: info = getRankStyle(rank);
+  $: sizeValue = typeof size === 'number' ? `${size}px` : size;
+  $: baseStyle = info ? [`--rank-size: ${sizeValue}`, `--rank-color: ${info.color}`] : [];
+  $: combinedStyle = info
+    ? [...baseStyle, style].filter(Boolean).join('; ')
+    : style;
+  $: classes = info
+    ? ['rank-badge', `tier-${info.tier}`, info.glitch ? 'is-glitched' : '', info.fallback ? 'is-fallback' : '', info.slug ? `rank-${info.slug}` : '', className]
+        .filter(Boolean)
+        .join(' ')
+    : className;
+</script>
+
+{#if info}
+  <div
+    class={classes}
+    style={combinedStyle}
+    role="img"
+    aria-label={info.label}
+    data-rank={info.slug}
+    data-rank-tier={info.tier}
+    data-rank-fallback={info.fallback ? 'true' : 'false'}
+    data-icon={info.icon}
+  >
+    <span class="badge-ring" aria-hidden="true"></span>
+    <span class="badge-core" aria-hidden="true">{info.icon}</span>
+    <span class="badge-label" aria-hidden="true">{info.shortLabel}</span>
+    <span class="sr-only">{info.label}</span>
+  </div>
+{/if}
+
+<style>
+  .rank-badge {
+    --rank-size: 1.75rem;
+    --rank-color: #cd7f32;
+    position: relative;
+    display: inline-flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    width: var(--rank-size);
+    height: var(--rank-size);
+    border-radius: 999px;
+    background: radial-gradient(
+      circle at 32% 28%,
+      color-mix(in oklab, var(--rank-color) 75%, white 15%) 0%,
+      color-mix(in oklab, var(--rank-color) 68%, black 25%) 65%,
+      color-mix(in oklab, var(--rank-color) 52%, black 40%) 100%
+    );
+    border: 2px solid rgba(255, 255, 255, 0.85);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.45);
+    text-transform: uppercase;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    color: #101010;
+    padding: calc(var(--rank-size) * 0.08);
+    overflow: hidden;
+    isolation: isolate;
+    z-index: 1;
+  }
+
+  .badge-ring {
+    position: absolute;
+    inset: calc(var(--rank-size) * -0.2);
+    border-radius: 50%;
+    background: radial-gradient(
+      circle,
+      rgba(255, 255, 255, 0.4) 0%,
+      rgba(255, 255, 255, 0.15) 40%,
+      rgba(0, 0, 0, 0) 70%
+    );
+    opacity: 0.65;
+    pointer-events: none;
+    mix-blend-mode: screen;
+  }
+
+  .badge-core {
+    font-size: calc(var(--rank-size) * 0.55);
+    line-height: 1;
+    z-index: 2;
+    text-shadow: 0 1px 2px rgba(255, 255, 255, 0.4);
+  }
+
+  .badge-label {
+    font-size: calc(var(--rank-size) * 0.28);
+    margin-top: calc(var(--rank-size) * -0.05);
+    z-index: 2;
+    color: color-mix(in oklab, #111 55%, var(--rank-color) 45%);
+    text-shadow: 0 1px 2px rgba(255, 255, 255, 0.35);
+  }
+
+  .rank-badge.is-fallback {
+    background: radial-gradient(
+      circle at 32% 28%,
+      color-mix(in oklab, var(--rank-color) 82%, white 8%) 0%,
+      color-mix(in oklab, var(--rank-color) 60%, black 30%) 70%
+    );
+  }
+
+  .rank-badge[data-rank-tier='platinum'] {
+    color: #161616;
+  }
+
+  .rank-badge[data-rank-tier='diamond'] {
+    color: #0d1d26;
+  }
+
+  .rank-badge.is-glitched::before,
+  .rank-badge.is-glitched::after {
+    content: attr(data-icon);
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    font-size: calc(var(--rank-size) * 0.55);
+    opacity: 0.6;
+    pointer-events: none;
+    mix-blend-mode: screen;
+  }
+
+  .rank-badge.is-glitched::before {
+    color: #67f3da;
+    animation: rank-glitch-1 2.5s infinite;
+  }
+
+  .rank-badge.is-glitched::after {
+    color: #f16f6f;
+    animation: rank-glitch-2 2.5s infinite;
+  }
+
+  @keyframes rank-glitch-1 {
+    0% {
+      transform: translate(-50%, -50%);
+      opacity: 0.45;
+    }
+    7% {
+      transform: translate(calc(-50% - 1px), calc(-50% - 1px));
+      opacity: 0.7;
+    }
+    14% {
+      transform: translate(-50%, -50%);
+      opacity: 0.45;
+    }
+    44% {
+      transform: translate(-50%, -50%);
+      opacity: 0.45;
+    }
+    50% {
+      transform: translate(calc(-50% - 1.5px), calc(-50% + 1px));
+      opacity: 0.7;
+    }
+    56% {
+      transform: translate(-50%, -50%);
+      opacity: 0.45;
+    }
+    86% {
+      transform: translate(-50%, -50%);
+      opacity: 0.45;
+    }
+    92% {
+      transform: translate(calc(-50% - 0.5px), calc(-50% - 1.5px));
+      opacity: 0.7;
+    }
+    100% {
+      transform: translate(-50%, -50%);
+      opacity: 0.45;
+    }
+  }
+
+  @keyframes rank-glitch-2 {
+    0% {
+      transform: translate(-50%, -50%);
+      opacity: 0.45;
+    }
+    9% {
+      transform: translate(calc(-50% + 1.5px), calc(-50% + 1px));
+      opacity: 0.7;
+    }
+    16% {
+      transform: translate(-50%, -50%);
+      opacity: 0.45;
+    }
+    46% {
+      transform: translate(-50%, -50%);
+      opacity: 0.45;
+    }
+    52% {
+      transform: translate(calc(-50% + 1px), calc(-50% - 0.5px));
+      opacity: 0.7;
+    }
+    58% {
+      transform: translate(-50%, -50%);
+      opacity: 0.45;
+    }
+    88% {
+      transform: translate(-50%, -50%);
+      opacity: 0.45;
+    }
+    94% {
+      transform: translate(calc(-50% + 0.5px), calc(-50% + 1.5px));
+      opacity: 0.7;
+    }
+    100% {
+      transform: translate(-50%, -50%);
+      opacity: 0.45;
+    }
+  }
+
+  .sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+</style>

--- a/frontend/src/lib/battle/rankStyles.js
+++ b/frontend/src/lib/battle/rankStyles.js
@@ -1,0 +1,80 @@
+const RANK_STYLES = {
+  prime: {
+    label: 'Prime',
+    shortLabel: 'PR',
+    icon: '★',
+    color: '#c0c0c0',
+    tier: 'silver',
+    slug: 'prime'
+  },
+  'glitched prime': {
+    label: 'Glitched Prime',
+    shortLabel: 'GP',
+    icon: '★',
+    color: '#ffd700',
+    tier: 'gold',
+    slug: 'glitched-prime',
+    glitch: true
+  },
+  boss: {
+    label: 'Boss',
+    shortLabel: 'B',
+    icon: '♛',
+    color: '#e5e4e2',
+    tier: 'platinum',
+    slug: 'boss'
+  },
+  'glitched boss': {
+    label: 'Glitched Boss',
+    shortLabel: 'GB',
+    icon: '◆',
+    color: '#b9f2ff',
+    tier: 'diamond',
+    slug: 'glitched-boss',
+    glitch: true
+  }
+};
+
+const OMITTED_RANKS = new Set(['', 'normal', 'common', 'standard', 'default']);
+
+function titleCase(value) {
+  return value
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+}
+
+export function getRankStyle(rank) {
+  if (rank == null) return null;
+  const normalized = String(rank).trim();
+  if (!normalized) return null;
+  const lowered = normalized.toLowerCase();
+  if (OMITTED_RANKS.has(lowered)) {
+    return null;
+  }
+
+  const preset = RANK_STYLES[lowered];
+  if (preset) {
+    return { ...preset };
+  }
+
+  const label = titleCase(normalized);
+  const slug = lowered.replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '') || 'unknown';
+  const shortLabel = label
+    .split(' ')
+    .map((part) => part.charAt(0))
+    .join('')
+    .slice(0, 3)
+    .toUpperCase();
+
+  return {
+    label,
+    shortLabel: shortLabel || label.slice(0, 2).toUpperCase(),
+    icon: '★',
+    color: '#cd7f32',
+    tier: 'bronze',
+    slug,
+    fallback: true
+  };
+}

--- a/frontend/src/lib/components/BattleReview.svelte
+++ b/frontend/src/lib/components/BattleReview.svelte
@@ -209,12 +209,12 @@
     for (const foe of foesDisplay || []) {
       if (foe.id) {
         const name = foe.name || foe.id;
-        const label = foe.rank ? `${name} — ${foe.rank}` : name;
         tabs.push({
           id: foe.id,
-          label,
+          label: name,
           type: 'foe',
-          entity: foe
+          entity: foe,
+          rank: foe.rank || null
         });
       }
     }
@@ -678,6 +678,15 @@
     margin: 0;
     color: #fff;
     font-size: 1.2rem;
+    display: flex;
+    align-items: center;
+    gap: 0.35rem;
+  }
+
+  .rank-inline {
+    font-size: 0.95rem;
+    color: rgba(255, 255, 255, 0.8);
+    font-weight: 500;
   }
   
   .entity-section {
@@ -905,14 +914,18 @@
             class="icon-btn"
             class:active={activeTab === tab.id}
             on:click={() => activeTab = tab.id}
-            aria-label={tab.label}
+            aria-label={tab.rank ? `${tab.label} — ${tab.rank}` : tab.label}
           >
             {#if tab.icon}
               <svelte:component this={tab.icon} size={20} />
             {:else if tab.entity}
               {@const _tabFighter = toDisplayFighter(tab.entity)}
               <div style="--portrait-size: 4rem;">
-                <LegacyFighterPortrait fighter={_tabFighter} {reducedMotion} />
+                <LegacyFighterPortrait
+                  fighter={_tabFighter}
+                  rankTag={tab.rank ?? _tabFighter.rank}
+                  {reducedMotion}
+                />
               </div>
             {:else}
               <User size={20} />
@@ -1313,10 +1326,20 @@
               {#if currentTab.entity}
                 {@const _fighter = toDisplayFighter(currentTab.entity)}
                 <div style="--portrait-size: 7rem;">
-                  <LegacyFighterPortrait fighter={_fighter} {reducedMotion} />
+                  <LegacyFighterPortrait
+                    fighter={_fighter}
+                    rankTag={currentTab.rank ?? _fighter.rank}
+                    {reducedMotion}
+                  />
                 </div>
               {/if}
-              <h3>{currentTab.label} Breakdown</h3>
+              <h3>
+                {currentTab.label}
+                {#if currentTab.rank}
+                  <span class="rank-inline">— {currentTab.rank}</span>
+                {/if}
+                Breakdown
+              </h3>
             </div>
 
             {#if Object.keys(entityData.damage).length > 0}

--- a/frontend/tests/rank-badges.vitest.js
+++ b/frontend/tests/rank-badges.vitest.js
@@ -1,0 +1,60 @@
+import { render, cleanup, screen } from '@testing-library/svelte';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import BattleFighterCard from '../src/lib/battle/BattleFighterCard.svelte';
+
+vi.mock('../src/lib/systems/assetLoader.js', () => ({
+  getCharacterImage: () => 'placeholder.png',
+  getElementColor: () => '#888888',
+  getElementIcon: () => null,
+  hasCharacterGallery: () => false,
+  advanceCharacterImage: () => {}
+}));
+
+afterEach(() => {
+  cleanup();
+});
+
+function renderFoe(rank) {
+  const fighter = {
+    id: `foe-${rank}`,
+    name: `Dummy ${rank}`,
+    rank,
+    element: 'fire',
+    hp: 120,
+    max_hp: 120,
+    ultimate_charge: 0,
+    passives: []
+  };
+
+  return render(BattleFighterCard, {
+    props: {
+      fighter,
+      position: 'top',
+      reducedMotion: true,
+      size: 'small'
+    }
+  });
+}
+
+describe('BattleFighterCard rank badges', () => {
+  it('renders a Prime badge with the silver theme', () => {
+    renderFoe('prime');
+    const badge = screen.getByRole('img', { name: /prime/i });
+    expect(badge.getAttribute('data-rank')).toBe('prime');
+    expect(badge.getAttribute('data-rank-tier')).toBe('silver');
+  });
+
+  it('renders a Glitched Prime badge with the glitch animation', () => {
+    renderFoe('glitched prime');
+    const badge = screen.getByRole('img', { name: /glitched prime/i });
+    expect(badge.getAttribute('data-rank')).toBe('glitched-prime');
+    expect(badge.classList.contains('is-glitched')).toBe(true);
+  });
+
+  it('renders a Boss badge with the platinum styling', () => {
+    renderFoe('boss');
+    const badge = screen.getByRole('img', { name: /boss/i });
+    expect(badge.getAttribute('data-rank')).toBe('boss');
+    expect(badge.getAttribute('data-rank-tier')).toBe('platinum');
+  });
+});

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -60,8 +60,10 @@ function backendDiscoveryPlugin() {
 }
 
 export default defineConfig(async () => {
-  // Discover backend during config time
-  const backendUrl = await discoverBackend();
+  const isVitest = process.env.VITEST === 'true';
+  const backendUrl = isVitest
+    ? (process.env.VITE_API_BASE || 'http://localhost')
+    : await discoverBackend();
   
   return {
     plugins: [
@@ -74,7 +76,7 @@ export default defineConfig(async () => {
           }
         ]
       }),
-      backendDiscoveryPlugin()
+      ...(isVitest ? [] : [backendDiscoveryPlugin()])
     ],
     server: {
       proxy: {
@@ -85,6 +87,12 @@ export default defineConfig(async () => {
         }
       }
     },
-    assetsInclude: ['**/*.efkefc']
+    assetsInclude: ['**/*.efkefc'],
+    test: {
+      environment: 'jsdom',
+      setupFiles: ['./vitest.setup.js'],
+      include: ['tests/**/*.vitest.{js,ts}'],
+      css: true
+    }
   };
 });

--- a/frontend/vitest.config.js
+++ b/frontend/vitest.config.js
@@ -1,0 +1,42 @@
+import { defineConfig } from 'vitest/config';
+import { svelte } from '@sveltejs/vite-plugin-svelte';
+import path from 'node:path';
+
+const vitestEnvironmentShim = {
+  name: 'vitest-environment-shim',
+  enforce: 'pre',
+  configureServer(server) {
+    if (!server.environments) {
+      const assetsInclude = server.config?.assetsInclude || (() => false);
+      server.environments = {
+        client: {
+          config: {
+            consumer: 'client',
+            assetsInclude
+          }
+        }
+      };
+    }
+  }
+};
+
+export default defineConfig({
+  plugins: [
+    vitestEnvironmentShim,
+    svelte({
+      hot: false
+    })
+  ],
+  resolve: {
+    alias: {
+      $lib: path.resolve('./src/lib'),
+      '$app/environment': path.resolve('./src/lib/mocks/app-environment.js')
+    }
+  },
+  test: {
+    environment: 'jsdom',
+    setupFiles: ['./vitest.setup.js'],
+    include: ['tests/**/*.vitest.{js,ts}'],
+    css: true
+  }
+});

--- a/frontend/vitest.setup.js
+++ b/frontend/vitest.setup.js
@@ -1,0 +1,22 @@
+import { beforeAll } from 'vitest';
+
+beforeAll(() => {
+  globalThis.$app = {
+    environment: {
+      browser: false,
+      dev: false,
+      building: false,
+      version: {}
+    }
+  };
+
+  globalThis.$stores = {
+    page: { subscribe: () => () => {} },
+    navigating: { subscribe: () => () => {} },
+    updated: { subscribe: () => () => {} }
+  };
+
+  if (typeof globalThis.fetch !== 'function') {
+    globalThis.fetch = () => Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+  }
+});

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -185,6 +185,8 @@ if command -v bun >/dev/null 2>&1; then
     echo "Running frontend test: $file"
     run_test "$NODE_CMD tests/$file" "frontend tests/$file"
   done
+  echo "Running frontend vitest suite"
+  run_test "bun x vitest run --config vitest.config.js" "frontend vitest"
 else
   echo "bun not found, skipping frontend tests (tests require bun:test API)"
   echo "To run frontend tests, install bun: https://bun.sh/"


### PR DESCRIPTION
## Summary
- persist the selected floor boss when starting a run and whenever a new floor is generated
- reuse the stored boss for boss rooms while excluding it from normal battles on that floor
- add a regression test to confirm the boss rolls refresh between floors

## Testing
- uv run pytest tests/test_floor_boss_rotation.py
- uv run ruff check services/room_service.py services/run_service.py
- uv run ruff check tests/test_floor_boss_rotation.py


------
https://chatgpt.com/codex/tasks/task_b_68cc496baa70832c9c0956cfde666e26