### PR TITLE
fix: end battle poll when run missing

### DIFF
--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -705,7 +705,18 @@
       }
     } catch (err) {
       // Treat snapshot errors as transient unless run is confirmed ended.
-      if (shouldHandleRunEndError(err)) {
+      const messageCandidates = [];
+      if (typeof err === 'string') messageCandidates.push(err);
+      if (typeof err?.message === 'string') messageCandidates.push(err.message);
+      if (typeof err?.error === 'string') messageCandidates.push(err.error);
+      if (typeof err?.body?.message === 'string') messageCandidates.push(err.body.message);
+      if (typeof err?.response?.message === 'string') messageCandidates.push(err.response.message);
+
+      const hasNoActiveRunMessage = messageCandidates
+        .map((msg) => (typeof msg === 'string' ? msg.toLowerCase() : ''))
+        .some((msg) => msg.includes('no active run'));
+
+      if (shouldHandleRunEndError(err) || hasNoActiveRunMessage) {
         handleRunEnd();
         return;
       }


### PR DESCRIPTION
## Summary
- treat pollBattle errors containing "no active run" as run termination
- halt the poller immediately so battle teardown runs without rescheduling

## Testing
- bun run lint

------
https://chatgpt.com/codex/tasks/task_b_68cfc2ae8230832c93cf90fc74118f18