### PR TITLE
[FIX] Persist Null Lantern suppression state

### DIFF
--- a/backend/autofighter/party.py
+++ b/backend/autofighter/party.py
@@ -11,3 +11,5 @@ class Party:
     relics: list[str] = field(default_factory=list)
     cards: list[str] = field(default_factory=list)
     rdr: float = 1.0
+    no_shops: bool = False
+    no_rests: bool = False

--- a/backend/autofighter/rooms/battle/engine.py
+++ b/backend/autofighter/rooms/battle/engine.py
@@ -154,6 +154,14 @@ async def run_battle(
     party.gold = combat_party.gold
     party.relics = combat_party.relics
     party.cards = combat_party.cards
+    party.no_shops = getattr(combat_party, "no_shops", getattr(party, "no_shops", False))
+    party.no_rests = getattr(combat_party, "no_rests", getattr(party, "no_rests", False))
+
+    if hasattr(combat_party, "pull_tokens"):
+        party.pull_tokens = getattr(combat_party, "pull_tokens", getattr(party, "pull_tokens", 0))
+    if hasattr(combat_party, "_null_lantern_cleared"):
+        cleared = getattr(combat_party, "_null_lantern_cleared", 0)
+        setattr(party, "_null_lantern_cleared", cleared)
 
     if any(member.hp > 0 for member in party.members) and exp_reward > 0:
         for member in party.members:

--- a/backend/autofighter/rooms/battle/setup.py
+++ b/backend/autofighter/rooms/battle/setup.py
@@ -91,7 +91,14 @@ async def setup_battle(
         relics=party.relics,
         cards=party.cards,
         rdr=party.rdr,
+        no_shops=getattr(party, "no_shops", False),
+        no_rests=getattr(party, "no_rests", False),
     )
+
+    if hasattr(party, "pull_tokens"):
+        combat_party.pull_tokens = getattr(party, "pull_tokens", 0)
+    if hasattr(party, "_null_lantern_cleared"):
+        setattr(combat_party, "_null_lantern_cleared", getattr(party, "_null_lantern_cleared", 0))
 
     await apply_cards(combat_party)
     await _apply_relics_async(combat_party)

--- a/backend/runs/party_manager.py
+++ b/backend/runs/party_manager.py
@@ -325,8 +325,7 @@ def load_party(run_id: str) -> Party:
         tokens = int(data.get("pull_tokens", 0) or 0)
     except Exception:
         tokens = 0
-    if tokens:
-        party.pull_tokens = tokens
+    setattr(party, "pull_tokens", tokens)
     return party
 
 def save_party(run_id: str, party: Party) -> None:

--- a/backend/runs/party_manager.py
+++ b/backend/runs/party_manager.py
@@ -310,9 +310,23 @@ def load_party(run_id: str) -> Party:
         relics=data.get("relics", []),
         cards=data.get("cards", []),
         rdr=stored_rdr + daily_bonus,
+        no_shops=bool(data.get("no_shops", False)),
+        no_rests=bool(data.get("no_rests", False)),
     )
     setattr(party, "login_rdr_bonus", daily_bonus)
     setattr(party, "base_rdr", stored_rdr)
+    try:
+        cleared = int(data.get("null_lantern_cleared", 0) or 0)
+    except Exception:
+        cleared = 0
+    if cleared:
+        setattr(party, "_null_lantern_cleared", cleared)
+    try:
+        tokens = int(data.get("pull_tokens", 0) or 0)
+    except Exception:
+        tokens = 0
+    if tokens:
+        party.pull_tokens = tokens
     return party
 
 def save_party(run_id: str, party: Party) -> None:
@@ -336,6 +350,10 @@ def save_party(run_id: str, party: Party) -> None:
             "level": {m.id: m.level for m in party.members},
             "exp_multiplier": {m.id: m.exp_multiplier for m in party.members},
             "rdr": _extract_base_rdr(party),
+            "no_shops": bool(getattr(party, "no_shops", False)),
+            "no_rests": bool(getattr(party, "no_rests", False)),
+            "null_lantern_cleared": int(getattr(party, "_null_lantern_cleared", 0) or 0),
+            "pull_tokens": int(getattr(party, "pull_tokens", 0) or 0),
             "player": snapshot,
         }
         conn.execute(

--- a/backend/services/room_service.py
+++ b/backend/services/room_service.py
@@ -22,11 +22,11 @@ from autofighter.rooms import BattleRoom
 from autofighter.rooms import BossRoom
 from autofighter.rooms import ChatRoom
 from autofighter.rooms import ShopRoom
-from autofighter.rooms import calculate_rank_probabilities
 from autofighter.rooms import _build_foes
 from autofighter.rooms import _choose_foe
 from autofighter.rooms import _scale_stats
 from autofighter.rooms import _serialize
+from autofighter.rooms import calculate_rank_probabilities
 from autofighter.summons.manager import SummonManager
 from plugins import foes as foe_plugins
 from plugins.damage_types import load_damage_type
@@ -305,7 +305,17 @@ async def battle_room(run_id: str, data: dict[str, Any]) -> dict[str, Any]:
             relics=party.relics,
             cards=party.cards,
             rdr=party.rdr,
+            no_shops=getattr(party, "no_shops", False),
+            no_rests=getattr(party, "no_rests", False),
         )
+        if hasattr(party, "pull_tokens"):
+            combat_party.pull_tokens = getattr(party, "pull_tokens", 0)
+        if hasattr(party, "_null_lantern_cleared"):
+            setattr(
+                combat_party,
+                "_null_lantern_cleared",
+                getattr(party, "_null_lantern_cleared", 0),
+            )
         battle_snapshots[run_id] = {
             "result": "battle",
             "party": [_serialize(m) for m in combat_party.members],
@@ -518,7 +528,17 @@ async def boss_room(run_id: str, data: dict[str, Any]) -> dict[str, Any]:
             relics=party.relics,
             cards=party.cards,
             rdr=party.rdr,
+            no_shops=getattr(party, "no_shops", False),
+            no_rests=getattr(party, "no_rests", False),
         )
+        if hasattr(party, "pull_tokens"):
+            combat_party.pull_tokens = getattr(party, "pull_tokens", 0)
+        if hasattr(party, "_null_lantern_cleared"):
+            setattr(
+                combat_party,
+                "_null_lantern_cleared",
+                getattr(party, "_null_lantern_cleared", 0),
+            )
         battle_snapshots[run_id] = {
             "result": "boss",
             "party": [_serialize(m) for m in combat_party.members],

--- a/backend/services/run_service.py
+++ b/backend/services/run_service.py
@@ -71,9 +71,6 @@ async def start_run(
     run_id = str(uuid4())
     start_run_logging(run_id)
 
-    generator = MapGenerator(run_id, pressure=pressure)
-    nodes = generator.generate_floor()
-
     party_members: list[player_plugins._base.PlayerBase] = []
     party_info: list[dict[str, object]] = []
     for pid in members:
@@ -103,6 +100,9 @@ async def start_run(
         cards=[],
         rdr=1.0,
     )
+
+    generator = MapGenerator(run_id, pressure=pressure)
+    nodes = generator.generate_floor(party=initial_party)
 
     boss_choice = None
     if initial_party.members and nodes:
@@ -275,20 +275,21 @@ async def advance_room(run_id: str) -> dict[str, object]:
         except Exception:
             next_floor, loop, pressure = 1, 1, 0
 
+        try:
+            party = await asyncio.to_thread(load_party, run_id)
+        except Exception:
+            party = None
+
         generator = MapGenerator(
             f"{run_id}-floor-{next_floor}", floor=next_floor, loop=loop, pressure=pressure
         )
-        nodes = generator.generate_floor()
+        nodes = generator.generate_floor(party=party)
         state["rooms"] = [n.to_dict() for n in nodes]
         state["current"] = 1
         state["floors_cleared"] = int(state.get("floors_cleared", 0)) + 1
         state["current_pressure"] = int(getattr(nodes[-1], "pressure", pressure)) if nodes else int(pressure)
         new_floor = getattr(nodes[-1], "floor", next_floor) if nodes else next_floor
         new_loop = getattr(nodes[-1], "loop", loop) if nodes else loop
-        try:
-            party = await asyncio.to_thread(load_party, run_id)
-        except Exception:
-            party = None
         if party and party.members and nodes:
             boss_choice = _choose_foe(nodes[-1], party)
             state["floor_boss"] = {

--- a/backend/tests/test_null_lantern_suppression.py
+++ b/backend/tests/test_null_lantern_suppression.py
@@ -1,0 +1,80 @@
+import asyncio
+from pathlib import Path
+import sys
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from runs import encryption as enc
+from runs.lifecycle import load_map
+from runs.party_manager import load_party
+from runs.party_manager import save_party
+from services.run_service import advance_room
+from services.run_service import start_run
+
+from autofighter.mapgen import MapGenerator
+from autofighter.stats import BUS
+from plugins.relics.null_lantern import NullLantern
+
+
+@pytest.fixture(autouse=True)
+def reset_save(monkeypatch, tmp_path):
+    original_manager = enc.SAVE_MANAGER
+    original_fernet = enc.FERNET
+    monkeypatch.setenv("AF_DB_PATH", str(tmp_path / "null_lantern.db"))
+    enc.SAVE_MANAGER = None
+    enc.FERNET = None
+    yield
+    enc.SAVE_MANAGER = original_manager
+    enc.FERNET = original_fernet
+
+
+@pytest.mark.asyncio
+async def test_null_lantern_removes_future_shops():
+    run_state = await start_run(["player"])
+    run_id = run_state["run_id"]
+
+    _, initial_nodes = await asyncio.to_thread(load_map, run_id)
+    interior_initial = [node.room_type for node in initial_nodes[1:-1]]
+    assert "shop" in interior_initial  # sanity check the baseline map
+
+    party = await asyncio.to_thread(load_party, run_id)
+    relic = NullLantern()
+    party.relics.append(relic.id)
+    await relic.apply(party)
+    assert party.no_shops is True
+    assert party.no_rests is True
+    await asyncio.to_thread(save_party, run_id, party)
+
+    # Clean up event bus subscribers to avoid leaking state between tests
+    state = getattr(party, "_null_lantern_state", None)
+    if isinstance(state, dict):
+        handler = state.get("battle_start_handler")
+        if handler is not None:
+            BUS.unsubscribe("battle_start", handler)
+        end_handler = state.get("battle_end_handler")
+        if end_handler is not None:
+            BUS.unsubscribe("battle_end", end_handler)
+        cleanup_handler = state.get("cleanup_handler")
+        if cleanup_handler is not None:
+            BUS.unsubscribe("battle_end", cleanup_handler)
+        if hasattr(party, "_null_lantern_state"):
+            delattr(party, "_null_lantern_state")
+
+    persisted_party = await asyncio.to_thread(load_party, run_id)
+    assert persisted_party.no_shops is True
+    assert persisted_party.no_rests is True
+
+    saw_reset = False
+    for _ in range(MapGenerator.rooms_per_floor * 2):
+        result = await advance_room(run_id)
+        if result.get("current_index") == 1:
+            saw_reset = True
+            break
+    assert saw_reset, "expected to reach the next floor"
+
+    _, new_nodes = await asyncio.to_thread(load_map, run_id)
+    inner_types = [node.room_type for node in new_nodes[1:-1]]
+    assert "shop" not in inner_types
+    assert "rest" not in inner_types


### PR DESCRIPTION
## Summary
- persist Null Lantern suppression flags on the Party model, copying them through battle resolution and persistence flows
- update map generation and room service helpers to honor suppression when creating combat parties and new floors
- add a regression test that equips Null Lantern and ensures subsequent floors contain no shop or rest rooms

## Testing
- uv run ruff check autofighter/party.py autofighter/mapgen.py autofighter/rooms/battle/engine.py autofighter/rooms/battle/setup.py services/room_service.py services/run_service.py runs/party_manager.py tests/test_null_lantern_suppression.py
- uv run pytest tests/test_mapgen.py tests/test_null_lantern_suppression.py

------
https://chatgpt.com/codex/tasks/task_b_68cfb63d7808832ca0b1708c5c2d933e