### PR TITLE
feat(frontend): batch shop purchases

### DIFF
--- a/backend/autofighter/rooms/shop.py
+++ b/backend/autofighter/rooms/shop.py
@@ -164,6 +164,8 @@ class ShopRoom(Room):
             payload_items = data.get("items")
             if isinstance(payload_items, list) and payload_items:
                 purchases = [p for p in payload_items if isinstance(p, dict)]
+            elif isinstance(payload_items, dict) and payload_items:
+                purchases = [payload_items]
             else:
                 item_id = data.get("id") or data.get("item")
                 cost_value = data.get("cost") or data.get("price")


### PR DESCRIPTION
## Summary
- normalize shop menu purchase payloads and dispatch a single event containing either a lone item or the selected cart entries
- convert the shop buy handler to coerce incoming details into list or single-item payloads and forward them to the backend via the `items` key

## Testing
- ./run-tests.sh
- (cd frontend && bun run lint)


------
https://chatgpt.com/codex/tasks/task_b_68cdc1b22154832c94a74382b09fefcc