### PR TITLE
feat: scale boss foes before battle prep

### DIFF
--- a/backend/autofighter/rooms/battle/setup.py
+++ b/backend/autofighter/rooms/battle/setup.py
@@ -75,6 +75,11 @@ async def setup_battle(
 
     for stats in foes:
         _scale_stats(stats, node, strength)
+        rank = getattr(stats, "rank", "")
+        if isinstance(rank, str) and "boss" in rank.lower():
+            boss_scaling = getattr(stats, "apply_boss_scaling", None)
+            if callable(boss_scaling):
+                boss_scaling()
         prepare = getattr(stats, "prepare_for_battle", None)
         if callable(prepare):
             prepare(node, registry)


### PR DESCRIPTION
## Summary
- call boss scaling hooks during battle setup for enemies whose rank contains "boss"
- add a regression test confirming Luna applies her boss scaling when treated as a boss

## Testing
- [x] Backend tests (`uv run pytest tests/test_luna_weighting.py`)
- [ ] Frontend tests
- [x] Linting (`uv run ruff check autofighter/rooms/battle/setup.py tests/test_luna_weighting.py --fix`)
- [ ] Doc sync updates (README and `.codex/implementation` docs; link tasks below)


------
https://chatgpt.com/codex/tasks/task_b_68cfae7662a8832c80ed2cf4739dcd79