### PR TITLE
[TASK] Extend battle review planning

### DIFF
--- a/.codex/tasks/16a58b4c-theme-motion-settings.md
+++ b/.codex/tasks/16a58b4c-theme-motion-settings.md
@@ -1,0 +1,21 @@
+Coder, expand the WebUI settings to support theming and granular motion control.
+
+## Context
+- `frontend/src/lib/components/SettingsMenu.svelte` currently exposes Audio/System/Gameplay tabs with a single Reduced Motion toggle and no theme configuration.
+- `frontend/src/lib/components/SystemSettings.svelte` only offers a boolean Reduced Motion checkbox and fixed framerate options; there is no way to opt out of specific animations like StarStorm, battle floaters, or portrait glows.
+- `frontend/src/lib/components/GameViewport.svelte` hard-codes the accent color to the user's level via `levelToAccent`, so players cannot override the palette or background rotation.
+- `frontend/src/lib/systems/settingsStorage.js` persists only simple numeric/boolean settings and lacks schema support for themes or nested accessibility preferences.
+
+## Requirements
+- Introduce a theme system that lets players pick from predefined palettes (e.g., "Default", "Solaris", "Nocturne") or supply a custom accent/background. The selection should drive `GameViewport` styling instead of the current level-derived hue.
+- Provide controls to choose background behavior (hourly rotation, static pick, custom asset) and whether decorative layers like `StarStorm.svelte` render at all.
+- Replace the single Reduced Motion toggle with a tree of options (e.g., "Global Reduced Motion", "Disable Floating Damage Popups", "Disable Portrait Glows", "Simplify Overlay Transitions"). Respect `prefers-reduced-motion` by defaulting the root switch appropriately.
+- Persist the new settings structure in `settingsStorage.js` with backward-compatible migration logic so existing players keep their saved volumes/animation speed.
+- Ensure all major animation-producing components (`StarStorm.svelte`, `BattleEventFloaters.svelte`, `BattleFighterCard.svelte`, overlay transitions) read the new granular flags and adjust behavior without extra prop plumbing in every call site.
+- Update the settings documentation in `frontend/.codex/implementation/settings-menu.md` to describe the theme picker and motion sub-options, including UX expectations.
+
+## Notes
+- Consider exposing a preview area in the Settings overlay so players can see their theme choices before closing the dialog.
+- Do not regress keyboard navigation: all new controls must be reachable via tab order and have accessible labels.
+
+Task ready for implementation.

--- a/.codex/tasks/4e7a2427-stabilize-webui-animations.md
+++ b/.codex/tasks/4e7a2427-stabilize-webui-animations.md
@@ -1,0 +1,21 @@
+Coder, standardize WebUI animation tokens and smooth out battle/menu motion.
+
+## Context
+- `frontend/src/lib/components/StarStorm.svelte` (destined to be the `ElementOrbs` backdrop) randomizes orb drift, delays, and colors at module load, leading to inconsistent visuals between renders and no linkage to global animation speed or reduced-motion settings.【F:frontend/src/lib/components/StarStorm.svelte†L1-L120】
+- `frontend/src/lib/components/BattleEventFloaters.svelte` hard-codes durations (`BASE_DURATION`, stagger timers) and easing curves with no shared constants, producing abrupt motion compared to other overlays.【F:frontend/src/lib/components/BattleEventFloaters.svelte†L1-L220】【F:frontend/src/lib/components/BattleEventFloaters.svelte†L220-L360】
+- `frontend/src/lib/battle/BattleFighterCard.svelte` uses random animation durations/delays for rank outlines and ultimate icon pulses, which makes the UI feel jittery and is difficult to test.【F:frontend/src/lib/battle/BattleFighterCard.svelte†L1-L200】
+- Reduced Motion currently only toggles certain transitions off; many components ignore `reducedMotion` props or `prefers-reduced-motion` entirely.
+
+## Requirements
+- Create a shared animation token module (e.g., `frontend/src/lib/systems/animationTokens.js`) that defines durations, easings, and opacity curves for primary UI effects (background ambiance, popups, battle floaters, portrait glows).
+- Rename `StarStorm.svelte` and the related implementation notes to `ElementOrbs` (or similar) as part of the refactor so the component name matches the current art direction.
+- Refactor ElementOrbs, BattleEventFloaters, BattleFighterCard, and other animation-heavy components (e.g., `TripleRingSpinner.svelte`, overlay transitions in `OverlayHost.svelte`) to consume the shared tokens instead of inventing per-file constants/randomization.
+- Ensure every component honors the granular motion settings from the new settings tree (see task 16a58b4c) and `window.matchMedia('(prefers-reduced-motion)')` by clamping durations to zero or swapping in static art where appropriate.
+- Provide snapshot or unit coverage verifying that animation tokens export the expected structure and that components fall back to static states when motion is disabled.
+- Update relevant documentation (`frontend/.codex/implementation/battle-effects.md`, `frontend/.codex/implementation/settings-menu.md`) to describe the token system and how motion flags map to component behavior.
+
+## Notes
+- Avoid introducing runtime randomness in animations; if variation is required, derive it deterministically from ids or seeds so renders stay stable between sessions.
+- Coordinate with the theme task so token colors/strengths can adapt to the selected theme.
+
+Task ready for implementation.

--- a/.codex/tasks/851e9055-skip-battle-review-setting.md
+++ b/.codex/tasks/851e9055-skip-battle-review-setting.md
@@ -1,0 +1,22 @@
+Coder, add a gameplay setting that lets players skip the Battle Review overlay.
+
+## Context
+- `SettingsMenu.svelte` persists gameplay preferences (reduced motion, animation speed, idle mode) via `saveSettings` but offers no option to bypass the post-fight Battle Review.【F:frontend/src/lib/components/SettingsMenu.svelte†L154-L185】
+- The Gameplay tab renders toggles for action values and full idle mode, making it the natural home for a "Skip Battle Review" control.【F:frontend/src/lib/components/GameplaySettings.svelte†L92-L145】
+- `OverlayHost.svelte` always opens the Battle Review popup when `reviewOpen && reviewReady`, forcing players through the screen even if they just want to advance.【F:frontend/src/lib/components/OverlayHost.svelte†L372-L398】
+- Settings persistence lives in `frontend/src/lib/systems/settingsStorage.js`, so the new toggle must round-trip through local storage and initialization the same way as other gameplay options.【F:frontend/src/lib/systems/settingsStorage.js†L1-L44】
+
+## Requirements
+- Add a `skipBattleReview` boolean to the settings schema, including load/save logic, defaulting to `false` for existing players.
+- Surface a checkbox (or similar control) within the Gameplay settings tab that flips `skipBattleReview`, reusing the tooltip/label styling and wiring it into the existing debounced `scheduleSave` flow.
+- Teach `OverlayHost` (and any other review gating logic) to respect the flag: when enabled, immediately dispatch the `nextRoom` progression after logging battle results without mounting the Battle Review overlay.
+- Ensure the skip path still honors reward handling—only bypass the review when there are no outstanding loot choices and the backend has marked the battle complete.
+- Update initialization code (`viewportState`, overlay stores) so the skip flag is available when deciding whether to request summaries or prefetched data.
+- Provide tests to cover settings persistence and overlay branching (e.g., Vitest components or store unit tests that confirm review bypass behavior).
+- Document the new toggle in `frontend/.codex/implementation/settings-menu.md` and cross-link from the Battle Review documentation so players know how to disable the timeline screen once the redesign ships.
+
+## Notes
+- Coordinate with the timeline overhaul (task d6ec9364) so skip behavior gracefully handles future review modules.
+- Consider analytics or logging hooks to measure how often players skip the review for future UX tuning.
+
+Task ready for implementation.

--- a/.codex/tasks/b4f064c7-webui-root-cleanup.md
+++ b/.codex/tasks/b4f064c7-webui-root-cleanup.md
@@ -1,0 +1,20 @@
+Coder, refactor the WebUI root page and retire legacy component naming.
+
+## Context
+- `frontend/src/routes/+page.svelte` has ballooned to 1,500+ lines and mixes data fetching, polling orchestration, overlay wiring, and UI state normalization in a single Svelte component, making it difficult to reason about and test.【09b46a†L1-L2】
+- The file still contains legacy helpers (e.g., the "NEW UI API APPROACH" block, manual polling, and direct `window.*` flags) intermixed with current run handling, making cleanup risky without a structured split.【F:frontend/src/routes/+page.svelte†L1290-L1455】
+- `frontend/src/lib/components/BattleReview.svelte` imports `LegacyFighterPortrait`, a name that implies it is deprecated even though it powers the modern review overlay.【F:frontend/src/lib/components/BattleReview.svelte†L1-L18】
+- The corresponding component file `frontend/src/lib/battle/LegacyFighterPortrait.svelte` still carries TODO comments about future behavior and ships duplicated HP/overheal logic that also lives in `BattleFighterCard.svelte`.【F:frontend/src/lib/battle/LegacyFighterPortrait.svelte†L1-L80】
+
+## Requirements
+- Break `+page.svelte` into focused modules: extract run state management, backend polling, and overlay coordination into dedicated stores/utilities under `frontend/src/lib/systems/`. Keep the Svelte page focused on composing the viewport and wiring events.
+- While refactoring, remove vestigial logic such as the direct `window.af*` flags and the commented "NEW UI API" scaffolding, replacing them with explicit stores that can be unit tested.
+- Replace `frontend/src/lib/battle/LegacyFighterPortrait.svelte` with a modernized review portrait that reuses the shared fighter card helpers, then delete the legacy component outright once call sites are migrated.
+- Update all imports (`BattleReview.svelte`, any other references) and ensure styles/tests/docs reference the new portrait module and utilities.
+- Refresh documentation under `frontend/.codex/implementation/battle-review-ui.md` (and related notes) to describe the new module boundaries and the retirement of the legacy portrait file.
+
+## Notes
+- Add targeted unit or component tests for the new extracted stores so regressions in run polling or overlay gating are caught quickly.
+- Coordinate with other in-flight frontend work when renaming the portrait component to avoid merge pain (flag in PR description if necessary).
+
+Task ready for implementation.

--- a/.codex/tasks/cc500aa6-remove-per-character-hardcodes.md
+++ b/.codex/tasks/cc500aa6-remove-per-character-hardcodes.md
@@ -1,0 +1,20 @@
+Coder, remove per-character hard-coding from the WebUI and source data from backend metadata.
+
+## Context
+- `frontend/src/routes/+page.svelte` seeds the party with `['sample_player']`, a placeholder id that leaks into run creation until the player reselects a roster.【F:frontend/src/routes/+page.svelte†L30-L39】
+- `frontend/src/lib/systems/viewportState.js` gives the character id `luna` triple weight when picking battle music, rather than reading any weighting from backend data.【F:frontend/src/lib/systems/viewportState.js†L118-L135】
+- `frontend/src/lib/systems/assetLoader.js` includes hard-coded aliases such as `lady_echo → echo` and special-cases mimic behavior, with no way for backend-driven alias lists to flow in.【F:frontend/src/lib/systems/assetLoader.js†L232-L308】
+- The current documentation in `frontend/.codex/implementation/party-ui.md` and `frontend/.codex/implementation/battle-effects.md` assumes the UI reflects backend metadata, but the hard-coded values above break that contract.
+
+## Requirements
+- Replace the `'sample_player'` default with a dynamic roster-derived seed (e.g., automatically select the first available player id after fetching `getPlayers()`), and ensure party state stays empty until real data arrives.
+- Update the music selection logic to consume weighting metadata from backend responses or a configuration map returned by `getPlayers()`/`getUIState()`, falling back gracefully when weights are missing. Remove the inline `id === 'luna' ? 3 : 1` logic.
+- Expose a structured alias map (e.g., `{ id, aliases, assetFolder }`) from the backend UI bootstrap or a new endpoint, and update the asset loader to honor it instead of shipping hard-coded switches. Keep mimic behavior but derive the base image id from metadata where possible.
+- Audit the WebUI for any other name-based conditionals (e.g., summons, overlays, UI badges) and replace them with metadata-driven flags supplied by the backend. Document any new keys expected from API responses.
+- Update relevant `.codex/implementation` docs (party UI, battle viewer, asset loading) to describe the new metadata fields and remove references to the deleted hard codes.
+
+## Notes
+- Coordinate with backend developers if additional metadata must be added to existing endpoints; include acceptance notes in the task PR so QA knows what to verify.
+- Ensure existing players retain their saved parties after the migration—perform necessary state migrations or validation when loading persisted run data.
+
+Task ready for implementation.

--- a/.codex/tasks/d6ec9364-battle-review-timeline.md
+++ b/.codex/tasks/d6ec9364-battle-review-timeline.md
@@ -1,0 +1,24 @@
+Coder, redesign the Battle Review into an FFLogs-style timeline analysis surface.
+
+## Context
+- `frontend/src/lib/components/BattleReview.svelte` currently renders tab buttons, summary tables, and a modal toggle for raw events, but it lacks timeline graphs, metric tabs, or deep filtering similar to FFLogs. The implementation glues together summary fetches and per-entity panels within a monolithic component, making larger visualizations difficult to add.【F:frontend/src/lib/components/BattleReview.svelte†L1-L200】【F:frontend/src/lib/components/BattleReview.svelte†L340-L520】
+- The Battle Review documentation still describes a static three-column layout driven by `LegacyFighterPortrait`, with no mention of timeline playback, comparison, or query controls.【F:frontend/.codex/implementation/battle-review-ui.md†L1-L13】
+- OverlayHost mounts BattleReview as a fullscreen popup after each fight, so any new analysis view must continue to integrate with the existing overlay lifecycle and respect reduced-motion settings.【F:frontend/src/lib/components/OverlayHost.svelte†L372-L398】
+
+## Requirements
+- Replace the current Battle Review layout with a timeline-first interface inspired by FFLogs: metric tabs across the top (Damage Done, Damage Taken, Healing, etc.), a query/filter bar, a synchronized fight timeline graph, per-entity tables, and a dedicated events log.
+- Implement an interactive timeline visualization that can zoom to specific windows, scrub along the fight, and highlight ability usage for the selected player, foe, or filter.
+- Add comparison workflows that allow selecting multiple entities (e.g., two party members) and overlaying their timelines/tables to highlight rotation differences. Persist comparison selections within the review session.
+- Build a pins/bookmark system so users can save a filtered view (time window + filters + metric) and jump back to it quickly; ensure pins can be shared via overlay events or copied links once backend routing supports it.
+- Introduce modular stores/utilities under `frontend/src/lib/systems/battleReview/` to manage fetched summaries, events, and derived timeline datasets so the Svelte components stay focused on presentation.
+- Ensure the events log supports fast searching, type filtering (damage, healing, buffs, mitigations), and jumping the timeline playback to the selected timestamp.
+- Integrate reduced-motion handling so graph animations, scrubbing highlights, and transitions respect the animation token work (task 4e7a2427) and granular motion settings.
+- Update or replace `frontend/src/lib/components/battle-review/` subcomponents with timeline-aware equivalents (graphs, tables, comparison panel) and delete obsolete files once migrated.
+- Refresh documentation (`frontend/.codex/implementation/battle-review-ui.md`, plus any new module docs) to describe the timeline system, query controls, comparison flows, and pinning UX.
+- Provide unit or component coverage for the new stores (data shaping, filtering) and interaction-heavy components (timeline syncing, comparison toggles) to keep regressions visible.
+
+## Notes
+- Coordinate with backend/API owners if additional data is required (e.g., positioning, timestamps, mitigations). Document interim stubs if full parity needs multiple milestones.
+- Aim for deterministic rendering so pins and comparison views stay shareable across sessions.
+
+Task ready for implementation.

--- a/.codex/tasks/eb7504e6-webui-asset-registry.md
+++ b/.codex/tasks/eb7504e6-webui-asset-registry.md
@@ -1,0 +1,24 @@
+Coder, unify the WebUI asset loading pipeline into a single registry.
+
+## Context
+- `frontend/src/lib/systems/assetLoader.js` hand-rolls URL normalization and caches for characters, backgrounds, DoT icons, and lightstream swords that currently live alongside character portraits instead of under a summons-specific grouping.
+- `frontend/src/lib/systems/rewardLoader.js` and `frontend/src/lib/systems/materialAssetLoader.js` repeat similar `import.meta.glob` + `normalizeUrl` logic for cards, relics, and items.
+- `frontend/src/lib/systems/music.js` and `frontend/src/lib/systems/sfx.js` expose separate loading conventions for audio assets, making it hard to standardize how sounds are discovered/configured.
+- The asset-loading implementation notes in `frontend/.codex/implementation/asset-loading.md` no longer match the current code, and there is no single surface for coders to plug in future asset families (e.g., UI backgrounds, particle packs).
+
+## Requirements
+- Design a central `assetRegistry` (or similar) inside `frontend/src/lib/systems/` that exposes typed loaders for:
+  - character portraits, fallbacks, lightstream sword art, jellyfish summons, and background rotations (with swords/jellyfish relocated into a dedicated `summons/` folder so they no longer mix with character art);
+  - cards, relics, inventory materials (icons + glyphs);
+  - music playlists and sound effects.
+- Deduplicate and delete one-off helpers such as the `normalizeUrl` copies in `assetLoader.js` and `rewardLoader.js`, and consolidate caching into the shared registry.
+- Provide a consistent API that callers across the app can import (e.g., `getCharacterImage`, `listBackgrounds`, `getMusicPlaylist`, `getSfxClip`), replacing the bespoke exports in the existing modules.
+- Ensure the registry supports injecting metadata (aliases, rarity folders, etc.) instead of hard-coded heuristics, preparing the codebase for backend-provided asset descriptors.
+- Update all call sites to use the new registry while maintaining existing functionality (portraits should still randomize per session, rewards still resolve art, music still honors battle context, etc.).
+- Refresh `frontend/.codex/implementation/asset-loading.md` so the documentation matches the unified pipeline and describes how new asset families should be registered.
+
+## Notes
+- Be careful to keep Vite's static `import.meta.glob` analysis working—registry helpers still need to declare the globs at module scope.
+- Provide unit coverage or integration tests for the registry functions where practical (especially alias resolution and fallback ordering).
+
+Task ready for implementation.


### PR DESCRIPTION
## Summary
- update the animation token task to fold the StarStorm backdrop into an ElementOrbs rename
- revise the WebUI root cleanup task to fully retire the legacy battle review portrait component
- refine the asset registry task to relocate swords and jellyfish into a summons asset bucket
- add follow-on tasks for an FFLogs-inspired battle review timeline and a gameplay toggle to skip the review overlay

## Testing
- not run (task planning only)

------
https://chatgpt.com/codex/tasks/task_b_68cfe5eff6d0832c810083aee95715ab