### PR TITLE
Add Null Lantern pull rewards to warp tickets

### DIFF
--- a/backend/runs/party_manager.py
+++ b/backend/runs/party_manager.py
@@ -325,8 +325,7 @@ def load_party(run_id: str) -> Party:
         tokens = int(data.get("pull_tokens", 0) or 0)
     except Exception:
         tokens = 0
-    if tokens:
-        party.pull_tokens = tokens
+    setattr(party, "pull_tokens", tokens)
     return party
 
 def save_party(run_id: str, party: Party) -> None:


### PR DESCRIPTION
## Summary
- ensure Null Lantern-earned pull tokens are converted into ticket loot so gacha inventory updates correctly
- persist pull token counts when loading parties
- add an integration test that wins a Null Lantern battle and verifies tickets are saved for warps

## Testing
- uv run pytest tests/test_null_lantern_suppression.py::test_null_lantern_awards_pull_tickets

------
https://chatgpt.com/codex/tasks/task_b_68cfba81ca84832cb0d159a492c3cfda