### PR TITLE
[FIX] Ensure card bus subscriptions clean up

### DIFF
--- a/backend/plugins/cards/a_micro_blade.py
+++ b/backend/plugins/cards/a_micro_blade.py
@@ -71,4 +71,4 @@ class MicroBlade(CardBase):
                             },
                         )
 
-        BUS.subscribe("damage_dealt", _on_damage_dealt)
+        self.subscribe("damage_dealt", _on_damage_dealt)

--- a/backend/plugins/cards/adamantine_band.py
+++ b/backend/plugins/cards/adamantine_band.py
@@ -49,4 +49,4 @@ class AdamantineBand(CardBase):
                         },
                     )
 
-        BUS.subscribe("damage_taken", _on_damage_taken)
+        self.subscribe("damage_taken", _on_damage_taken)

--- a/backend/plugins/cards/arc_lightning.py
+++ b/backend/plugins/cards/arc_lightning.py
@@ -31,9 +31,7 @@ class ArcLightning(CardBase):
             if isinstance(entity, FoeBase) and entity in foes:
                 foes.remove(entity)
             if entity in party.members:
-                BUS.unsubscribe("hit_landed", _hit)
-                BUS.unsubscribe("battle_start", _battle_start)
-                BUS.unsubscribe("battle_end", _battle_end)
+                self.cleanup_subscriptions()
 
         async def _hit(attacker, target, amount, source, *_):
             if attacker not in party.members or source != "attack":
@@ -53,6 +51,6 @@ class ArcLightning(CardBase):
                 {"target": getattr(extra, "id", str(extra))},
             )
 
-        BUS.subscribe("battle_start", _battle_start)
-        BUS.subscribe("battle_end", _battle_end)
-        BUS.subscribe("hit_landed", _hit)
+        self.subscribe("battle_start", _battle_start)
+        self.subscribe("battle_end", _battle_end)
+        self.subscribe("hit_landed", _hit)

--- a/backend/plugins/cards/arcane_repeater.py
+++ b/backend/plugins/cards/arcane_repeater.py
@@ -42,4 +42,4 @@ class ArcaneRepeater(CardBase):
             )
             safe_async_task(target.apply_damage(dmg, attacker=attacker))
 
-        BUS.subscribe("attack_used", _attack)
+        self.subscribe("attack_used", _attack)

--- a/backend/plugins/cards/balanced_diet.py
+++ b/backend/plugins/cards/balanced_diet.py
@@ -46,4 +46,4 @@ class BalancedDiet(CardBase):
                     "heal_amount": heal_amount
                 })
 
-        BUS.subscribe("heal_received", _on_heal_received)
+        self.subscribe("heal_received", _on_heal_received)

--- a/backend/plugins/cards/battle_meditation.py
+++ b/backend/plugins/cards/battle_meditation.py
@@ -50,12 +50,11 @@ class BattleMeditation(CardBase):
                             "trigger_event": "battle_start"
                         })
 
-                    BUS.unsubscribe("battle_start", _on_battle_start)
+                    self.unsubscribe("battle_start", _on_battle_start)
 
         def _on_battle_end(entity) -> None:
             self._battle_boost_applied = False
-            BUS.unsubscribe("battle_start", _on_battle_start)
-            BUS.unsubscribe("battle_end", _on_battle_end)
+            self.cleanup_subscriptions()
 
-        BUS.subscribe("battle_start", _on_battle_start)
-        BUS.subscribe("battle_end", _on_battle_end)
+        self.subscribe("battle_start", _on_battle_start)
+        self.subscribe("battle_end", _on_battle_end)

--- a/backend/plugins/cards/bulwark_totem.py
+++ b/backend/plugins/cards/bulwark_totem.py
@@ -115,4 +115,4 @@ class BulwarkTotem(CardBase):
                 },
             )
 
-        BUS.subscribe("damage_taken", _on_damage_taken)
+        self.subscribe("damage_taken", _on_damage_taken)

--- a/backend/plugins/cards/calm_beads.py
+++ b/backend/plugins/cards/calm_beads.py
@@ -58,4 +58,4 @@ class CalmBeads(CardBase):
                 payload["metadata"] = metadata
             await BUS.emit_async("card_effect", self.id, target, "resist_charge_gain", 1, payload)
 
-        BUS.subscribe("effect_resisted", _on_effect_resisted)
+        self.subscribe("effect_resisted", _on_effect_resisted)

--- a/backend/plugins/cards/coated_armor.py
+++ b/backend/plugins/cards/coated_armor.py
@@ -59,8 +59,7 @@ class CoatedArmor(CardBase):
                         )
 
         def _on_battle_end(_entity) -> None:
-            BUS.unsubscribe("mitigation_triggered", _on_mitigation_triggered)
-            BUS.unsubscribe("battle_end", _on_battle_end)
+            self.cleanup_subscriptions()
 
-        BUS.subscribe("mitigation_triggered", _on_mitigation_triggered)
-        BUS.subscribe("battle_end", _on_battle_end)
+        self.subscribe("mitigation_triggered", _on_mitigation_triggered)
+        self.subscribe("battle_end", _on_battle_end)

--- a/backend/plugins/cards/critical_focus.py
+++ b/backend/plugins/cards/critical_focus.py
@@ -36,4 +36,4 @@ class CriticalFocus(CardBase):
                     {"stacks": effect.stacks},
                 )
 
-        BUS.subscribe("turn_start", _turn_start)
+        self.subscribe("turn_start", _turn_start)

--- a/backend/plugins/cards/critical_overdrive.py
+++ b/backend/plugins/cards/critical_overdrive.py
@@ -68,8 +68,7 @@ class CriticalOverdrive(CardBase):
                 if mod in entity.effect_manager.mods:
                     entity.effect_manager.mods.remove(mod)
             if not state:
-                BUS.unsubscribe("critical_boost_change", _change)
-                BUS.unsubscribe("battle_end", _battle_end)
+                self.cleanup_subscriptions()
 
-        BUS.subscribe("critical_boost_change", _change)
-        BUS.subscribe("battle_end", _battle_end)
+        self.subscribe("critical_boost_change", _change)
+        self.subscribe("battle_end", _battle_end)

--- a/backend/plugins/cards/critical_transfer.py
+++ b/backend/plugins/cards/critical_transfer.py
@@ -56,4 +56,4 @@ class CriticalTransfer(CardBase):
                 {"stacks": total, "atk_bonus_pct": 4 * total},
             )
 
-        BUS.subscribe("ultimate_used", _ultimate_used)
+        self.subscribe("ultimate_used", _ultimate_used)

--- a/backend/plugins/cards/elemental_spark.py
+++ b/backend/plugins/cards/elemental_spark.py
@@ -54,6 +54,7 @@ class ElementalSpark(CardBase):
             member = chosen.get("member")
             data = chosen.get("mod")
             if member is None or data is None:
+                self.cleanup_subscriptions()
                 return
             mgr, mod = data
             mod.remove()
@@ -63,6 +64,7 @@ class ElementalSpark(CardBase):
                 member.mods.remove(mod.id)
             chosen["member"] = None
             chosen["mod"] = None
+            self.cleanup_subscriptions()
 
-        BUS.subscribe("battle_start", _battle_start)
-        BUS.subscribe("battle_end", _battle_end)
+        self.subscribe("battle_start", _battle_start)
+        self.subscribe("battle_end", _battle_end)

--- a/backend/plugins/cards/enduring_charm.py
+++ b/backend/plugins/cards/enduring_charm.py
@@ -66,16 +66,9 @@ class EnduringCharm(CardBase):
 
                     loop.call_soon_threadsafe(lambda: loop.call_later(20, _remove_boost))
 
-        BUS.subscribe("turn_start", _check_low_hp)
+        self.subscribe("turn_start", _check_low_hp)
 
         def _on_damage_taken(target, attacker, damage, *_: object):
             _check_low_hp()
 
-        BUS.subscribe("damage_taken", _on_damage_taken)
-
-        def _cleanup(*_: object) -> None:
-            BUS.unsubscribe("turn_start", _check_low_hp)
-            BUS.unsubscribe("damage_taken", _on_damage_taken)
-            BUS.unsubscribe("battle_end", _cleanup)
-
-        BUS.subscribe("battle_end", _cleanup)
+        self.subscribe("damage_taken", _on_damage_taken)

--- a/backend/plugins/cards/enduring_will.py
+++ b/backend/plugins/cards/enduring_will.py
@@ -73,6 +73,6 @@ class EnduringWill(CardBase):
                             "trigger_event": "battle_start"
                         })
 
-        BUS.subscribe("death", _on_death)
-        BUS.subscribe("battle_end", _on_battle_end)
-        BUS.subscribe("battle_start", _on_battle_start)
+        self.subscribe("death", _on_death)
+        self.subscribe("battle_end", _on_battle_end)
+        self.subscribe("battle_start", _on_battle_start)

--- a/backend/plugins/cards/energizing_tea.py
+++ b/backend/plugins/cards/energizing_tea.py
@@ -41,12 +41,10 @@ class EnergizingTea(CardBase):
                         },
                     )
 
-                BUS.unsubscribe("battle_start", _on_battle_start)
-                BUS.unsubscribe("battle_end", _on_battle_end)
+                self.unsubscribe("battle_start", _on_battle_start)
 
         def _on_battle_end(entity) -> None:
-            BUS.unsubscribe("battle_start", _on_battle_start)
-            BUS.unsubscribe("battle_end", _on_battle_end)
+            self.cleanup_subscriptions()
 
-        BUS.subscribe("battle_start", _on_battle_start)
-        BUS.subscribe("battle_end", _on_battle_end)
+        self.subscribe("battle_start", _on_battle_start)
+        self.subscribe("battle_end", _on_battle_end)

--- a/backend/plugins/cards/expert_manual.py
+++ b/backend/plugins/cards/expert_manual.py
@@ -43,5 +43,5 @@ class ExpertManual(CardBase):
             if target in party.members:
                 extra_xp_used.clear()
 
-        BUS.subscribe("entity_killed", _on_kill)
-        BUS.subscribe("battle_start", _on_battle_start)
+        self.subscribe("entity_killed", _on_kill)
+        self.subscribe("battle_start", _on_battle_start)

--- a/backend/plugins/cards/farsight_scope.py
+++ b/backend/plugins/cards/farsight_scope.py
@@ -64,8 +64,8 @@ class FarsightScope(CardBase):
                                 "Farsight Scope crit bonus removed from %s",
                                 getattr(attacker, "id", "attacker"),
                             )
-                            BUS.unsubscribe("action_used", _remove_bonus)
+                            self.unsubscribe("action_used", _remove_bonus)
 
-                    BUS.subscribe("action_used", _remove_bonus)
+                    self.subscribe("action_used", _remove_bonus)
 
-        BUS.subscribe("before_attack", _before_attack)
+        self.subscribe("before_attack", _before_attack)

--- a/backend/plugins/cards/fortified_plating.py
+++ b/backend/plugins/cards/fortified_plating.py
@@ -43,5 +43,5 @@ class FortifiedPlating(CardBase):
             # Reset first hit usage at the start of each turn
             first_hit_used.clear()
 
-        BUS.subscribe("damage_taken", _on_damage_taken)
-        BUS.subscribe("turn_start", _on_turn_start)
+        self.subscribe("damage_taken", _on_damage_taken)
+        self.subscribe("turn_start", _on_turn_start)

--- a/backend/plugins/cards/guardian_shard.py
+++ b/backend/plugins/cards/guardian_shard.py
@@ -98,6 +98,6 @@ class GuardianShard(CardBase):
                             {"mitigation_bonus": 1, "trigger_event": "battle_start"},
                         )
 
-        BUS.subscribe("death", _on_death)
-        BUS.subscribe("battle_end", _on_battle_end)
-        BUS.subscribe("battle_start", _on_battle_start)
+        self.subscribe("death", _on_death)
+        self.subscribe("battle_end", _on_battle_end)
+        self.subscribe("battle_start", _on_battle_start)

--- a/backend/plugins/cards/guiding_compass.py
+++ b/backend/plugins/cards/guiding_compass.py
@@ -47,12 +47,11 @@ class GuidingCompass(CardBase):
                         },
                     )
 
-        BUS.subscribe("battle_start", _on_battle_start)
+        self.subscribe("battle_start", _on_battle_start)
 
         async def _on_battle_end(*_args):
             nonlocal first_battle_bonus_used
             first_battle_bonus_used = False
-            BUS.unsubscribe("battle_start", _on_battle_start)
-            BUS.unsubscribe("battle_end", _on_battle_end)
+            self.cleanup_subscriptions()
 
-        BUS.subscribe("battle_end", _on_battle_end)
+        self.subscribe("battle_end", _on_battle_end)

--- a/backend/plugins/cards/honed_point.py
+++ b/backend/plugins/cards/honed_point.py
@@ -61,5 +61,5 @@ class HonedPoint(CardBase):
             if target in party.members:
                 marked_enemies.clear()
 
-        BUS.subscribe("damage_dealt", _on_damage_dealt)
-        BUS.subscribe("battle_start", _on_battle_start)
+        self.subscribe("damage_dealt", _on_damage_dealt)
+        self.subscribe("battle_start", _on_battle_start)

--- a/backend/plugins/cards/inspiring_banner.py
+++ b/backend/plugins/cards/inspiring_banner.py
@@ -53,4 +53,4 @@ class InspiringBanner(CardBase):
                         "trigger_event": "battle_start"
                     })
 
-        BUS.subscribe("battle_start", _on_battle_start)
+        self.subscribe("battle_start", _on_battle_start)

--- a/backend/plugins/cards/iron_guard.py
+++ b/backend/plugins/cards/iron_guard.py
@@ -45,4 +45,4 @@ class IronGuard(CardBase):
                 )
                 mgr.add_modifier(mod)
 
-        BUS.subscribe("damage_taken", _damage_taken)
+        self.subscribe("damage_taken", _damage_taken)

--- a/backend/plugins/cards/iron_resolve.py
+++ b/backend/plugins/cards/iron_resolve.py
@@ -48,5 +48,5 @@ class IronResolve(CardBase):
                 if cooldowns[pid] > 0:
                     cooldowns[pid] -= 1
 
-        BUS.subscribe("damage_taken", _damage_taken)
-        BUS.subscribe("turn_end", _turn_end)
+        self.subscribe("damage_taken", _damage_taken)
+        self.subscribe("turn_end", _turn_end)

--- a/backend/plugins/cards/iron_resurgence.py
+++ b/backend/plugins/cards/iron_resurgence.py
@@ -43,10 +43,8 @@ class IronResurgence(CardBase):
         def _battle_end(entity) -> None:
             if entity not in party.members:
                 return
-            BUS.unsubscribe("damage_taken", _damage)
-            BUS.unsubscribe("turn_start", _turn_start)
-            BUS.unsubscribe("battle_end", _battle_end)
+            self.cleanup_subscriptions()
 
-        BUS.subscribe("damage_taken", _damage)
-        BUS.subscribe("turn_start", _turn_start)
-        BUS.subscribe("battle_end", _battle_end)
+        self.subscribe("damage_taken", _damage)
+        self.subscribe("turn_start", _turn_start)
+        self.subscribe("battle_end", _battle_end)

--- a/backend/plugins/cards/keen_goggles.py
+++ b/backend/plugins/cards/keen_goggles.py
@@ -69,12 +69,5 @@ class KeenGoggles(CardBase):
                 if actor_id in crit_stacks:
                     del crit_stacks[actor_id]
 
-        BUS.subscribe("effect_applied", _on_effect_applied)
-        BUS.subscribe("action_taken", _on_action_taken)
-
-        def _cleanup(*_: object) -> None:
-            BUS.unsubscribe("effect_applied", _on_effect_applied)
-            BUS.unsubscribe("action_taken", _on_action_taken)
-            BUS.unsubscribe("battle_end", _cleanup)
-
-        BUS.subscribe("battle_end", _cleanup)
+        self.subscribe("effect_applied", _on_effect_applied)
+        self.subscribe("action_taken", _on_action_taken)

--- a/backend/plugins/cards/lightweight_boots.py
+++ b/backend/plugins/cards/lightweight_boots.py
@@ -51,8 +51,7 @@ class LightweightBoots(CardBase):
                         log.warning("Error applying Lightweight Boots dodge heal: %s", e)
 
         def _on_battle_end(_entity) -> None:
-            BUS.unsubscribe("dodge", _on_dodge)
-            BUS.unsubscribe("battle_end", _on_battle_end)
+            self.cleanup_subscriptions()
 
-        BUS.subscribe("dodge", _on_dodge)
-        BUS.subscribe("battle_end", _on_battle_end)
+        self.subscribe("dodge", _on_dodge)
+        self.subscribe("battle_end", _on_battle_end)

--- a/backend/plugins/cards/lucky_coin.py
+++ b/backend/plugins/cards/lucky_coin.py
@@ -34,4 +34,4 @@ class LuckyCoin(CardBase):
                         "trigger_event": "critical_hit"
                     })
 
-        BUS.subscribe("critical_hit", _on_critical_hit)
+        self.subscribe("critical_hit", _on_critical_hit)

--- a/backend/plugins/cards/mindful_tassel.py
+++ b/backend/plugins/cards/mindful_tassel.py
@@ -88,10 +88,8 @@ class MindfulTassel(CardBase):
                 bonus_used = False
 
         def _on_battle_end(_entity) -> None:
-            BUS.unsubscribe("effect_applied", _on_effect_applied)
-            BUS.unsubscribe("battle_start", _on_battle_start)
-            BUS.unsubscribe("battle_end", _on_battle_end)
+            self.cleanup_subscriptions()
 
-        BUS.subscribe("effect_applied", _on_effect_applied)
-        BUS.subscribe("battle_start", _on_battle_start)
-        BUS.subscribe("battle_end", _on_battle_end)
+        self.subscribe("effect_applied", _on_effect_applied)
+        self.subscribe("battle_start", _on_battle_start)
+        self.subscribe("battle_end", _on_battle_end)

--- a/backend/plugins/cards/mystic_aegis.py
+++ b/backend/plugins/cards/mystic_aegis.py
@@ -31,4 +31,4 @@ class MysticAegis(CardBase):
             )
             safe_async_task(member.apply_healing(heal))
 
-        BUS.subscribe("debuff_resisted", _resisted)
+        self.subscribe("debuff_resisted", _resisted)

--- a/backend/plugins/cards/overclock.py
+++ b/backend/plugins/cards/overclock.py
@@ -80,4 +80,4 @@ class Overclock(CardBase):
             if entity in party.members:
                 safe_async_task(_grant_speed_boost(entity))
 
-        BUS.subscribe("battle_start", _battle_start)
+        self.subscribe("battle_start", _battle_start)

--- a/backend/plugins/cards/phantom_ally.py
+++ b/backend/plugins/cards/phantom_ally.py
@@ -139,6 +139,6 @@ class PhantomAlly(CardBase):
                 if not remaining_phantoms:
                     setattr(original, phantom_slot_tracker, 0)
             SummonManager.remove_summon(summon, "phantom_ally_cleanup")
-            BUS.unsubscribe("battle_end", _cleanup)
+            self.cleanup_subscriptions()
 
-        BUS.subscribe("battle_end", _cleanup)
+        self.subscribe("battle_end", _cleanup)

--- a/backend/plugins/cards/polished_shield.py
+++ b/backend/plugins/cards/polished_shield.py
@@ -61,4 +61,4 @@ class PolishedShield(CardBase):
                 payload["metadata"] = metadata
             await BUS.emit_async("card_effect", self.id, target, "resist_def_bonus", 3, payload)
 
-        BUS.subscribe("effect_resisted", _on_effect_resisted)
+        self.subscribe("effect_resisted", _on_effect_resisted)

--- a/backend/plugins/cards/precision_sights.py
+++ b/backend/plugins/cards/precision_sights.py
@@ -48,4 +48,4 @@ class PrecisionSights(CardBase):
                     "trigger_event": "critical_hit"
                 })
 
-        BUS.subscribe("critical_hit", _on_critical_hit)
+        self.subscribe("critical_hit", _on_critical_hit)

--- a/backend/plugins/cards/reality_split.py
+++ b/backend/plugins/cards/reality_split.py
@@ -35,13 +35,8 @@ class RealitySplit(CardBase):
         state: dict[str, object] = {"active": None, "foes": []}
 
         def _cleanup() -> None:
-            bundle = handlers_store.pop(self.id, None)
-            if not bundle:
-                state["foes"].clear()
-                state["active"] = None
-                return
-            for event_name, handler in bundle["handlers"].items():
-                BUS.unsubscribe(event_name, handler)
+            handlers_store.pop(self.id, None)
+            self.cleanup_subscriptions()
             state["foes"].clear()
             state["active"] = None
 
@@ -100,7 +95,7 @@ class RealitySplit(CardBase):
 
         def _register(event_name: str, handler) -> None:
             handlers[event_name] = handler
-            BUS.subscribe(event_name, handler)
+            self.subscribe(event_name, handler)
 
         handlers_store[self.id] = {"handlers": handlers}
 

--- a/backend/plugins/cards/reinforced_cloak.py
+++ b/backend/plugins/cards/reinforced_cloak.py
@@ -44,4 +44,4 @@ class ReinforcedCloak(CardBase):
                                     })
                                     break
 
-        BUS.subscribe("effect_applied", _on_effect_applied)
+        self.subscribe("effect_applied", _on_effect_applied)

--- a/backend/plugins/cards/rejuvenating_tonic.py
+++ b/backend/plugins/cards/rejuvenating_tonic.py
@@ -37,4 +37,4 @@ class RejuvenatingTonic(CardBase):
                     except Exception as e:
                         log.warning("Error applying Rejuvenating Tonic bonus heal: %s", e)
 
-        BUS.subscribe("heal", _on_heal)
+        self.subscribe("heal", _on_heal)

--- a/backend/plugins/cards/sharpening_stone.py
+++ b/backend/plugins/cards/sharpening_stone.py
@@ -45,4 +45,4 @@ class SharpeningStone(CardBase):
                     "trigger_event": "critical_hit"
                 })
 
-        BUS.subscribe("critical_hit", _on_critical_hit)
+        self.subscribe("critical_hit", _on_critical_hit)

--- a/backend/plugins/cards/spiked_shield.py
+++ b/backend/plugins/cards/spiked_shield.py
@@ -67,4 +67,4 @@ class SpikedShield(CardBase):
 
                     safe_async_task(_retaliate())
 
-        BUS.subscribe("mitigation_triggered", _on_mitigation_triggered)
+        self.subscribe("mitigation_triggered", _on_mitigation_triggered)

--- a/backend/plugins/cards/steady_grip.py
+++ b/backend/plugins/cards/steady_grip.py
@@ -50,4 +50,4 @@ class SteadyGrip(CardBase):
                         "trigger_event": "control_applied"
                     })
 
-        BUS.subscribe("effect_applied", _on_effect_applied)
+        self.subscribe("effect_applied", _on_effect_applied)

--- a/backend/plugins/cards/steel_bangles.py
+++ b/backend/plugins/cards/steel_bangles.py
@@ -48,10 +48,4 @@ class SteelBangles(CardBase):
                         "trigger_chance": 0.05
                     })
 
-        BUS.subscribe("damage_dealt", _on_damage_dealt)
-
-        def _cleanup(*_: object) -> None:
-            BUS.unsubscribe("damage_dealt", _on_damage_dealt)
-            BUS.unsubscribe("battle_end", _cleanup)
-
-        BUS.subscribe("battle_end", _cleanup)
+        self.subscribe("damage_dealt", _on_damage_dealt)

--- a/backend/plugins/cards/sturdy_vest.py
+++ b/backend/plugins/cards/sturdy_vest.py
@@ -96,5 +96,5 @@ class SturdyVest(CardBase):
             await _check_low_hp()
 
         # Check HP at the start of each turn and after damage taken
-        BUS.subscribe("turn_start", _on_turn_start)
-        BUS.subscribe("damage_taken", _on_damage_taken)
+        self.subscribe("turn_start", _on_turn_start)
+        self.subscribe("damage_taken", _on_damage_taken)

--- a/backend/plugins/cards/swift_bandanna.py
+++ b/backend/plugins/cards/swift_bandanna.py
@@ -45,4 +45,4 @@ class SwiftBandanna(CardBase):
                     "trigger_event": "dodge"
                 })
 
-        BUS.subscribe("dodge", _on_dodge)
+        self.subscribe("dodge", _on_dodge)

--- a/backend/plugins/cards/swift_footwork.py
+++ b/backend/plugins/cards/swift_footwork.py
@@ -63,7 +63,7 @@ class SwiftFootwork(CardBase):
                     },
                 )
 
-        BUS.subscribe("battle_start", _battle_start)
+        self.subscribe("battle_start", _battle_start)
 
         async def _battle_end(*_args) -> None:
             for member in party.members:
@@ -85,8 +85,7 @@ class SwiftFootwork(CardBase):
                 if isinstance(mods_list, list):
                     mods_list[:] = [mid for mid in mods_list if mid != burst_id]
 
-            BUS.unsubscribe("battle_start", _battle_start)
-            BUS.unsubscribe("battle_end", _battle_end)
+            self.cleanup_subscriptions()
 
-        BUS.subscribe("battle_end", _battle_end)
+        self.subscribe("battle_end", _battle_end)
 

--- a/backend/plugins/cards/tactical_kit.py
+++ b/backend/plugins/cards/tactical_kit.py
@@ -68,5 +68,5 @@ class TacticalKit(CardBase):
             if target in party.members:
                 conversion_used.clear()
 
-        BUS.subscribe("action_start", _on_action_about_to_start)
-        BUS.subscribe("battle_start", _on_battle_start)
+        self.subscribe("action_start", _on_action_about_to_start)
+        self.subscribe("battle_start", _on_battle_start)

--- a/backend/plugins/cards/temporal_shield.py
+++ b/backend/plugins/cards/temporal_shield.py
@@ -46,4 +46,4 @@ class TemporalShield(CardBase):
                         {"reduction_percent": 99},
                     )
 
-        BUS.subscribe("turn_start", _turn_start)
+        self.subscribe("turn_start", _turn_start)

--- a/backend/plugins/cards/thick_skin.py
+++ b/backend/plugins/cards/thick_skin.py
@@ -39,10 +39,9 @@ class ThickSkin(CardBase):
                                     })
                                     break
 
-        BUS.subscribe("effect_applied", _on_effect_applied)
+        self.subscribe("effect_applied", _on_effect_applied)
 
         def _on_battle_end(entity) -> None:
-            BUS.unsubscribe("effect_applied", _on_effect_applied)
-            BUS.unsubscribe("battle_end", _on_battle_end)
+            self.cleanup_subscriptions()
 
-        BUS.subscribe("battle_end", _on_battle_end)
+        self.subscribe("battle_end", _on_battle_end)

--- a/backend/plugins/cards/vital_core.py
+++ b/backend/plugins/cards/vital_core.py
@@ -70,11 +70,5 @@ class VitalCore(CardBase):
         def _on_damage_taken(target, attacker, damage, *_: object):
             _check_low_hp()
 
-        def _cleanup(*_: object) -> None:
-            BUS.unsubscribe("turn_start", _check_low_hp)
-            BUS.unsubscribe("damage_taken", _on_damage_taken)
-            BUS.unsubscribe("battle_end", _cleanup)
-
-        BUS.subscribe("turn_start", _check_low_hp)
-        BUS.subscribe("damage_taken", _on_damage_taken)
-        BUS.subscribe("battle_end", _cleanup)
+        self.subscribe("turn_start", _check_low_hp)
+        self.subscribe("damage_taken", _on_damage_taken)

--- a/backend/plugins/cards/vital_surge.py
+++ b/backend/plugins/cards/vital_surge.py
@@ -65,6 +65,6 @@ class VitalSurge(CardBase):
             if member in party.members:
                 _check(member)
 
-        BUS.subscribe("turn_start", _turn_start)
-        BUS.subscribe("damage_taken", _damage_taken)
-        BUS.subscribe("heal_received", _heal_received)
+        self.subscribe("turn_start", _turn_start)
+        self.subscribe("damage_taken", _damage_taken)
+        self.subscribe("heal_received", _heal_received)


### PR DESCRIPTION
## Summary
- introduce a subscription registry on `CardBase` so cards can register and automatically clean up event bus handlers
- refactor card implementations to call the helper APIs instead of directly touching the bus
- extend the card effects test suite with a parametrized case that guards against duplicate handler registration across battles

## Testing
- uv run ruff check backend/plugins/cards backend/tests/test_card_effects.py --fix
- PYTHONPATH=backend uv run pytest backend/tests/test_card_effects.py -k apply_cards_cleans_up_bus_handlers

------
https://chatgpt.com/codex/tasks/task_b_68cfe3501df8832c86b4c13d3bac316c