### PR TITLE
Add recent foe cooldown tracking to battle flow

### DIFF
--- a/backend/tests/test_boss_room_single_foe.py
+++ b/backend/tests/test_boss_room_single_foe.py
@@ -30,7 +30,7 @@ def _make_node(pressure: int) -> MapNode:
 def test_boss_rooms_spawn_one_foe(size: int, pressure: int) -> None:
     party = _make_party(size)
     node = _make_node(pressure)
-    foes = utils._build_foes(node, party)
+    foes = utils._build_foes(node, party, [])
     assert len(foes) == 1
     assert foes[0].rank == "boss"
 

--- a/backend/tests/test_foe_rank.py
+++ b/backend/tests/test_foe_rank.py
@@ -32,7 +32,7 @@ def test_normal_foe_rank() -> None:
         loop=1,
         pressure=0,
     )
-    foes = _build_foes(node, party)
+    foes = _build_foes(node, party, [])
     data = [_serialize(f) for f in foes]
     assert all(f["rank"] == "normal" for f in data)
 
@@ -47,6 +47,6 @@ def test_boss_foe_rank() -> None:
         loop=1,
         pressure=0,
     )
-    foes = _build_foes(node, party)
+    foes = _build_foes(node, party, [])
     data = [_serialize(f) for f in foes]
     assert data[0]["rank"] == "boss"

--- a/backend/tests/test_luna_weighting.py
+++ b/backend/tests/test_luna_weighting.py
@@ -27,6 +27,34 @@ def test_luna_can_be_boss() -> None:
     random.seed(0)
     party = Party(members=[Player()])
     node = MapNode(room_id=0, room_type="boss", floor=1, index=1, loop=1, pressure=0)
-    foe = utils._build_foes(node, party)[0]
+    foe = utils._build_foes(node, party, [])[0]
     assert foe.id == "luna"
     assert foe.rank == "boss"
+
+
+def test_recent_foes_reduce_weights(monkeypatch) -> None:
+    party = Party(members=[Player()])
+    node = MapNode(
+        room_id=0,
+        room_type="battle-normal",
+        floor=1,
+        index=1,
+        loop=1,
+        pressure=0,
+    )
+    captured: list[tuple[str, float]] = []
+
+    def fake_choices(seq, weights, k):
+        nonlocal captured
+        captured = [
+            (getattr(cls, "id", ""), weight)
+            for cls, weight in zip(seq, weights, strict=False)
+        ]
+        return [seq[0]]
+
+    monkeypatch.setattr(utils.random, "choices", fake_choices)
+    utils._build_foes(node, party, ["slime"])
+    assert captured, "Expected captured weights"
+    slime_weight = next((weight for cid, weight in captured if cid == "slime"), None)
+    assert slime_weight is not None
+    assert 0 < slime_weight < 1

--- a/backend/tests/test_party_size_foe_generation.py
+++ b/backend/tests/test_party_size_foe_generation.py
@@ -29,7 +29,7 @@ def _run(monkeypatch, values: list[float]) -> int:
     monkeypatch.setattr(utils.random, "random", lambda: next(it, 1.0))
     party = _make_party(3)
     node = _make_node()
-    return len(utils._build_foes(node, party))
+    return len(utils._build_foes(node, party, []))
 
 
 def test_add_two_foes(monkeypatch) -> None:

--- a/backend/tests/test_pressure_scaling.py
+++ b/backend/tests/test_pressure_scaling.py
@@ -25,7 +25,7 @@ def test_build_foes_pressure(pressure, expected) -> None:
     player = Stats(hp=10)
     player.id = "p1"
     party = Party(members=[player])
-    foes = _build_foes(node, party)
+    foes = _build_foes(node, party, [])
     assert len(foes) == expected
 
 


### PR DESCRIPTION
## Summary
- track recent foes with a cooldown list in the run state and update it after battles
- load and prune recent foe cooldowns when launching battles, passing the active list into foe generation
- apply cooldown-aware weighting in foe selection and adjust tests to exercise the new behaviour

## Testing
- `uv run ruff check runs/lifecycle.py services/room_service.py autofighter/rooms/utils.py tests/test_boss_room_single_foe.py tests/test_foe_rank.py tests/test_luna_weighting.py tests/test_party_size_foe_generation.py tests/test_pressure_scaling.py --fix`
- `uv run pytest tests/test_luna_weighting.py`
- `uv run pytest tests/test_party_size_foe_generation.py`
- `uv run pytest tests/test_boss_room_single_foe.py`
- `uv run pytest tests/test_foe_rank.py`
- `PYTHONPATH=$PWD uv run pytest tests/test_pressure_scaling.py -k build_foes`

------
https://chatgpt.com/codex/tasks/task_b_68cc50c2fb18832cb447956d3d8ee28b