### PR TITLE
[FEAT] add turn timeout enforcement

### DIFF
--- a/frontend/src/lib/components/BackendShutdownOverlay.svelte
+++ b/frontend/src/lib/components/BackendShutdownOverlay.svelte
@@ -1,0 +1,152 @@
+<script>
+  import PopupWindow from './PopupWindow.svelte';
+  import { createEventDispatcher } from 'svelte';
+  import { FEEDBACK_URL, CONTACT_EMAIL, BACKEND_LOGS_PATH_HINT } from '../systems/constants.js';
+
+  export let message = 'The backend encountered a critical error.';
+  export let traceback = '';
+  export let status = 500;
+
+  const dispatch = createEventDispatcher();
+
+  $: githubIssueUrl = `${FEEDBACK_URL}?title=${encodeURIComponent(`Backend shutdown (${status})`)}&body=${encodeURIComponent(`### What happened?\nThe backend shut down after returning status ${status}.\n\n### Error message\n${message}\n\n### Traceback\n\n\`\`\`\n${traceback}\n\`\`\`\n\n### Logs\nPlease attach the JSON logs from ${BACKEND_LOGS_PATH_HINT}.`)}`;
+  $: mailtoUrl = `mailto:${CONTACT_EMAIL}?subject=${encodeURIComponent('Midori AI AutoFighter backend shutdown')}&body=${encodeURIComponent(`The backend shut down after returning status ${status}.\n\nError message: ${message}\n\nTraceback:\n${traceback}\n\nLogs: (please attach JSON files from ${BACKEND_LOGS_PATH_HINT})`)}`;
+
+  function openIssue() {
+    window.open(githubIssueUrl, '_blank', 'noopener');
+  }
+
+  function emailSupport() {
+    window.open(mailtoUrl, '_blank', 'noopener');
+  }
+
+  async function copyLogsPath() {
+    try {
+      await navigator.clipboard.writeText(BACKEND_LOGS_PATH_HINT);
+      copyState = 'copied';
+      setTimeout(() => { copyState = 'idle'; }, 2000);
+    } catch (error) {
+      console.error('Failed to copy logs path:', error);
+      copyState = 'error';
+      setTimeout(() => { copyState = 'idle'; }, 2000);
+    }
+  }
+
+  let copyState = 'idle';
+
+  function close() {
+    dispatch('close');
+  }
+</script>
+
+<PopupWindow title="Backend Shutting Down" on:close={close}>
+  <div class="content">
+    <p class="lead">The backend reported a critical error (status {status}) and is shutting down.</p>
+    <p>
+      Please collect the JSON log files from <code>{BACKEND_LOGS_PATH_HINT}</code> (including any
+      <code>battle_summary.json</code> and <code>events.json</code> files) and attach them when you reach out so we can investigate.
+    </p>
+    <p>
+      You can <button class="link-btn" type="button" on:click={openIssue}>open a GitHub issue</button>
+      or email us at <button class="link-btn" type="button" on:click={emailSupport}>{CONTACT_EMAIL}</button>.
+    </p>
+
+    <details class="error-details">
+      <summary>Error details</summary>
+      <pre>{message}\n\n{traceback}</pre>
+    </details>
+
+    <div class="actions">
+      <button class="icon-btn" type="button" on:click={copyLogsPath}>
+        {#if copyState === 'copied'}Copied path!{/if}
+        {#if copyState === 'error'}Copy failed{/if}
+        {#if copyState === 'idle'}Copy logs path{/if}
+      </button>
+      <button class="icon-btn" type="button" on:click={openIssue}>Report on GitHub</button>
+      <button class="icon-btn" type="button" on:click={emailSupport}>Email support</button>
+      <button class="icon-btn" type="button" on:click={close}>Close</button>
+    </div>
+  </div>
+</PopupWindow>
+
+<style>
+  .content {
+    padding: 0.75rem 0.5rem;
+    line-height: 1.45;
+  }
+
+  .lead {
+    font-weight: 600;
+  }
+
+  code {
+    font-family: "Fira Code", "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+    font-size: 0.85rem;
+    background: rgba(255, 255, 255, 0.12);
+    padding: 0.1rem 0.3rem;
+    border-radius: 3px;
+  }
+
+  .link-btn {
+    background: none;
+    border: none;
+    color: #8dd8ff;
+    cursor: pointer;
+    padding: 0;
+    text-decoration: underline;
+    font: inherit;
+  }
+
+  .link-btn:hover,
+  .link-btn:focus {
+    color: #b4e5ff;
+  }
+
+  .error-details {
+    margin: 0.75rem 0;
+    background: rgba(0, 0, 0, 0.45);
+    border: 1px solid rgba(255, 255, 255, 0.15);
+  }
+
+  .error-details summary {
+    cursor: pointer;
+    padding: 0.35rem 0.5rem;
+    font-weight: 600;
+    list-style: none;
+  }
+
+  .error-details pre {
+    margin: 0;
+    padding: 0.5rem;
+    max-height: 40vh;
+    overflow: auto;
+    white-space: pre-wrap;
+  }
+
+  .actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    justify-content: flex-end;
+    margin-top: 0.75rem;
+    padding: 0.5rem 0.7rem;
+    background: var(--glass-bg);
+    box-shadow: var(--glass-shadow);
+    border: var(--glass-border);
+    backdrop-filter: var(--glass-filter);
+  }
+
+  .icon-btn {
+    background: rgba(255, 255, 255, 0.1);
+    border: none;
+    border-radius: 0;
+    color: #fff;
+    padding: 0.35rem 0.6rem;
+    cursor: pointer;
+  }
+
+  .icon-btn:hover,
+  .icon-btn:focus {
+    background: rgba(255, 255, 255, 0.2);
+  }
+</style>

--- a/frontend/src/lib/components/OverlayHost.svelte
+++ b/frontend/src/lib/components/OverlayHost.svelte
@@ -22,6 +22,7 @@
     import BattleView from './BattleView.svelte';
   import ErrorOverlay from './ErrorOverlay.svelte';
   import BackendNotReady from './BackendNotReady.svelte';
+  import BackendShutdownOverlay from './BackendShutdownOverlay.svelte';
   import FloatingLoot from './FloatingLoot.svelte';
   import CombatViewer from './CombatViewer.svelte';
   import { rewardOpen as computeRewardOpen } from '../systems/viewportState.js';
@@ -201,6 +202,15 @@
   <ErrorOverlay
     message={$overlayData.message || 'An unexpected error occurred.'}
     traceback={$overlayData.traceback || ''}
+    on:close={() => dispatch('back')}
+  />
+{/if}
+
+{#if $overlayView === 'backend-shutdown'}
+  <BackendShutdownOverlay
+    message={$overlayData.message || 'A critical backend error occurred.'}
+    traceback={$overlayData.traceback || ''}
+    status={$overlayData.status || 500}
     on:close={() => dispatch('back')}
   />
 {/if}

--- a/frontend/src/lib/systems/constants.js
+++ b/frontend/src/lib/systems/constants.js
@@ -2,3 +2,5 @@ export const FEEDBACK_URL =
   'https://github.com/Midori-AI-OSS/Midori-AI-AutoFighter/issues/new/choose';
 export const DISCORD_URL = 'https://discord.gg/xdgCx3VyHU';
 export const WEBSITE_URL = 'https://io.midori-ai.xyz/';
+export const CONTACT_EMAIL = 'contact-us@midori-ai.xyz';
+export const BACKEND_LOGS_PATH_HINT = 'backend/logs';


### PR DESCRIPTION
## Summary
- add a shared TurnTimeoutError and timeout logging utilities for battle turn loops
- wrap player and foe turn iterations with asyncio.wait_for and capture timeout details for logging
- propagate timeout failures through the turn orchestrator and battle engine and add a regression test covering the behaviour
- surface a backend shutdown overlay in the web UI so users know to collect JSON logs and contact the team

## Testing
- `uv run ruff check autofighter/rooms/battle/turn_loop`
- `uv run ruff check tests/test_turn_timeout.py`
- `uv run pytest tests/test_turn_timeout.py`
- `bun run lint`


------
https://chatgpt.com/codex/tasks/task_b_68cd7728abf0832cacc27a4ec4be8835