### PR TITLE
feat: add relic bus subscription management

### DIFF
--- a/backend/plugins/relics/bent_dagger.py
+++ b/backend/plugins/relics/bent_dagger.py
@@ -44,7 +44,7 @@ class BentDagger(RelicBase):
                     "triggered_by_kill": True
                 })
 
-        BUS.subscribe("damage_taken", _on_death)
+        self.subscribe(party, "damage_taken", _on_death)
 
     def describe(self, stacks: int) -> str:
         if stacks == 1:

--- a/backend/plugins/relics/echo_bell.py
+++ b/backend/plugins/relics/echo_bell.py
@@ -26,76 +26,70 @@ class EchoBell(RelicBase):
         stacks = party.relics.count(self.id)
 
         if state is None:
-            used: set[int] = set()
-
-            def _battle_start(*_args) -> None:
-                used.clear()
-
-            async def _action(actor, target, amount, action_type="damage") -> None:
-                global _echo_processing
-                # Prevent infinite loops from recursive echo effects
-                if _echo_processing:
-                    return
-
-                pid = id(actor)
-                if pid in used:
-                    return
-                used.add(pid)
-                current_stacks = state.get("stacks", 0)
-                if current_stacks <= 0:
-                    return
-
-                # Set flag to prevent recursive echo effects
-                _echo_processing = True
-                try:
-                    echo_amount = int(amount * 0.15 * current_stacks)
-
-                    # Emit relic effect event for echo action
-                    await BUS.emit_async("relic_effect", "echo_bell", actor, "echo_action", echo_amount, {
-                        "original_amount": amount,
-                        "echo_percentage": 15 * current_stacks,
-                        "target": getattr(target, 'id', str(target)),
-                        "first_action": True,
-                        "action_type": action_type,
-                        "stacks": current_stacks
-                    })
-
-                    # Echo the same type of action - damage or healing
-                    if action_type == "healing":
-                        safe_async_task(target.apply_healing(echo_amount, healer=actor))
-                    else:
-                        safe_async_task(target.apply_damage(echo_amount, attacker=actor))
-                finally:
-                    _echo_processing = False
-
-            def _healing(actor, target, amount) -> None:
-                _action(actor, target, amount, "healing")
-
-            def _cleanup(*_args) -> None:
-                BUS.unsubscribe("battle_start", state["battle_start_handler"])
-                BUS.unsubscribe("action_used", state["action_handler"])
-                BUS.unsubscribe("healing_used", state["healing_handler"])
-                BUS.unsubscribe("battle_end", state["cleanup_handler"])
-                used.clear()
-                if getattr(party, "_echo_bell_state", None) is state:
-                    delattr(party, "_echo_bell_state")
-
             state = {
                 "stacks": stacks,
-                "used": used,
-                "battle_start_handler": _battle_start,
-                "action_handler": _action,
-                "healing_handler": _healing,
-                "cleanup_handler": _cleanup,
+                "used": set(),
             }
             party._echo_bell_state = state
-
-            BUS.subscribe("battle_start", _battle_start)
-            BUS.subscribe("action_used", _action)
-            BUS.subscribe("healing_used", _healing)
-            BUS.subscribe("battle_end", _cleanup)
         else:
             state["stacks"] = stacks
+
+        used: set[int] = state.setdefault("used", set())
+
+        def _battle_start(*_args) -> None:
+            used.clear()
+
+        async def _action(actor, target, amount, action_type="damage") -> None:
+            global _echo_processing
+            # Prevent infinite loops from recursive echo effects
+            if _echo_processing:
+                return
+
+            pid = id(actor)
+            if pid in used:
+                return
+            used.add(pid)
+            current_state = getattr(party, "_echo_bell_state", state)
+            current_stacks = current_state.get("stacks", 0)
+            if current_stacks <= 0:
+                return
+
+            # Set flag to prevent recursive echo effects
+            _echo_processing = True
+            try:
+                echo_amount = int(amount * 0.15 * current_stacks)
+
+                # Emit relic effect event for echo action
+                await BUS.emit_async("relic_effect", "echo_bell", actor, "echo_action", echo_amount, {
+                    "original_amount": amount,
+                    "echo_percentage": 15 * current_stacks,
+                    "target": getattr(target, 'id', str(target)),
+                    "first_action": True,
+                    "action_type": action_type,
+                    "stacks": current_stacks
+                })
+
+                # Echo the same type of action - damage or healing
+                if action_type == "healing":
+                    safe_async_task(target.apply_healing(echo_amount, healer=actor))
+                else:
+                    safe_async_task(target.apply_damage(echo_amount, attacker=actor))
+            finally:
+                _echo_processing = False
+
+        async def _healing(actor, target, amount) -> None:
+            await _action(actor, target, amount, "healing")
+
+        def _cleanup(*_args) -> None:
+            self.clear_subscriptions(party)
+            used.clear()
+            if getattr(party, "_echo_bell_state", None) is state:
+                delattr(party, "_echo_bell_state")
+
+        self.subscribe(party, "battle_start", _battle_start)
+        self.subscribe(party, "action_used", _action)
+        self.subscribe(party, "healing_used", _healing)
+        self.subscribe(party, "battle_end", _cleanup)
 
     def describe(self, stacks: int) -> str:
         pct = 15 * stacks

--- a/backend/plugins/relics/echoing_drum.py
+++ b/backend/plugins/relics/echoing_drum.py
@@ -26,65 +26,58 @@ class EchoingDrum(RelicBase):
         stacks = party.relics.count(self.id)
 
         if state is None:
-            used: set[int] = set()
-
-            def _battle_start(*_args) -> None:
-                used.clear()
-
-            async def _attack(attacker, target, amount) -> None:
-                global _echo_processing
-                # Prevent infinite loops from recursive echo effects
-                if _echo_processing:
-                    return
-
-                pid = id(attacker)
-                if pid in used:
-                    return
-                used.add(pid)
-                current_stacks = state.get("stacks", 0)
-                if current_stacks <= 0:
-                    return
-
-                # Set flag to prevent recursive echo effects
-                _echo_processing = True
-                try:
-                    dmg = int(amount * 0.25 * current_stacks)
-
-                    # Emit relic effect event for echo attack
-                    await BUS.emit_async("relic_effect", "echoing_drum", attacker, "echo_attack", dmg, {
-                        "original_amount": amount,
-                        "echo_percentage": 25 * current_stacks,
-                        "target": getattr(target, 'id', str(target)),
-                        "first_attack": True,
-                        "stacks": current_stacks
-                    })
-
-                    safe_async_task(target.apply_damage(dmg, attacker=attacker))
-                finally:
-                    _echo_processing = False
-
-            def _cleanup(*_args) -> None:
-                BUS.unsubscribe("battle_start", state["battle_start_handler"])
-                BUS.unsubscribe("action_used", state["attack_handler"])
-                BUS.unsubscribe("battle_end", state["cleanup_handler"])
-                used.clear()
-                if getattr(party, "_echoing_drum_state", None) is state:
-                    delattr(party, "_echoing_drum_state")
-
-            state = {
-                "stacks": stacks,
-                "used": used,
-                "battle_start_handler": _battle_start,
-                "attack_handler": _attack,
-                "cleanup_handler": _cleanup,
-            }
+            state = {"stacks": stacks, "used": set()}
             party._echoing_drum_state = state
-
-            BUS.subscribe("battle_start", _battle_start)
-            BUS.subscribe("action_used", _attack)
-            BUS.subscribe("battle_end", _cleanup)
         else:
             state["stacks"] = stacks
+
+        used: set[int] = state.setdefault("used", set())
+
+        def _battle_start(*_args) -> None:
+            used.clear()
+
+        async def _attack(attacker, target, amount) -> None:
+            global _echo_processing
+            # Prevent infinite loops from recursive echo effects
+            if _echo_processing:
+                return
+
+            pid = id(attacker)
+            if pid in used:
+                return
+            used.add(pid)
+            current_state = getattr(party, "_echoing_drum_state", state)
+            current_stacks = current_state.get("stacks", 0)
+            if current_stacks <= 0:
+                return
+
+            # Set flag to prevent recursive echo effects
+            _echo_processing = True
+            try:
+                dmg = int(amount * 0.25 * current_stacks)
+
+                # Emit relic effect event for echo attack
+                await BUS.emit_async("relic_effect", "echoing_drum", attacker, "echo_attack", dmg, {
+                    "original_amount": amount,
+                    "echo_percentage": 25 * current_stacks,
+                    "target": getattr(target, 'id', str(target)),
+                    "first_attack": True,
+                    "stacks": current_stacks
+                })
+
+                safe_async_task(target.apply_damage(dmg, attacker=attacker))
+            finally:
+                _echo_processing = False
+
+        def _cleanup(*_args) -> None:
+            self.clear_subscriptions(party)
+            used.clear()
+            if getattr(party, "_echoing_drum_state", None) is state:
+                delattr(party, "_echoing_drum_state")
+
+        self.subscribe(party, "battle_start", _battle_start)
+        self.subscribe(party, "action_used", _attack)
+        self.subscribe(party, "battle_end", _cleanup)
 
     def describe(self, stacks: int) -> str:
         pct = 25 * stacks

--- a/backend/plugins/relics/ember_stone.py
+++ b/backend/plugins/relics/ember_stone.py
@@ -17,47 +17,45 @@ class EmberStone(RelicBase):
     about: str = "Below 25% HP, burn the attacker for 50% ATK per stack."
 
     async def apply(self, party) -> None:
+        await super().apply(party)
+
         state = getattr(party, "_ember_stone_state", None)
         stacks = party.relics.count(self.id)
 
         if state is None:
-            async def _burn(target, attacker, amount, *_: object) -> None:
-                if attacker is None or target not in party.members:
-                    return
-                current_stacks = state.get("stacks", 0)
-                if current_stacks <= 0:
-                    return
-                if target.hp <= target.max_hp * 0.25:
-                    dmg = int(target.atk * 0.5 * current_stacks)
-
-                    # Emit relic effect event for burn counter-attack
-                    await BUS.emit_async("relic_effect", "ember_stone", target, "burn_counter", dmg, {
-                        "trigger_condition": "below_25_percent_hp",
-                        "current_hp_percentage": (target.hp / target.max_hp) * 100,
-                        "burn_damage": dmg,
-                        "attacker": getattr(attacker, 'id', str(attacker)),
-                        "stacks": current_stacks
-                    })
-
-                    safe_async_task(attacker.apply_damage(dmg, attacker=target))
-
-            def _cleanup(*_args) -> None:
-                BUS.unsubscribe("damage_taken", state["damage_handler"])
-                BUS.unsubscribe("battle_end", state["cleanup_handler"])
-                if getattr(party, "_ember_stone_state", None) is state:
-                    delattr(party, "_ember_stone_state")
-
-            state = {
-                "stacks": stacks,
-                "damage_handler": _burn,
-                "cleanup_handler": _cleanup,
-            }
+            state = {"stacks": stacks}
             party._ember_stone_state = state
-
-            BUS.subscribe("damage_taken", _burn)
-            BUS.subscribe("battle_end", _cleanup)
         else:
             state["stacks"] = stacks
+
+        async def _burn(target, attacker, amount, *_: object) -> None:
+            if attacker is None or target not in party.members:
+                return
+            current_state = getattr(party, "_ember_stone_state", {})
+            current_stacks = current_state.get("stacks", 0)
+            if current_stacks <= 0:
+                return
+            if target.hp <= target.max_hp * 0.25:
+                dmg = int(target.atk * 0.5 * current_stacks)
+
+                # Emit relic effect event for burn counter-attack
+                await BUS.emit_async("relic_effect", "ember_stone", target, "burn_counter", dmg, {
+                    "trigger_condition": "below_25_percent_hp",
+                    "current_hp_percentage": (target.hp / target.max_hp) * 100,
+                    "burn_damage": dmg,
+                    "attacker": getattr(attacker, 'id', str(attacker)),
+                    "stacks": current_stacks
+                })
+
+                safe_async_task(attacker.apply_damage(dmg, attacker=target))
+
+        def _cleanup(*_args) -> None:
+            self.clear_subscriptions(party)
+            if getattr(party, "_ember_stone_state", None) is state:
+                delattr(party, "_ember_stone_state")
+
+        self.subscribe(party, "damage_taken", _burn)
+        self.subscribe(party, "battle_end", _cleanup)
 
     def describe(self, stacks: int) -> str:
         pct = 50 * stacks

--- a/backend/plugins/relics/killer_instinct.py
+++ b/backend/plugins/relics/killer_instinct.py
@@ -24,122 +24,111 @@ class KillerInstinct(RelicBase):
         state = getattr(party, "_killer_instinct_state", None)
 
         if state is None:
-            ultimate_buffs: dict[int, tuple[PlayerBase, object]] = {}
-            speed_buffs: dict[int, tuple[PlayerBase, object]] = {}
-
-            def _remove_buff(store: dict[int, tuple[PlayerBase, object]], member_id: int) -> None:
-                member_entry = store.pop(member_id, None)
-                if member_entry is None:
-                    return
-                member, mod = member_entry
-                mod.remove()
-                if mod in member.effect_manager.mods:
-                    member.effect_manager.mods.remove(mod)
-                if mod.id in member.mods:
-                    member.mods.remove(mod.id)
-
-            def _clear_ultimate_buffs() -> None:
-                for member_id in list(ultimate_buffs.keys()):
-                    _remove_buff(ultimate_buffs, member_id)
-
-            def _clear_speed_buffs() -> None:
-                for member_id in list(speed_buffs.keys()):
-                    _remove_buff(speed_buffs, member_id)
-
-            async def _ultimate(user) -> None:
-                current_stacks = state.get("stacks", 0)
-                if current_stacks <= 0:
-                    return
-                atk_pct = 75 * current_stacks
-                atk_mult = 1 + (0.75 * current_stacks)
-
-                # Emit relic effect event for ultimate ATK boost
-                await BUS.emit_async("relic_effect", "killer_instinct", user, "ultimate_atk_boost", atk_pct, {
-                    "atk_percentage": atk_pct,
-                    "trigger": "ultimate_used",
-                    "duration": "1_turn",
-                    "stacks": current_stacks
-                })
-
-                mod = create_stat_buff(user, name=f"{self.id}_atk", atk_mult=atk_mult, turns=1)
-                user.effect_manager.add_modifier(mod)
-                _remove_buff(ultimate_buffs, id(user))
-                ultimate_buffs[id(user)] = (user, mod)
-
-            async def _damage(target, attacker, amount, *_: object) -> None:
-                if attacker is None:
-                    return
-                if target.hp <= 0 and id(attacker) in ultimate_buffs:
-                    current_stacks = state.get("stacks", 0)
-                    if current_stacks <= 0:
-                        return
-
-                    speed_pct = 50 * current_stacks
-                    speed_mult = 1 + (0.5 * current_stacks)
-
-                    await BUS.emit_async(
-                        "relic_effect",
-                        "killer_instinct",
-                        attacker,
-                        "kill_speed_boost",
-                        speed_pct,
-                        {
-                            "spd_percentage": speed_pct,
-                            "trigger": "kill",
-                            "duration": "2_turns",
-                            "stacks": current_stacks,
-                            "killer_damage": amount,
-                            "victim": getattr(target, "id", str(target)),
-                            "speed_multiplier": speed_mult,
-                        },
-                    )
-
-                    _remove_buff(speed_buffs, id(attacker))
-                    mod = create_stat_buff(
-                        attacker,
-                        name=f"{self.id}_spd",
-                        spd_mult=speed_mult,
-                        turns=2,
-                    )
-                    attacker.effect_manager.add_modifier(mod)
-                    speed_buffs[id(attacker)] = (attacker, mod)
-
-            def _turn_end(*_args) -> None:
-                _clear_ultimate_buffs()
-                # Drop any expired speed buffs that have already been removed by the effect manager
-                for member_id, (member, mod) in list(speed_buffs.items()):
-                    if mod not in member.effect_manager.mods:
-                        speed_buffs.pop(member_id, None)
-
-            def _cleanup(*_args) -> None:
-                BUS.unsubscribe("ultimate_used", state["ultimate_handler"])
-                BUS.unsubscribe("damage_taken", state["damage_handler"])
-                BUS.unsubscribe("turn_end", state["turn_end_handler"])
-                BUS.unsubscribe("battle_end", state["cleanup_handler"])
-                _clear_ultimate_buffs()
-                _clear_speed_buffs()
-                if getattr(party, "_killer_instinct_state", None) is state:
-                    delattr(party, "_killer_instinct_state")
-
-            state = {
-                "stacks": stacks,
-                "buffs": ultimate_buffs,
-                "speed_buffs": speed_buffs,
-                "ultimate_handler": _ultimate,
-                "damage_handler": _damage,
-                "turn_end_handler": _turn_end,
-                "cleanup_handler": _cleanup,
-                "clear_buffs": _clear_ultimate_buffs,
-                "clear_speed_buffs": _clear_speed_buffs,
-            }
+            state = {"stacks": stacks}
             party._killer_instinct_state = state
-
-            BUS.subscribe("ultimate_used", _ultimate)
-            BUS.subscribe("damage_taken", _damage)
-            BUS.subscribe("turn_end", _turn_end)
-            BUS.subscribe("battle_end", _cleanup)
         else:
             state["stacks"] = stacks
+
+        ultimate_buffs: dict[int, tuple[PlayerBase, object]] = state.setdefault("buffs", {})
+        speed_buffs: dict[int, tuple[PlayerBase, object]] = state.setdefault("speed_buffs", {})
+
+        def _remove_buff(store: dict[int, tuple[PlayerBase, object]], member_id: int) -> None:
+            member_entry = store.pop(member_id, None)
+            if member_entry is None:
+                return
+            member, mod = member_entry
+            mod.remove()
+            if mod in member.effect_manager.mods:
+                member.effect_manager.mods.remove(mod)
+            if mod.id in member.mods:
+                member.mods.remove(mod.id)
+
+        def _clear_ultimate_buffs() -> None:
+            for member_id in list(ultimate_buffs.keys()):
+                _remove_buff(ultimate_buffs, member_id)
+
+        def _clear_speed_buffs() -> None:
+            for member_id in list(speed_buffs.keys()):
+                _remove_buff(speed_buffs, member_id)
+
+        async def _ultimate(user) -> None:
+            current_state = getattr(party, "_killer_instinct_state", state)
+            current_stacks = current_state.get("stacks", 0)
+            if current_stacks <= 0:
+                return
+            atk_pct = 75 * current_stacks
+            atk_mult = 1 + (0.75 * current_stacks)
+
+            # Emit relic effect event for ultimate ATK boost
+            await BUS.emit_async("relic_effect", "killer_instinct", user, "ultimate_atk_boost", atk_pct, {
+                "atk_percentage": atk_pct,
+                "trigger": "ultimate_used",
+                "duration": "1_turn",
+                "stacks": current_stacks
+            })
+
+            mod = create_stat_buff(user, name=f"{self.id}_atk", atk_mult=atk_mult, turns=1)
+            user.effect_manager.add_modifier(mod)
+            _remove_buff(ultimate_buffs, id(user))
+            ultimate_buffs[id(user)] = (user, mod)
+
+        async def _damage(target, attacker, amount, *_: object) -> None:
+            if attacker is None:
+                return
+            if target.hp <= 0 and id(attacker) in ultimate_buffs:
+                current_state = getattr(party, "_killer_instinct_state", state)
+                current_stacks = current_state.get("stacks", 0)
+                if current_stacks <= 0:
+                    return
+
+                speed_pct = 50 * current_stacks
+                speed_mult = 1 + (0.5 * current_stacks)
+
+                await BUS.emit_async(
+                    "relic_effect",
+                    "killer_instinct",
+                    attacker,
+                    "kill_speed_boost",
+                    speed_pct,
+                    {
+                        "spd_percentage": speed_pct,
+                        "trigger": "kill",
+                        "duration": "2_turns",
+                        "stacks": current_stacks,
+                        "killer_damage": amount,
+                        "victim": getattr(target, "id", str(target)),
+                        "speed_multiplier": speed_mult,
+                    },
+                )
+
+                _remove_buff(speed_buffs, id(attacker))
+                mod = create_stat_buff(
+                    attacker,
+                    name=f"{self.id}_spd",
+                    spd_mult=speed_mult,
+                    turns=2,
+                )
+                attacker.effect_manager.add_modifier(mod)
+                speed_buffs[id(attacker)] = (attacker, mod)
+
+        def _turn_end(*_args) -> None:
+            _clear_ultimate_buffs()
+            # Drop any expired speed buffs that have already been removed by the effect manager
+            for member_id, (member, mod) in list(speed_buffs.items()):
+                if mod not in member.effect_manager.mods:
+                    speed_buffs.pop(member_id, None)
+
+        def _cleanup(*_args) -> None:
+            self.clear_subscriptions(party)
+            _clear_ultimate_buffs()
+            _clear_speed_buffs()
+            if getattr(party, "_killer_instinct_state", None) is state:
+                delattr(party, "_killer_instinct_state")
+
+        self.subscribe(party, "ultimate_used", _ultimate)
+        self.subscribe(party, "damage_taken", _damage)
+        self.subscribe(party, "turn_end", _turn_end)
+        self.subscribe(party, "battle_end", _cleanup)
 
     def describe(self, stacks: int) -> str:
         pct = 75 * stacks

--- a/backend/plugins/relics/lucky_button.py
+++ b/backend/plugins/relics/lucky_button.py
@@ -58,17 +58,14 @@ class LuckyButton(RelicBase):
                 del active[pid]
 
         async def _battle_end(_entity, *_args) -> None:
-            BUS.unsubscribe("crit_missed", _crit_missed)
-            BUS.unsubscribe("turn_start", _turn_start)
-            BUS.unsubscribe("turn_end", _turn_end)
-            BUS.unsubscribe("battle_end", _battle_end)
+            self.clear_subscriptions(party)
             pending.clear()
             active.clear()
 
-        BUS.subscribe("crit_missed", _crit_missed)
-        BUS.subscribe("turn_start", _turn_start)
-        BUS.subscribe("turn_end", _turn_end)
-        BUS.subscribe("battle_end", _battle_end)
+        self.subscribe(party, "crit_missed", _crit_missed)
+        self.subscribe(party, "turn_start", _turn_start)
+        self.subscribe(party, "turn_end", _turn_end)
+        self.subscribe(party, "battle_end", _battle_end)
 
     def describe(self, stacks: int) -> str:
         if stacks == 1:

--- a/backend/plugins/relics/null_lantern.py
+++ b/backend/plugins/relics/null_lantern.py
@@ -31,80 +31,77 @@ class NullLantern(RelicBase):
                 "cleared": cleared,
                 "stacks": stacks,
             }
-
-            if not hasattr(party, "pull_tokens"):
-                party.pull_tokens = 0
-
-            async def _battle_start(entity) -> None:
-                from plugins.foes._base import FoeBase
-
-                if isinstance(entity, FoeBase):
-                    current_stacks = state.get("stacks", 0)
-                    if current_stacks <= 0:
-                        return
-                    mult = 1 + 1.5 * state["cleared"] * current_stacks
-                    mod = create_stat_buff(
-                        entity,
-                        name=f"{self.id}_foe_{state['cleared']}",
-                        turns=9999,
-                        atk_mult=mult,
-                        defense_mult=mult,
-                        max_hp_mult=mult,
-                        hp_mult=mult,
-                    )
-                    entity.effect_manager.add_modifier(mod)
-
-                    # Track foe buffing
-                    await BUS.emit_async("relic_effect", "null_lantern", entity, "foe_buffed", int((mult - 1) * 100), {
-                        "battle_number": state["cleared"] + 1,
-                        "multiplier": mult,
-                        "escalation_percentage": 150 * current_stacks,
-                        "stacks": current_stacks
-                    })
-
-            async def _battle_end(entity) -> None:
-                from plugins.foes._base import FoeBase
-
-                if isinstance(entity, FoeBase):
-                    current_stacks = state.get("stacks", 0)
-                    if current_stacks <= 0:
-                        return
-                    state["cleared"] += 1
-                    party._null_lantern_cleared = state["cleared"]
-                    pull_reward = 1 + (current_stacks - 1)
-                    party.pull_tokens += pull_reward
-
-                    # Track pull token generation
-                    await BUS.emit_async("relic_effect", "null_lantern", entity, "pull_tokens_awarded", pull_reward, {
-                        "battles_cleared": state["cleared"],
-                        "base_tokens": 1,
-                        "stack_bonus": current_stacks - 1,
-                        "disabled_shops": True,
-                        "disabled_rests": True
-                    })
-
-            def _cleanup(entity) -> None:
-                from plugins.foes._base import FoeBase
-
-                if not isinstance(entity, FoeBase):
-                    return
-
-                BUS.unsubscribe("battle_start", state["battle_start_handler"])
-                BUS.unsubscribe("battle_end", state["battle_end_handler"])
-                BUS.unsubscribe("battle_end", state["cleanup_handler"])
-                if getattr(party, "_null_lantern_state", None) is state:
-                    delattr(party, "_null_lantern_state")
-
-            state["battle_start_handler"] = _battle_start
-            state["battle_end_handler"] = _battle_end
-            state["cleanup_handler"] = _cleanup
             party._null_lantern_state = state
-
-            BUS.subscribe("battle_start", _battle_start)
-            BUS.subscribe("battle_end", _battle_end)
-            BUS.subscribe("battle_end", _cleanup)
         else:
             state["stacks"] = stacks
+
+        if not hasattr(party, "pull_tokens"):
+            party.pull_tokens = 0
+
+        async def _battle_start(entity) -> None:
+            from plugins.foes._base import FoeBase
+
+            current_state = getattr(party, "_null_lantern_state", state)
+            if isinstance(entity, FoeBase):
+                current_stacks = current_state.get("stacks", 0)
+                if current_stacks <= 0:
+                    return
+                mult = 1 + 1.5 * current_state["cleared"] * current_stacks
+                mod = create_stat_buff(
+                    entity,
+                    name=f"{self.id}_foe_{current_state['cleared']}",
+                    turns=9999,
+                    atk_mult=mult,
+                    defense_mult=mult,
+                    max_hp_mult=mult,
+                    hp_mult=mult,
+                )
+                entity.effect_manager.add_modifier(mod)
+
+                # Track foe buffing
+                await BUS.emit_async("relic_effect", "null_lantern", entity, "foe_buffed", int((mult - 1) * 100), {
+                    "battle_number": current_state["cleared"] + 1,
+                    "multiplier": mult,
+                    "escalation_percentage": 150 * current_stacks,
+                    "stacks": current_stacks
+                })
+
+        async def _battle_end(entity) -> None:
+            from plugins.foes._base import FoeBase
+
+            current_state = getattr(party, "_null_lantern_state", state)
+            if isinstance(entity, FoeBase):
+                current_stacks = current_state.get("stacks", 0)
+                if current_stacks <= 0:
+                    return
+                current_state["cleared"] += 1
+                party._null_lantern_cleared = current_state["cleared"]
+                pull_reward = 1 + (current_stacks - 1)
+                party.pull_tokens += pull_reward
+
+                # Track pull token generation
+                await BUS.emit_async("relic_effect", "null_lantern", entity, "pull_tokens_awarded", pull_reward, {
+                    "battles_cleared": current_state["cleared"],
+                    "base_tokens": 1,
+                    "stack_bonus": current_stacks - 1,
+                    "disabled_shops": True,
+                    "disabled_rests": True
+                })
+
+        def _cleanup(entity) -> None:
+            from plugins.foes._base import FoeBase
+
+            if not isinstance(entity, FoeBase):
+                return
+
+            self.clear_subscriptions(party)
+            current_state = getattr(party, "_null_lantern_state", None)
+            if current_state is state:
+                delattr(party, "_null_lantern_state")
+
+        self.subscribe(party, "battle_start", _battle_start)
+        self.subscribe(party, "battle_end", _battle_end)
+        self.subscribe(party, "battle_end", _cleanup)
 
     def describe(self, stacks: int) -> str:
         pulls = 1 + (stacks - 1)

--- a/backend/plugins/relics/old_coin.py
+++ b/backend/plugins/relics/old_coin.py
@@ -22,62 +22,57 @@ class OldCoin(RelicBase):
         state = getattr(party, "_old_coin_state", None)
 
         if state is None:
-            first_purchase_done = getattr(party, "_old_coin_first_purchase", False)
-
-            async def _gold(amount: int) -> None:
-                current_stacks = state.get("stacks", 0)
-                if current_stacks <= 0:
-                    return
-                bonus = int(amount * 0.03 * current_stacks)
-                party.gold += bonus
-
-                # Emit relic effect event for gold bonus
-                await BUS.emit_async("relic_effect", "old_coin", party, "gold_bonus", bonus, {
-                    "original_amount": amount,
-                    "bonus_percentage": 3 * current_stacks,
-                    "stacks": current_stacks
-                })
-
-            async def _purchase(cost: int) -> None:
-                if state.get("first_purchase_done", False):
-                    return
-                current_stacks = state.get("stacks", 0)
-                if current_stacks <= 0:
-                    return
-                refund = int(cost * 0.03 * current_stacks)
-                party.gold += refund
-                state["first_purchase_done"] = True
-                party._old_coin_first_purchase = True
-
-                # Emit relic effect event for purchase refund
-                await BUS.emit_async("relic_effect", "old_coin", party, "purchase_refund", refund, {
-                    "original_cost": cost,
-                    "refund_percentage": 3 * current_stacks,
-                    "stacks": current_stacks,
-                    "first_purchase": True
-                })
-
-            def _cleanup(*_args) -> None:
-                BUS.unsubscribe("gold_earned", state["gold_handler"])
-                BUS.unsubscribe("shop_purchase", state["purchase_handler"])
-                BUS.unsubscribe("battle_end", state["cleanup_handler"])
-                if getattr(party, "_old_coin_state", None) is state:
-                    delattr(party, "_old_coin_state")
-
             state = {
                 "stacks": stacks,
-                "first_purchase_done": first_purchase_done,
-                "gold_handler": _gold,
-                "purchase_handler": _purchase,
-                "cleanup_handler": _cleanup,
+                "first_purchase_done": getattr(party, "_old_coin_first_purchase", False),
             }
             party._old_coin_state = state
-
-            BUS.subscribe("gold_earned", _gold)
-            BUS.subscribe("shop_purchase", _purchase)
-            BUS.subscribe("battle_end", _cleanup)
         else:
             state["stacks"] = stacks
+
+        async def _gold(amount: int) -> None:
+            current_state = getattr(party, "_old_coin_state", {})
+            current_stacks = current_state.get("stacks", 0)
+            if current_stacks <= 0:
+                return
+            bonus = int(amount * 0.03 * current_stacks)
+            party.gold += bonus
+
+            # Emit relic effect event for gold bonus
+            await BUS.emit_async("relic_effect", "old_coin", party, "gold_bonus", bonus, {
+                "original_amount": amount,
+                "bonus_percentage": 3 * current_stacks,
+                "stacks": current_stacks
+            })
+
+        async def _purchase(cost: int) -> None:
+            current_state = getattr(party, "_old_coin_state", {})
+            if current_state.get("first_purchase_done", False):
+                return
+            current_stacks = current_state.get("stacks", 0)
+            if current_stacks <= 0:
+                return
+            refund = int(cost * 0.03 * current_stacks)
+            party.gold += refund
+            current_state["first_purchase_done"] = True
+            party._old_coin_first_purchase = True
+
+            # Emit relic effect event for purchase refund
+            await BUS.emit_async("relic_effect", "old_coin", party, "purchase_refund", refund, {
+                "original_cost": cost,
+                "refund_percentage": 3 * current_stacks,
+                "stacks": current_stacks,
+                "first_purchase": True
+            })
+
+        def _cleanup(*_args) -> None:
+            self.clear_subscriptions(party)
+            if getattr(party, "_old_coin_state", None) is state:
+                delattr(party, "_old_coin_state")
+
+        self.subscribe(party, "gold_earned", _gold)
+        self.subscribe(party, "shop_purchase", _purchase)
+        self.subscribe(party, "battle_end", _cleanup)
 
     def describe(self, stacks: int) -> str:
         rate = 3 * stacks

--- a/backend/plugins/relics/omega_core.py
+++ b/backend/plugins/relics/omega_core.py
@@ -95,9 +95,9 @@ class OmegaCore(RelicBase):
                     mod.remove()
             state["mods"].clear()
 
-        BUS.subscribe("battle_start", _battle_start)
-        BUS.subscribe("turn_start", _turn_start)
-        BUS.subscribe("battle_end", _battle_end)
+        self.subscribe(party, "battle_start", _battle_start)
+        self.subscribe(party, "turn_start", _turn_start)
+        self.subscribe(party, "battle_end", _battle_end)
 
     def describe(self, stacks: int) -> str:
         delay = 10 + 2 * (stacks - 1)

--- a/backend/plugins/relics/paradox_hourglass.py
+++ b/backend/plugins/relics/paradox_hourglass.py
@@ -137,8 +137,8 @@ class ParadoxHourglass(RelicBase):
                         member.mods.remove(mod.id)
             state.pop("done", None)
 
-        BUS.subscribe("battle_start", _battle_start)
-        BUS.subscribe("battle_end", _battle_end)
+        self.subscribe(party, "battle_start", _battle_start)
+        self.subscribe(party, "battle_end", _battle_end)
 
     def describe(self, stacks: int) -> str:
         div = 4 + (stacks - 1)

--- a/backend/plugins/relics/pocket_manual.py
+++ b/backend/plugins/relics/pocket_manual.py
@@ -43,7 +43,7 @@ class PocketManual(RelicBase):
                     effect = Aftertaste(base_pot=base)
                     safe_async_task(effect.apply(attacker, target))
 
-        BUS.subscribe("hit_landed", _hit)
+        self.subscribe(party, "hit_landed", _hit)
 
     def describe(self, stacks: int) -> str:
         if stacks == 1:

--- a/backend/plugins/relics/shiny_pebble.py
+++ b/backend/plugins/relics/shiny_pebble.py
@@ -25,50 +25,55 @@ class ShinyPebble(RelicBase):
         if state is None:
             state = {"active": {}, "triggered": set()}
             party._shiny_pebble_state = state
+        else:
+            state.setdefault("active", {})
+            state.setdefault("triggered", set())
 
-            async def _first_hit(target, attacker, amount, *_: object) -> None:
-                if target not in party.members or id(target) in state["triggered"]:
-                    return
-                state["triggered"].add(id(target))
-                stacks = party.relics.count(self.id)
-                mit_mult = 1 + 0.03 * stacks
-                mod = create_stat_buff(
-                    target,
-                    name=f"{self.id}_{id(target)}",
-                    mitigation=target.mitigation * (mit_mult - 1),
-                    turns=1,
-                )
-                target.effect_manager.add_modifier(mod)
-                state["active"][id(target)] = (target, mod)
+        async def _first_hit(target, attacker, amount, *_: object) -> None:
+            current_state = getattr(party, "_shiny_pebble_state", state)
+            if target not in party.members or id(target) in current_state["triggered"]:
+                return
+            current_state["triggered"].add(id(target))
+            stacks = party.relics.count(self.id)
+            mit_mult = 1 + 0.03 * stacks
+            mod = create_stat_buff(
+                target,
+                name=f"{self.id}_{id(target)}",
+                mitigation=target.mitigation * (mit_mult - 1),
+                turns=1,
+            )
+            target.effect_manager.add_modifier(mod)
+            current_state["active"][id(target)] = (target, mod)
 
-                # Track mitigation burst application
-                await BUS.emit_async(
-                    "relic_effect",
-                    "shiny_pebble",
-                    target,
-                    "mitigation_burst",
-                    int((mit_mult - 1) * 100),
-                    {
-                        "target": getattr(target, 'id', str(target)),
-                        "mitigation_multiplier": mit_mult,
-                        "base_mitigation": target.mitigation,
-                        "duration_turns": 1,
-                        "trigger": "first_hit",
-                        "stacks": stacks,
-                    },
-                )
+            # Track mitigation burst application
+            await BUS.emit_async(
+                "relic_effect",
+                "shiny_pebble",
+                target,
+                "mitigation_burst",
+                int((mit_mult - 1) * 100),
+                {
+                    "target": getattr(target, 'id', str(target)),
+                    "mitigation_multiplier": mit_mult,
+                    "base_mitigation": target.mitigation,
+                    "duration_turns": 1,
+                    "trigger": "first_hit",
+                    "stacks": stacks,
+                },
+            )
 
-            def _reset(*_) -> None:
-                for key, (member, mod) in list(state["active"].items()):
-                    mod.remove()
-                    if mod in member.effect_manager.mods:
-                        member.effect_manager.mods.remove(mod)
-                    if mod.id in member.mods:
-                        member.mods.remove(mod.id)
-                    state["active"].pop(key, None)
+        def _reset(*_) -> None:
+            current_state = getattr(party, "_shiny_pebble_state", state)
+            for key, (member, mod) in list(current_state["active"].items()):
+                mod.remove()
+                if mod in member.effect_manager.mods:
+                    member.effect_manager.mods.remove(mod)
+                if mod.id in member.mods:
+                    member.mods.remove(mod.id)
+                current_state["active"].pop(key, None)
 
-            BUS.subscribe("damage_taken", _first_hit)
-            BUS.subscribe("turn_start", _reset)
+        self.subscribe(party, "damage_taken", _first_hit)
+        self.subscribe(party, "turn_start", _reset)
 
     def describe(self, stacks: int) -> str:
         if stacks == 1:

--- a/backend/plugins/relics/soul_prism.py
+++ b/backend/plugins/relics/soul_prism.py
@@ -82,9 +82,9 @@ class SoulPrism(RelicBase):
                     "buff_percentage": buff * 100
                 })
 
-            BUS.unsubscribe("battle_end", _battle_end)
+            self.unsubscribe(party, "battle_end", _battle_end)
 
-        BUS.subscribe("battle_end", _battle_end)
+        self.subscribe(party, "battle_end", _battle_end)
 
     def describe(self, stacks: int) -> str:
         penalty = 75 - 5 * (stacks - 1)

--- a/backend/plugins/relics/tattered_flag.py
+++ b/backend/plugins/relics/tattered_flag.py
@@ -40,7 +40,7 @@ class TatteredFlag(RelicBase):
                 mod = create_stat_buff(member, name=f"{self.id}_buff", atk_mult=1.03, turns=9999)
                 member.effect_manager.add_modifier(mod)
 
-        BUS.subscribe("damage_taken", _fallen)
+        self.subscribe(party, "damage_taken", _fallen)
 
     def describe(self, stacks: int) -> str:
         if stacks == 1:

--- a/backend/plugins/relics/threadbare_cloak.py
+++ b/backend/plugins/relics/threadbare_cloak.py
@@ -1,7 +1,6 @@
 from dataclasses import dataclass
 from dataclasses import field
 
-from autofighter.stats import BUS
 from plugins.relics._base import RelicBase
 from plugins.relics._base import safe_async_task
 
@@ -34,9 +33,9 @@ class ThreadbareCloak(RelicBase):
 
         def _reset(*_: object) -> None:
             party._threadbare_cloak_stacks = 0
-            BUS.unsubscribe("battle_end", _reset)
+            self.clear_subscriptions(party)
 
-        BUS.subscribe("battle_end", _reset)
+        self.subscribe(party, "battle_end", _reset)
 
     def describe(self, stacks: int) -> str:
         pct = 3 * stacks

--- a/backend/plugins/relics/timekeepers_hourglass.py
+++ b/backend/plugins/relics/timekeepers_hourglass.py
@@ -5,7 +5,6 @@ import random
 
 from autofighter.effects import StatModifier
 from autofighter.effects import create_stat_buff
-from autofighter.stats import BUS
 from plugins.relics._base import RelicBase
 
 
@@ -85,8 +84,7 @@ class TimekeepersHourglass(RelicBase):
                     active_mods[id(member)] = mod
 
         def _battle_end(_entity) -> None:
-            BUS.unsubscribe("turn_start", _turn_start)
-            BUS.unsubscribe("battle_end", _battle_end)
+            self.clear_subscriptions(party)
             for member in party.members:
                 mod = active_mods.pop(id(member), None)
                 if mod is None:
@@ -104,8 +102,8 @@ class TimekeepersHourglass(RelicBase):
             if hasattr(party, "_t_hourglass_applied"):
                 delattr(party, "_t_hourglass_applied")
 
-        BUS.subscribe("turn_start", _turn_start)
-        BUS.subscribe("battle_end", _battle_end)
+        self.subscribe(party, "turn_start", _turn_start)
+        self.subscribe(party, "battle_end", _battle_end)
 
     def describe(self, stacks: int) -> str:
         pct = 10 + 1 * (stacks - 1)

--- a/backend/plugins/relics/travelers_charm.py
+++ b/backend/plugins/relics/travelers_charm.py
@@ -96,22 +96,21 @@ class TravelersCharm(RelicBase):
                     member.mods.remove(mod.id)
             active.clear()
 
-        def _on_turn_start(*_):
-            _turn_start()
+        async def _on_turn_start(*_) -> None:
+            await _turn_start()
 
-        def _on_turn_end(*_):
+        def _on_turn_end(*_) -> None:
             _turn_end()
 
         def _on_battle_end(entity) -> None:
-            BUS.unsubscribe("damage_taken", _hit)
-            BUS.unsubscribe("turn_start", _on_turn_start)
-            BUS.unsubscribe("turn_end", _on_turn_end)
-            BUS.unsubscribe("battle_end", _on_battle_end)
+            self.clear_subscriptions(party)
+            pending.clear()
+            _turn_end()
 
-        BUS.subscribe("damage_taken", _hit)
-        BUS.subscribe("turn_start", _on_turn_start)
-        BUS.subscribe("turn_end", _on_turn_end)
-        BUS.subscribe("battle_end", _on_battle_end)
+        self.subscribe(party, "damage_taken", _hit)
+        self.subscribe(party, "turn_start", _on_turn_start)
+        self.subscribe(party, "turn_end", _on_turn_end)
+        self.subscribe(party, "battle_end", _on_battle_end)
 
     def describe(self, stacks: int) -> str:
         d = 25 * stacks

--- a/backend/plugins/relics/wooden_idol.py
+++ b/backend/plugins/relics/wooden_idol.py
@@ -75,9 +75,15 @@ class WoodenIdol(RelicBase):
                     member.mods.remove(mod.id)
             active.clear()
 
-        BUS.subscribe("debuff_resisted", _resisted)
-        BUS.subscribe("turn_start", lambda *_: _turn_start())
-        BUS.subscribe("turn_end", lambda *_: _turn_end())
+        async def _turn_start_handler(*_args) -> None:
+            await _turn_start()
+
+        def _turn_end_handler(*_args) -> None:
+            _turn_end()
+
+        self.subscribe(party, "debuff_resisted", _resisted)
+        self.subscribe(party, "turn_start", _turn_start_handler)
+        self.subscribe(party, "turn_end", _turn_end_handler)
 
     def describe(self, stacks: int) -> str:
         if stacks == 1:

--- a/backend/tests/test_relic_subscription_cleanup.py
+++ b/backend/tests/test_relic_subscription_cleanup.py
@@ -1,0 +1,94 @@
+"""Tests ensuring relic event handlers do not duplicate on reapplication."""
+
+from __future__ import annotations
+
+import pytest
+
+from autofighter.party import Party
+from autofighter.relics import apply_relics
+from autofighter.relics import award_relic
+from autofighter.stats import BUS
+from autofighter.stats import Stats
+from plugins import event_bus as event_bus_module
+
+
+def _collect_events(relic_id: str, effect_key: str, events: list[tuple]) -> list[tuple]:
+    """Return all recorded relic effect events matching the requested keys."""
+
+    return [event for event in events if event[0] == relic_id and event[2] == effect_key]
+
+
+@pytest.mark.asyncio
+async def test_bent_dagger_handlers_run_once_after_reapply() -> None:
+    event_bus_module.bus._subs.clear()
+
+    party = Party()
+    member = Stats()
+    enemy = Stats()
+    member.set_base_stat("atk", 100)
+    enemy.hp = enemy.set_base_stat("max_hp", 10)
+    party.members.append(member)
+
+    award_relic(party, "bent_dagger")
+    await apply_relics(party)
+    await apply_relics(party)
+
+    assert len(event_bus_module.bus._subs.get("damage_taken", [])) == 1
+
+    events: list[tuple] = []
+    BUS.subscribe("relic_effect", lambda *args: events.append(args))
+
+    enemy.hp = 0
+    await BUS.emit_async("damage_taken", enemy, member, 10)
+
+    atk_events = _collect_events("bent_dagger", "atk_boost_applied", events)
+    assert len(atk_events) == len(party.members)
+
+    event_bus_module.bus._subs.clear()
+
+
+@pytest.mark.asyncio
+async def test_pocket_manual_reapply_only_triggers_once_per_cycle() -> None:
+    event_bus_module.bus._subs.clear()
+
+    party = Party()
+    attacker = Stats()
+    target = Stats()
+    party.members.append(attacker)
+    award_relic(party, "pocket_manual")
+
+    await apply_relics(party)
+    await apply_relics(party)
+
+    assert len(event_bus_module.bus._subs.get("hit_landed", [])) == 1
+
+    events: list[tuple] = []
+    BUS.subscribe("relic_effect", lambda *args: events.append(args))
+
+    for _ in range(10):
+        await BUS.emit_async("hit_landed", attacker, target, 100)
+
+    triggers = _collect_events("pocket_manual", "trigger_aftertaste", events)
+    assert len(triggers) == 1
+
+    event_bus_module.bus._subs.clear()
+
+
+@pytest.mark.asyncio
+async def test_omega_core_single_battle_start_subscription() -> None:
+    event_bus_module.bus._subs.clear()
+
+    party = Party()
+    member = Stats()
+    member.set_base_stat("atk", 100)
+    party.members.append(member)
+
+    award_relic(party, "omega_core")
+    await apply_relics(party)
+    await apply_relics(party)
+
+    assert len(event_bus_module.bus._subs.get("battle_start", [])) == 1
+    assert len(event_bus_module.bus._subs.get("turn_start", [])) == 1
+    assert len(event_bus_module.bus._subs.get("battle_end", [])) == 1
+
+    event_bus_module.bus._subs.clear()


### PR DESCRIPTION
## Summary
- add subscription tracking and cleanup helpers to the relic base class
- update event-driven relics to register through the helper for automatic unsubscribe
- add regression tests ensuring repeated relic application does not duplicate handlers

## Testing
- uv run pytest tests/test_relic_subscription_cleanup.py

------
https://chatgpt.com/codex/tasks/task_b_68cfe353da98832cad8709beb8b0e0ee