### PR TITLE
fix: resync luna actions after sword charge

### DIFF
--- a/backend/plugins/players/luna.py
+++ b/backend/plugins/players/luna.py
@@ -123,9 +123,7 @@ class _LunaSwordCoordinator:
             per_hit = 8
         _register_luna_sword(owner, attacker, label or "")
         passive = _get_luna_passive()
-        entity_id = passive._ensure_charge_slot(owner)  # type: ignore[attr-defined]
-        passive._charge_points[entity_id] = passive._charge_points.get(entity_id, 0) + per_hit  # type: ignore[attr-defined]
-        owner.luna_sword_charge = getattr(owner, "luna_sword_charge", 0) + per_hit
+        passive.add_charge(owner, amount=per_hit)  # type: ignore[attr-defined]
         try:
             helper = getattr(owner, "_luna_sword_helper", None)
             if helper is not None and hasattr(helper, "sync_actions_per_turn"):


### PR DESCRIPTION
## Summary
- recompute Luna's passive cadence via a shared helper so action counts reflect the latest charge
- invoke the new sync helper from sword charge handling to immediately update Luna and her swords

## Testing
- `PYTHONPATH=backend uv run pytest backend/tests/test_luna_swords.py backend/tests/test_battle_setup.py` *(fails: ModuleNotFoundError: No module named 'rich')*


------
https://chatgpt.com/codex/tasks/task_b_68cce11aa15c832c9b19387af85423f3