### PR TITLE
[FEAT] Render Luna sword summon artwork

### DIFF
--- a/frontend/src/lib/systems/assetLoader.js
+++ b/frontend/src/lib/systems/assetLoader.js
@@ -151,6 +151,15 @@ const SWORD_KEYWORD_ALIASES = {
   wind: 'wind'
 };
 
+const LIGHTSTREAM_SWORD_ELEMENTS = new Set([
+  'fire',
+  'ice',
+  'lightning',
+  'light',
+  'dark',
+  'wind'
+]);
+
 export function normalizeDamageTypeId(typeId) {
   if (!typeId) return 'generic';
   const lowered = String(typeId).trim().toLowerCase();
@@ -434,9 +443,11 @@ function inferSwordElementFromPath(path) {
   const tokens = tokenizeSwordPath(path);
   for (const token of tokens) {
     const alias = SWORD_KEYWORD_ALIASES[token];
-    if (alias) return alias;
+    if (alias && LIGHTSTREAM_SWORD_ELEMENTS.has(alias)) {
+      return alias;
+    }
     const normalized = normalizeDamageTypeId(token);
-    if (normalized && normalized !== 'generic') {
+    if (LIGHTSTREAM_SWORD_ELEMENTS.has(normalized)) {
       return normalized;
     }
   }


### PR DESCRIPTION
## Summary
- add lightstream sword asset loading utilities that normalize file names and provide deterministic selection helpers
- detect Luna sword summons in the battle snapshot, attach their element tint, and share chosen artwork with fighter cards
- render summon sword art with an element-tinted overlay and fallbacks when no custom art exists
- skip tokens that do not resolve to known elements when inferring sword artwork keys so custom assets are discovered reliably

## Testing
- bun run lint *(fails: Script not found "lint")*

------
https://chatgpt.com/codex/tasks/task_b_68ccf0b7c85c832c81f1192e7e85f462