### PR TITLE
fix: handle aborted pull results audio playback

### DIFF
--- a/frontend/src/lib/components/PullResultsOverlay.svelte
+++ b/frontend/src/lib/components/PullResultsOverlay.svelte
@@ -77,7 +77,15 @@
       } else {
         node.volume = dealSfx.volume;
       }
-      node.play();
+      node
+        .play()
+        .catch((error) => {
+          if (error?.name === 'AbortError') {
+            console.debug('PullResultsOverlay: playback aborted');
+          } else {
+            console.debug('PullResultsOverlay: playback failed', error);
+          }
+        });
     } catch {}
   }
 

--- a/frontend/tests/pullresultsoverlay.test.js
+++ b/frontend/tests/pullresultsoverlay.test.js
@@ -11,5 +11,7 @@ describe('PullResultsOverlay component', () => {
     expect(content).toContain('crossfade');
     expect(content).toContain('stack =');
     expect(content).toContain('dealNext');
+    expect(content).toContain('catch((error) => {');
+    expect(content).toContain('PullResultsOverlay: playback aborted');
   });
 });


### PR DESCRIPTION
## Summary
- wrap the pull results deal sound playback in a rejection handler to keep aborted audio from surfacing as unhandled rejections
- add lightweight debug logging when playback aborts or fails for diagnostic context

## Testing
- VITE_API_BASE=http://localhost bun run build
- bun run lint

------
https://chatgpt.com/codex/tasks/task_b_68cfcc06e63c832c8c2f5710a2549b53