### PR TITLE
Align Micro Blade bonus damage element

### DIFF
--- a/backend/plugins/cards/a_micro_blade.py
+++ b/backend/plugins/cards/a_micro_blade.py
@@ -6,6 +6,8 @@ import random
 from autofighter.stats import BUS
 from plugins.cards._base import CardBase
 from plugins.cards._base import safe_async_task
+from plugins.damage_types import load_damage_type
+from plugins.damage_types import random_damage_type
 
 log = logging.getLogger(__name__)
 
@@ -16,7 +18,10 @@ class MicroBlade(CardBase):
     name: str = "Micro Blade"
     stars: int = 1
     effects: dict[str, float] = field(default_factory=lambda: {"atk": 0.03})
-    about: str = "+3% ATK; Attacks have a 6% chance to deal +8% bonus physical damage on hit"
+    about: str = (
+        "+3% ATK; Attacks have a 6% chance to deal +8% bonus damage that matches "
+        "the attacker's element"
+    )
 
     async def apply(self, party) -> None:  # type: ignore[override]
         await super().apply(party)
@@ -24,10 +29,22 @@ class MicroBlade(CardBase):
         async def _on_damage_dealt(attacker, target, damage, damage_type, source, source_action, action_name):
             # Check if attacker is one of our party members and this is an attack
             if attacker in party.members and action_name == "attack":
-                # 6% chance to deal +8% bonus physical damage
+                # 6% chance to deal +8% bonus damage aligned with the attacker
                 if random.random() < 0.06:
                     bonus_damage = int(damage * 0.08)
                     if bonus_damage > 0:
+                        attacker_damage_type = getattr(attacker, "damage_type", None)
+                        if hasattr(attacker_damage_type, "id"):
+                            resolved_damage_type = attacker_damage_type
+                        elif isinstance(attacker_damage_type, str):
+                            resolved_damage_type = load_damage_type(attacker_damage_type)
+                        else:
+                            resolved_damage_type = random_damage_type()
+                        damage_type_id = getattr(
+                            resolved_damage_type,
+                            "id",
+                            str(resolved_damage_type),
+                        )
                         safe_async_task(
                             target.apply_damage(
                                 bonus_damage,
@@ -37,7 +54,9 @@ class MicroBlade(CardBase):
                             )
                         )
                         log.debug(
-                            "Micro Blade bonus damage: +%d physical damage", bonus_damage
+                            "Micro Blade bonus damage: +%d %s damage",
+                            bonus_damage,
+                            damage_type_id,
                         )
                         await BUS.emit_async(
                             "card_effect",
@@ -48,7 +67,7 @@ class MicroBlade(CardBase):
                             {
                                 "bonus_damage": bonus_damage,
                                 "trigger_chance": 0.06,
-                                "damage_type": "physical",
+                                "damage_type": damage_type_id,
                             },
                         )
 


### PR DESCRIPTION
## Summary
- resolve Micro Blade bonus damage element from the attacker or a random fallback and propagate it through logging and card effect payloads
- refresh the card description to describe the element-matching bonus damage

## Testing
- uv run bash run-tests.sh *(fails: missing llms, battle_logging modules, accelerate dependency, Celestial Atrophy assertion)*

------
https://chatgpt.com/codex/tasks/task_b_68cfaf7cc354832c87ea8f7d61276984