### PR TITLE
feat: replace StarStorm starfield with orb gradients

### DIFF
--- a/frontend/.codex/implementation/starstorm.md
+++ b/frontend/.codex/implementation/starstorm.md
@@ -1,3 +1,3 @@
 # StarStorm Component
 
-Adds a field of falling element-colored stars. A global `storm-blur` layer duplicates the star positions with a heavy blur and soft opacity, replacing the previous per-star `blob` overlay. Star lifetimes remain slowed by roughly doubling their animation duration and delay ranges.
+Renders a small constellation of orbiting element-colored orbs. Each orb has a fixed position, radius, and drift timing, and is rendered exactly once with a layered radial gradient that mixes its base color with the component tint. Slow transform/opacity animations are handled purely in CSS, so retinting the `StarStorm` background simply updates gradient stops instead of respawning DOM nodes. A reduced-motion branch swaps the animation for a static blended gradient so the background remains gently tinted without movement.


### PR DESCRIPTION
## Summary
- replace the StarStorm particle generator with a fixed set of animated orb descriptors and CSS-driven tinting
- render each orb once with screen-blended radial gradients and a reduced-motion fallback overlay
- update the StarStorm design note to describe the orb-based backdrop

## Testing
- bun run lint
- bun run build *(fails: vite waits for backend service to become ready in this container)*

------
https://chatgpt.com/codex/tasks/task_b_68cd938e01a4832c9435c66f557ad9bd