### PR TITLE
fix: add source_star migration before upgrade backfill

### DIFF
--- a/backend/routes/players.py
+++ b/backend/routes/players.py
@@ -635,6 +635,11 @@ def _ensure_upgrade_tables(conn) -> None:
     cur = conn.execute("PRAGMA table_info(player_stat_upgrades)")
     columns = {row[1] for row in cur.fetchall()}
     has_source_star = "source_star" in columns
+    if not has_source_star:
+        conn.execute(
+            "ALTER TABLE player_stat_upgrades ADD COLUMN source_star INTEGER NOT NULL DEFAULT 0"
+        )
+        has_source_star = True
     needs_backfill = False
     if "cost_spent" not in columns:
         conn.execute(


### PR DESCRIPTION
## Summary
- award duplicate character pulls with free stat-upgrade rows and surface the new `stat_levels_awarded` result field
- adjust player upgrade helpers to tolerate zero-cost rows when building counts and next costs
- update the duplicate gacha test to check per-stat level gains instead of legacy upgrade points
- ensure older saves add the `source_star` column before running upgrade backfills

## Testing
- ruff check backend/autofighter/gacha.py backend/routes/players.py backend/tests/test_gacha.py --fix
- uv run pytest backend/tests/test_gacha.py *(fails: ModuleNotFoundError: No module named 'sqlcipher3')*


------
https://chatgpt.com/codex/tasks/task_b_68d00e067d88832cb42fea60aefae0bb