### PR TITLE
feat(shop): support multi-item purchases

### DIFF
--- a/backend/autofighter/rooms/shop.py
+++ b/backend/autofighter/rooms/shop.py
@@ -164,6 +164,8 @@ class ShopRoom(Room):
             payload_items = data.get("items")
             if isinstance(payload_items, list) and payload_items:
                 purchases = [p for p in payload_items if isinstance(p, dict)]
+            elif isinstance(payload_items, dict) and payload_items:
+                purchases = [payload_items]
             else:
                 item_id = data.get("id") or data.get("item")
                 cost_value = data.get("cost") or data.get("price")


### PR DESCRIPTION
## Summary
- allow the shop room resolver to process multi-item purchase payloads while keeping the legacy single-item pathway intact
- add tests covering sequential multi-item purchases and graceful handling of invalid entries

## Testing
- uv tool run ruff check backend/autofighter/rooms/shop.py backend/tests/test_shop_room.py --fix
- uv run -m pytest tests/test_shop_room.py

------
https://chatgpt.com/codex/tasks/task_b_68cd97ada7f0832ca78285af44d53a49