### PR TITLE
fix: avoid inflating party size when filtering floor bosses

### DIFF
--- a/backend/autofighter/rooms/utils.py
+++ b/backend/autofighter/rooms/utils.py
@@ -4,6 +4,7 @@ from dataclasses import fields
 import math
 import random
 from typing import Any
+from typing import Collection
 
 from plugins import foes as foe_plugins
 from plugins import players as player_plugins
@@ -468,7 +469,12 @@ def _choose_foe(party: Party) -> FoeBase:
     return foe_cls()
 
 
-def _build_foes(node: MapNode, party: Party) -> list[FoeBase]:
+def _build_foes(
+    node: MapNode,
+    party: Party,
+    *,
+    exclude_ids: Collection[str] | None = None,
+) -> list[FoeBase]:
     """Build a list of foes for the given room node.
 
     Ensures no duplicate foe IDs within a single encounter. If the available
@@ -496,6 +502,8 @@ def _build_foes(node: MapNode, party: Party) -> list[FoeBase]:
 
     # Build a candidate pool of foe classes that are not members of the party
     party_ids = {p.id for p in party.members}
+    if exclude_ids:
+        party_ids.update(eid for eid in exclude_ids if eid)
     candidates: list[type[FoeBase]] = []
     try:
         for name in getattr(foe_plugins, "__all__", []):

--- a/backend/services/room_service.py
+++ b/backend/services/room_service.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 import copy
-from types import SimpleNamespace
 from typing import Any
 
 from battle_logging.writers import get_current_run_logger
@@ -208,19 +207,12 @@ async def battle_room(run_id: str, data: dict[str, Any]) -> dict[str, Any]:
         await asyncio.to_thread(save_map, run_id, state)
         room = BattleRoom(node)
         boss_info = state.get("floor_boss")
-        build_party = party
+        exclude_ids = None
         if _boss_matches_node(boss_info, node):
             boss_id = boss_info.get("id") if isinstance(boss_info, dict) else None
             if boss_id:
-                dummy = SimpleNamespace(id=boss_id)
-                build_party = Party(
-                    members=[*party.members, dummy],
-                    gold=party.gold,
-                    relics=party.relics,
-                    cards=party.cards,
-                    rdr=party.rdr,
-                )
-        foes = _build_foes(node, build_party)
+                exclude_ids = {boss_id}
+        foes = _build_foes(node, party, exclude_ids=exclude_ids)
         for f in foes:
             _scale_stats(f, node, room.strength)
         combat_party = Party(


### PR DESCRIPTION
## Summary
- persist the selected floor boss when starting a run and whenever a new floor is generated
- reuse the stored boss for boss rooms while excluding it from normal battles on that floor
- add a regression test to confirm the boss rolls refresh between floors
- avoid inflating normal encounter sizes by excluding stored boss IDs directly in `_build_foes`

## Testing
- uv run pytest tests/test_floor_boss_rotation.py tests/test_party_size_foe_generation.py
- uv run ruff check backend/services/room_service.py backend/autofighter/rooms/utils.py

------
https://chatgpt.com/codex/tasks/task_b_68cc50a6d524832c89fecf08e08dd222