### PR TITLE
feat: add luna boss sword coordination

### DIFF
--- a/.codex/implementation/player-foe-reference.md
+++ b/.codex/implementation/player-foe-reference.md
@@ -56,7 +56,7 @@ Passives generally shouldn't be capped unless a designer explicitly specifies a 
 - **Lady Storm** (B, Wind or Lightning, 6★) – rotates between slipstreaming allies and overcharging lightning. Supercell Convergence grants permanent tailwinds, alternating action buffs that haste the party or stack charges, and detonates charged hits for bonus damage and mitigation shred.
 - **Persona Light and Dark** (B, Light or Dark) – 6★ dual-persona duelist. `persona_light_and_dark_duality` flips her element after every action, bathing allies in Light-form mitigation pulses and heals before pivoting into Dark-form crit bursts that strip foe defenses.
 - **Lady Wind** (B, Wind) – 5★ aeromancer and twin of Lady Lightning whose manic, wind-lashed experiments leave her workspace in constant disarray. Tempest Guard wraps her in a permanent slipstream of dodge and mitigation, bleeds off stacks at the start of her turn, then adds one for every foe she critically strikes to fuel gust boosts and siphon a slice of incoming damage into healing.
-- **Luna** (B, Generic) – applies `luna_passive`.
+- **Luna** (B, Generic) – applies `luna_passive`; boss-ranked variants pre-summon astral swords that inherit her stats, mirror her action cadence, and funnel their hits into Lunar Reservoir charge.
 - **Mezzy** (B, random) – raises Max HP, takes less damage, and siphons stats from healthy allies each turn.
 - **PersonaIce** (A, Ice) – 5★ cryo tank who shields his sisters with Cryo Cycle, layering mitigation and thawing the stored frost into end-of-turn healing barriers for the party.
 - **Player** (C, chosen) – avatar representing the user and may select any non-Generic damage type.

--- a/backend/autofighter/rooms/battle/setup.py
+++ b/backend/autofighter/rooms/battle/setup.py
@@ -75,6 +75,9 @@ async def setup_battle(
 
     for stats in foes:
         _scale_stats(stats, node, strength)
+        prepare = getattr(stats, "prepare_for_battle", None)
+        if callable(prepare):
+            prepare(node, registry)
 
     members = await _clone_members(party.members)
     combat_party = Party(
@@ -107,6 +110,9 @@ async def setup_battle(
     for member in combat_party.members:
         manager = EffectManager(member)
         member.effect_manager = manager
+        prepare = getattr(member, "prepare_for_battle", None)
+        if callable(prepare):
+            prepare(node, registry)
 
     try:
         entities = list(combat_party.members) + list(foes)

--- a/backend/plugins/players/_base.py
+++ b/backend/plugins/players/_base.py
@@ -6,6 +6,7 @@ from dataclasses import field
 from dataclasses import fields
 import logging
 from typing import Collection
+from typing import TYPE_CHECKING
 
 from autofighter.mapgen import MapNode
 from autofighter.character import CharacterType
@@ -41,6 +42,10 @@ class SimpleConversationMemory:
             if ai:
                 lines.append(f"AI: {ai}")
         return {"history": "\n".join(lines)}
+
+
+if TYPE_CHECKING:
+    from autofighter.passives import PassiveRegistry
 
 
 @dataclass
@@ -171,6 +176,13 @@ class PlayerBase(Stats):
             val = getattr(self, name)
             setattr(result, name, copy.deepcopy(val, memo))
         return result
+
+    def prepare_for_battle(
+        self,
+        node: MapNode,
+        registry: "PassiveRegistry",
+    ) -> None:
+        """Hook for subclasses to adjust state prior to entering battle."""
 
     async def use_ultimate(self) -> bool:
         """Consume charge and emit an event when firing the ultimate."""

--- a/backend/plugins/players/luna.py
+++ b/backend/plugins/players/luna.py
@@ -1,12 +1,171 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 from dataclasses import field
+import random
+from typing import TYPE_CHECKING
 from typing import Collection
+import weakref
 
 from autofighter.character import CharacterType
 from autofighter.mapgen import MapNode
+from autofighter.stats import BUS
+from autofighter.summons.base import Summon
+from autofighter.summons.manager import SummonManager
+from plugins.damage_types import ALL_DAMAGE_TYPES
 from plugins.damage_types import load_damage_type
 from plugins.damage_types._base import DamageTypeBase
 from plugins.players._base import PlayerBase
+
+if TYPE_CHECKING:
+    from autofighter.passives import PassiveRegistry
+    from plugins.passives.normal.luna_lunar_reservoir import LunaLunarReservoir
+
+
+_LUNA_PASSIVE: "type[LunaLunarReservoir] | None" = None
+
+
+def _get_luna_passive() -> "type[LunaLunarReservoir]":
+    """Import Luna's passive lazily to avoid circular dependencies."""
+
+    global _LUNA_PASSIVE
+    if _LUNA_PASSIVE is None:
+        from plugins.passives.normal.luna_lunar_reservoir import LunaLunarReservoir
+
+        _LUNA_PASSIVE = LunaLunarReservoir
+    return _LUNA_PASSIVE
+
+
+def _register_luna_sword(owner: "Luna", sword: Summon, label: str) -> None:
+    """Register a sword with Luna's passive without leaking import cycles."""
+
+    passive = _get_luna_passive()
+    passive._ensure_event_hooks()  # type: ignore[attr-defined]
+    passive._ensure_charge_slot(owner)  # type: ignore[attr-defined]
+    owner_id = id(passive._resolve_charge_holder(owner))  # type: ignore[attr-defined]
+    passive._swords_by_owner.setdefault(owner_id, set()).add(id(sword))  # type: ignore[attr-defined]
+    if isinstance(label, str):
+        setattr(sword, "luna_sword_label", label)
+
+
+class _LunaSwordCoordinator:
+    """Manage Luna's summoned swords within a single battle."""
+
+    EVENT_NAME = "luna_sword_hit"
+
+    def __init__(self, owner: "Luna", _registry: "PassiveRegistry") -> None:
+        self._owner_ref: weakref.ReferenceType[Luna] = weakref.ref(owner)
+        self._sword_refs: dict[int, weakref.ReferenceType[Summon]] = {}
+        self._hit_listener = self._handle_hit
+        self._removal_listener = self._handle_removal
+        BUS.subscribe("hit_landed", self._hit_listener)
+        BUS.subscribe("summon_removed", self._removal_listener)
+
+    def add_sword(self, sword: Summon, label: str) -> None:
+        """Track a newly created sword and tag it for downstream systems."""
+
+        owner = self._owner_ref()
+        if owner is None:
+            return
+        self._sword_refs[id(sword)] = weakref.ref(sword)
+        sword.actions_per_turn = owner.actions_per_turn
+        sword.summon_type = f"luna_sword_{label.lower()}"
+        sword.summon_source = "luna_sword"
+        sword.is_temporary = False
+        tags = set(getattr(sword, "tags", set()))
+        tags.update({"luna", "sword", label.lower()})
+        sword.tags = tags
+        sword.luna_sword_label = label
+        sword.luna_sword_owner_id = getattr(owner, "id", None)
+        sword.luna_sword = True
+        sword.luna_sword_owner = owner
+        _register_luna_sword(owner, sword, label)
+
+    def sync_actions_per_turn(self) -> None:
+        """Mirror the owner's action cadence onto all tracked swords."""
+
+        owner = self._owner_ref()
+        if owner is None:
+            return
+        actions = owner.actions_per_turn
+        for sword_ref in list(self._sword_refs.values()):
+            sword = sword_ref()
+            if sword is None:
+                continue
+            sword.actions_per_turn = actions
+
+    async def _handle_hit(
+        self,
+        attacker: Summon | None,
+        target,
+        amount: int | None = None,
+        action_type: str | None = None,
+        identifier: str | None = None,
+        *_: object,
+    ) -> None:
+        """Re-broadcast sword hits so Luna's passives can respond."""
+
+        if attacker is None or id(attacker) not in self._sword_refs:
+            return
+        owner = self._owner_ref()
+        if owner is None:
+            self.detach()
+            return
+        label = getattr(attacker, "luna_sword_label", None)
+        metadata = {
+            "sword_label": label,
+            "sword_identifier": getattr(attacker, "id", None),
+            "source_identifier": identifier,
+        }
+        per_hit = 4
+        rank = str(getattr(owner, "rank", ""))
+        if "glitched" in rank.lower():
+            per_hit = 8
+        _register_luna_sword(owner, attacker, label or "")
+        passive = _get_luna_passive()
+        entity_id = passive._ensure_charge_slot(owner)  # type: ignore[attr-defined]
+        passive._charge_points[entity_id] = passive._charge_points.get(entity_id, 0) + per_hit  # type: ignore[attr-defined]
+        owner.luna_sword_charge = getattr(owner, "luna_sword_charge", 0) + per_hit
+        try:
+            helper = getattr(owner, "_luna_sword_helper", None)
+            if helper is not None and hasattr(helper, "sync_actions_per_turn"):
+                helper.sync_actions_per_turn()
+        except Exception:
+            pass
+        metadata["charge_handled"] = True
+        await BUS.emit_async(
+            self.EVENT_NAME,
+            owner,
+            attacker,
+            target,
+            amount or 0,
+            action_type or "attack",
+            metadata,
+        )
+
+    def _handle_removal(self, summon: Summon | None, *_: object) -> None:
+        """Drop tracking when a sword is despawned."""
+
+        if summon is None:
+            return
+        sid = id(summon)
+        if sid not in self._sword_refs:
+            return
+        self._sword_refs.pop(sid, None)
+        _get_luna_passive().unregister_sword(summon)
+        if not self._sword_refs:
+            self.detach()
+
+    def detach(self) -> None:
+        """Unsubscribe from event bus callbacks when swords are gone."""
+        for sword_ref in list(self._sword_refs.values()):
+            sword = sword_ref()
+            if sword is not None:
+                _get_luna_passive().unregister_sword(sword)
+        self._sword_refs.clear()
+        BUS.unsubscribe("hit_landed", self._hit_listener)
+        BUS.unsubscribe("summon_removed", self._removal_listener)
+
 
 
 @dataclass
@@ -43,3 +202,48 @@ class Luna(PlayerBase):
         if boss and floor % 3 == 0:
             return 6.0
         return 1.0
+
+    def prepare_for_battle(
+        self,
+        node: MapNode,
+        registry: "PassiveRegistry",
+    ) -> None:
+        previous_helper = getattr(self, "_luna_sword_helper", None)
+        if isinstance(previous_helper, _LunaSwordCoordinator):
+            previous_helper.detach()
+
+        rank = str(getattr(self, "rank", ""))
+        if "boss" not in rank.lower():
+            self._luna_sword_helper = None
+            return
+
+        sword_count = 9 if "glitched" in rank.lower() else 4
+        self.ensure_permanent_summon_slots(sword_count)
+
+        helper = _LunaSwordCoordinator(self, registry)
+        created = False
+        for _ in range(sword_count):
+            label = random.choice(ALL_DAMAGE_TYPES)
+            damage_type = load_damage_type(label)
+            summon = SummonManager.create_summon(
+                self,
+                summon_type=f"luna_sword_{label.lower()}",
+                source="luna_sword",
+                stat_multiplier=1.0,
+                override_damage_type=damage_type,
+                force_create=True,
+            )
+            if summon is None:
+                continue
+            created = True
+            summon.owner_ref = weakref.ref(self)
+            helper.add_sword(summon, label)
+            _register_luna_sword(self, summon, label)
+
+        if not created:
+            helper.detach()
+            self._luna_sword_helper = None
+            return
+
+        helper.sync_actions_per_turn()
+        self._luna_sword_helper = helper

--- a/backend/tests/test_luna_swords.py
+++ b/backend/tests/test_luna_swords.py
@@ -1,0 +1,131 @@
+import pytest
+
+from autofighter.mapgen import MapNode
+from autofighter.party import Party
+from autofighter.rooms.battle.setup import setup_battle
+import pytest
+
+from autofighter.mapgen import MapNode
+import pytest
+
+from autofighter.mapgen import MapNode
+from autofighter.party import Party
+from autofighter.rooms.battle.setup import setup_battle
+from autofighter.stats import BUS
+from autofighter.stats import Stats
+from autofighter.summons.manager import SummonManager
+from plugins.passives.normal.luna_lunar_reservoir import LunaLunarReservoir
+from plugins.players.luna import Luna
+
+
+@pytest.fixture(autouse=True)
+def _reset_luna_state():
+    LunaLunarReservoir._charge_points.clear()
+    LunaLunarReservoir._swords_by_owner.clear()
+    SummonManager.reset_all()
+    yield
+    LunaLunarReservoir._charge_points.clear()
+    LunaLunarReservoir._swords_by_owner.clear()
+    SummonManager.reset_all()
+
+
+def _basic_party() -> Party:
+    member = Stats()
+    member.id = "hero"
+    member.hp = member.max_hp
+    return Party(members=[member], gold=0, relics=[], cards=[], rdr=1.0)
+
+
+def _boss_node() -> MapNode:
+    return MapNode(
+        room_id=0,
+        room_type="battle-boss",
+        floor=3,
+        index=1,
+        loop=1,
+        pressure=0,
+    )
+
+
+@pytest.mark.asyncio
+async def test_luna_boss_spawns_four_swords():
+    node = _boss_node()
+    party = _basic_party()
+    luna = Luna()
+    luna.id = "luna_boss"
+    luna.rank = "boss"
+
+    await setup_battle(node, party, foe=luna)
+
+    swords = SummonManager.get_summons(luna.id)
+    assert len(swords) == 4
+    assert all(getattr(sword, "luna_sword", False) for sword in swords)
+    assert all(str(getattr(sword, "summon_type", "")).startswith("luna_sword_") for sword in swords)
+
+
+@pytest.mark.asyncio
+async def test_luna_glitched_boss_spawns_nine_swords():
+    node = _boss_node()
+    party = _basic_party()
+    luna = Luna()
+    luna.id = "luna_glitched"
+    luna.rank = "glitched boss"
+
+    await setup_battle(node, party, foe=luna)
+
+    swords = SummonManager.get_summons(luna.id)
+    assert len(swords) == 9
+
+
+@pytest.mark.asyncio
+async def test_luna_sword_hits_feed_passive_stacks():
+    node = _boss_node()
+    party = _basic_party()
+    luna = Luna()
+    luna.id = "luna_stack"
+    luna.rank = "boss"
+
+    await setup_battle(node, party, foe=luna)
+
+    swords = SummonManager.get_summons(luna.id)
+    assert swords, "Boss Luna should summon swords"
+    sword = swords[0]
+
+    assert sword.max_hp == luna.max_hp
+    assert sword.atk == luna.atk
+
+    target = Stats()
+    target.id = "target"
+    target.hp = target.max_hp
+
+    before = LunaLunarReservoir.get_charge(luna)
+    await BUS.emit_async("hit_landed", sword, target, 100, "attack", "test")
+    after = LunaLunarReservoir.get_charge(luna)
+
+    assert after - before == 4
+    assert LunaLunarReservoir.get_charge(sword) == after
+
+
+@pytest.mark.asyncio
+async def test_glitched_luna_sword_hits_double_charge():
+    node = _boss_node()
+    party = _basic_party()
+    luna = Luna()
+    luna.id = "luna_glitched_stack"
+    luna.rank = "glitched boss"
+
+    await setup_battle(node, party, foe=luna)
+
+    swords = SummonManager.get_summons(luna.id)
+    assert swords, "Glitched boss Luna should summon swords"
+    sword = swords[0]
+
+    target = Stats()
+    target.id = "dummy"
+    target.hp = target.max_hp
+
+    before = LunaLunarReservoir.get_charge(luna)
+    await BUS.emit_async("hit_landed", sword, target, 100, "attack", "test")
+    after = LunaLunarReservoir.get_charge(luna)
+
+    assert after - before == 8


### PR DESCRIPTION
## Summary
- add a prepare_for_battle hook to PlayerBase and invoke it during battle setup for foes and party members
- implement Luna's boss sword coordinator to spawn swords, track their hits, and feed Luna's passive
- extend Luna's passive to share charge between swords and owner while tracking summon lifecycles
- add regression coverage for Luna boss sword behavior

## Testing
- `PYTHONPATH=. uv run pytest tests/test_luna_swords.py tests/test_battle_setup.py`


------
https://chatgpt.com/codex/tasks/task_b_68ccd4c358bc832cade26b68565362b5