### PR TITLE
feat: support configurable player spawn multipliers

### DIFF
--- a/backend/plugins/players/luna.py
+++ b/backend/plugins/players/luna.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from dataclasses import field
 import random
 from typing import TYPE_CHECKING
+from typing import ClassVar
 from typing import Collection
 import weakref
 
@@ -179,6 +180,7 @@ class Luna(PlayerBase):
     passives: list[str] = field(default_factory=lambda: ["luna_lunar_reservoir"])
     # UI hint: show numeric actions indicator
     actions_display: str = "number"
+    spawn_weight_multiplier: ClassVar[dict[str, float]] = {"non_boss": 5.0}
 
     @classmethod
     def get_spawn_weight(
@@ -192,14 +194,25 @@ class Luna(PlayerBase):
         if cls.id in {str(pid) for pid in party_ids}:
             return 0.0
 
+        base_weight = super().get_spawn_weight(
+            node=node,
+            party_ids=party_ids,
+            recent_ids=recent_ids,
+            boss=boss,
+        )
+        try:
+            weight = float(base_weight)
+        except (TypeError, ValueError):
+            weight = 1.0
+
         try:
             floor = int(getattr(node, "floor", 0))
         except Exception:
             floor = 0
 
         if boss and floor % 3 == 0:
-            return 6.0
-        return 1.0
+            return weight * 6.0
+        return weight
 
     def prepare_for_battle(
         self,

--- a/backend/tests/test_luna_weighting.py
+++ b/backend/tests/test_luna_weighting.py
@@ -7,6 +7,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from autofighter.mapgen import MapNode
 from autofighter.party import Party
+from autofighter.rooms import foe_factory
 from autofighter.rooms import utils
 from plugins.players import Player
 from plugins.players.luna import Luna
@@ -21,7 +22,7 @@ def _capture_weights(monkeypatch, node: MapNode, party: Party) -> dict[str, floa
             captured[str(ident)] = weight
         return [candidates[0]]
 
-    monkeypatch.setattr(utils.random, "choices", fake_choices)
+    monkeypatch.setattr(foe_factory.random, "choices", fake_choices)
     utils._choose_foe(node, party)
     return captured
 
@@ -56,6 +57,13 @@ def test_luna_boss_weight_default_other_floors(monkeypatch) -> None:
     party = Party(members=[Player()])
     weights = _capture_weights(monkeypatch, node, party)
     assert weights.get("luna") == pytest.approx(1.0)
+
+
+def test_luna_non_boss_weight_multiplier(monkeypatch) -> None:
+    node = MapNode(room_id=0, room_type="normal", floor=1, index=1, loop=1, pressure=0)
+    party = Party(members=[Player()])
+    weights = _capture_weights(monkeypatch, node, party)
+    assert weights.get("luna") == pytest.approx(5.0)
 
 
 def test_luna_weighting_respects_party_ids() -> None:


### PR DESCRIPTION
## Summary
- add a configurable spawn weight multiplier hook to the player base class
- register Luna's non-boss multiplier through the shared hook while preserving boss weighting
- extend the Luna weighting tests to cover the new non-boss odds and intercept the factory RNG

## Testing
- uv run pytest tests/test_luna_weighting.py
- uv run ruff check plugins/players/_base.py plugins/players/luna.py tests/test_luna_weighting.py --fix

------
https://chatgpt.com/codex/tasks/task_b_68cd8effa364832cb591783b08ec76f1