### PR TITLE
Add pacing yields to status tick events

### DIFF
--- a/backend/autofighter/rooms/battle/turns.py
+++ b/backend/autofighter/rooms/battle/turns.py
@@ -23,9 +23,9 @@ from autofighter.summons.manager import SummonManager
 
 from ...stats import Stats
 from ...stats import set_enrage_percent
+from ..utils import _serialize
 from .pacing import YIELD_MULTIPLIER
 from .pacing import pace_sleep
-from ..utils import _serialize
 
 if TYPE_CHECKING:
     from autofighter.effects import EffectManager
@@ -423,6 +423,7 @@ async def _on_target_acquired(
         amount=None,
         metadata=metadata,
     )
+    await pace_sleep(YIELD_MULTIPLIER)
 
 
 async def _on_dot_tick(
@@ -465,6 +466,7 @@ async def _on_dot_tick(
         amount=amount,
         metadata=metadata,
     )
+    await pace_sleep(YIELD_MULTIPLIER)
 
 
 async def _on_hot_tick(
@@ -507,6 +509,7 @@ async def _on_hot_tick(
         amount=amount,
         metadata=metadata,
     )
+    await pace_sleep(YIELD_MULTIPLIER)
 
 
 async def _on_card_effect(


### PR DESCRIPTION
## Summary
- ensure battle event handlers for target acquisition and DoT/HoT ticks yield control after recording events
- keep the pacing imports alongside the new awaits

## Testing
- `uv run --directory backend ruff check autofighter/rooms/battle/turns.py`
- `PYTHONPATH=/workspace/Midori-AI-AutoFighter/backend uv run --directory backend pytest tests/test_card_relic_snapshot_events.py`
- `PYTHONPATH=/workspace/Midori-AI-AutoFighter/backend uv run --directory backend pytest tests/test_battle_engine_async.py` *(fails: ModuleNotFoundError: No module named 'battle_logging' via engine import)*

------
https://chatgpt.com/codex/tasks/task_b_68cd635dfb24832cb5125f22302c053f