### PR TITLE
fix(tracking): allow logging actions without run

### DIFF
--- a/backend/tracking/service.py
+++ b/backend/tracking/service.py
@@ -2,12 +2,12 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Callable
 import json
 import logging
 import time
-import uuid
-from collections.abc import Callable
 from typing import Any
+import uuid
 
 from .manager import get_tracking_manager
 
@@ -40,6 +40,26 @@ def _dump(details: Any) -> str:
         return json.dumps(details)
     except Exception:
         return json.dumps({"value": str(details)})
+
+
+def _ensure_run_logged(conn: Any, run_id: str | None, *, create_placeholder: bool = False) -> str | None:
+    if not run_id:
+        return None
+
+    cur = conn.execute("SELECT 1 FROM runs WHERE run_id = ?", (run_id,))
+    if cur.fetchone():
+        return run_id
+
+    if create_placeholder:
+        conn.execute(
+            "INSERT OR IGNORE INTO runs (run_id, start_ts, end_ts, outcome) VALUES (?, ?, NULL, NULL)",
+            (run_id, _now()),
+        )
+        cur = conn.execute("SELECT 1 FROM runs WHERE run_id = ?", (run_id,))
+        if cur.fetchone():
+            return run_id
+
+    return None
 
 
 async def log_run_start(
@@ -128,11 +148,14 @@ async def log_card_acquisition(
     ts: int | None = None,
 ) -> None:
     ts = ts or _now()
+    sanitized_run_id: str | None = run_id
 
     def write(conn: Any) -> None:
+        nonlocal sanitized_run_id
+        sanitized_run_id = _ensure_run_logged(conn, run_id, create_placeholder=True)
         conn.execute(
             "INSERT INTO cards (run_id, room_id, card_id, source, ts) VALUES (?, ?, ?, ?, ?)",
-            (run_id, room_id, card_id, source, ts),
+            (sanitized_run_id, room_id, card_id, source, ts),
         )
 
     await _execute(write)
@@ -146,11 +169,14 @@ async def log_relic_acquisition(
     ts: int | None = None,
 ) -> None:
     ts = ts or _now()
+    sanitized_run_id: str | None = run_id
 
     def write(conn: Any) -> None:
+        nonlocal sanitized_run_id
+        sanitized_run_id = _ensure_run_logged(conn, run_id, create_placeholder=True)
         conn.execute(
             "INSERT INTO relics (run_id, room_id, relic_id, source, ts) VALUES (?, ?, ?, ?, ?)",
-            (run_id, room_id, relic_id, source, ts),
+            (sanitized_run_id, room_id, relic_id, source, ts),
         )
 
     await _execute(write)
@@ -166,10 +192,22 @@ async def log_battle_summary(
     ts: int | None = None,
 ) -> None:
     ts = ts or _now()
+    sanitized_run_id: str | None = run_id
+
     def write(conn: Any) -> None:
+        nonlocal sanitized_run_id
+        sanitized_run_id = _ensure_run_logged(conn, run_id, create_placeholder=True)
         conn.execute(
             "INSERT INTO battle_summaries (run_id, room_id, turns, dmg_dealt, dmg_taken, victory, ts) VALUES (?, ?, ?, ?, ?, ?, ?)",
-            (run_id, room_id, turns, dmg_dealt, dmg_taken, 1 if victory else 0, ts),
+            (
+                sanitized_run_id,
+                room_id,
+                turns,
+                dmg_dealt,
+                dmg_taken,
+                1 if victory else 0,
+                ts,
+            ),
         )
 
     await _execute(write)
@@ -197,11 +235,14 @@ async def log_game_action(
     ts: int | None = None,
 ) -> None:
     ts = ts or _now()
+    sanitized_run_id: str | None = run_id
 
     def write(conn: Any) -> None:
+        nonlocal sanitized_run_id
+        sanitized_run_id = _ensure_run_logged(conn, run_id)
         conn.execute(
             "INSERT INTO game_actions (run_id, room_id, action_type, ts, details_json) VALUES (?, ?, ?, ?, ?)",
-            (run_id, room_id, action_type, ts, _dump(details)),
+            (sanitized_run_id, room_id, action_type, ts, _dump(details)),
         )
 
     await _execute(write)
@@ -229,11 +270,14 @@ async def log_deck_change(
     ts: int | None = None,
 ) -> None:
     ts = ts or _now()
+    sanitized_run_id: str | None = run_id
 
     def write(conn: Any) -> None:
+        nonlocal sanitized_run_id
+        sanitized_run_id = _ensure_run_logged(conn, run_id)
         conn.execute(
             "INSERT INTO deck_changes (run_id, room_id, change_type, card_id, ts, details_json) VALUES (?, ?, ?, ?, ?, ?)",
-            (run_id, room_id, change_type, card_id, ts, _dump(details)),
+            (sanitized_run_id, room_id, change_type, card_id, ts, _dump(details)),
         )
 
     await _execute(write)
@@ -250,16 +294,19 @@ async def log_shop_transaction(
     ts: int | None = None,
 ) -> None:
     ts = ts or _now()
+    sanitized_run_id: str | None = run_id
 
     def write(conn: Any) -> None:
+        nonlocal sanitized_run_id
+        sanitized_run_id = _ensure_run_logged(conn, run_id)
         conn.execute(
             "INSERT INTO shop_transactions (run_id, room_id, item_type, item_id, cost, action, ts) VALUES (?, ?, ?, ?, ?, ?, ?)",
-            (run_id, room_id, item_type, item_id, cost, action, ts),
+            (sanitized_run_id, room_id, item_type, item_id, cost, action, ts),
         )
 
     await _execute(write)
     if item_type == "card" and item_id:
-        await log_deck_change(run_id, room_id, "shop_purchase", item_id, details, ts=ts)
+        await log_deck_change(sanitized_run_id, room_id, "shop_purchase", item_id, details, ts=ts)
 
 
 async def log_event_choice(
@@ -271,11 +318,14 @@ async def log_event_choice(
     ts: int | None = None,
 ) -> None:
     ts = ts or _now()
+    sanitized_run_id: str | None = run_id
 
     def write(conn: Any) -> None:
+        nonlocal sanitized_run_id
+        sanitized_run_id = _ensure_run_logged(conn, run_id)
         conn.execute(
             "INSERT INTO event_choices (run_id, room_id, event_name, choice, outcome_json, ts) VALUES (?, ?, ?, ?, ?, ?)",
-            (run_id, room_id, event_name, choice, _dump(outcome), ts),
+            (sanitized_run_id, room_id, event_name, choice, _dump(outcome), ts),
         )
 
     await _execute(write)
@@ -340,11 +390,14 @@ async def log_achievement_unlock(
     ts: int | None = None,
 ) -> None:
     ts = ts or _now()
+    sanitized_run_id: str | None = run_id
 
     def write(conn: Any) -> None:
+        nonlocal sanitized_run_id
+        sanitized_run_id = _ensure_run_logged(conn, run_id)
         conn.execute(
             "INSERT INTO achievement_unlocks (run_id, achievement_id, ts, details_json) VALUES (?, ?, ?, ?)",
-            (run_id, achievement_id, ts, _dump(details)),
+            (sanitized_run_id, achievement_id, ts, _dump(details)),
         )
 
     await _execute(write)


### PR DESCRIPTION
## Summary
- add a tracking helper to ensure run ids exist before associating telemetry events
- normalize run-aware log writers to fall back to placeholder runs or null associations
- add a regression test covering game actions logged without a run entry

## Testing
- [x] Backend tests (`uv run pytest tests/test_tracking_service.py`)
- [ ] Frontend tests
- [x] Linting (`uv run ruff check tracking/service.py tests/test_tracking_service.py --fix`)
- [ ] Doc sync updates (README and `.codex/implementation` docs; link tasks below)


------
https://chatgpt.com/codex/tasks/task_b_68d0a2ebf4d0832caa25714111b9a5d8