### PR TITLE
fix(light): handle zero max hp allies

### DIFF
--- a/backend/plugins/damage_types/light.py
+++ b/backend/plugins/damage_types/light.py
@@ -31,6 +31,9 @@ class Light(DamageTypeBase):
             await pace_sleep(YIELD_MULTIPLIER)
 
         for ally in allies:
+            if ally.max_hp <= 0:
+                await pace_sleep(YIELD_MULTIPLIER)
+                continue
             if ally.hp > 0 and ally.hp / ally.max_hp < 0.25:
                 await ally.apply_healing(actor.atk, healer=actor)
                 await pace_sleep(YIELD_MULTIPLIER)

--- a/backend/tests/test_light_zero_max_hp.py
+++ b/backend/tests/test_light_zero_max_hp.py
@@ -1,0 +1,17 @@
+import pytest
+
+from autofighter.stats import Stats
+from plugins.damage_types.light import Light
+
+
+@pytest.mark.asyncio
+async def test_light_on_action_skips_zero_max_hp_ally():
+    light = Light()
+    actor = Stats(damage_type=light)
+    ally = Stats()
+    ally.set_base_stat("max_hp", 0)
+    ally.hp = 1
+
+    result = await light.on_action(actor, [actor, ally], [])
+
+    assert result is True


### PR DESCRIPTION
## Summary
- avoid dividing by zero in `Light.on_action` by skipping allies whose max HP is non-positive
- add a regression test that ensures a zero-max-HP ally no longer crashes the action handler

## Testing
- `uv run pytest tests` *(fails: existing SyntaxError in tests/test_event_bus_performance.py and tests/test_spiked_shield.py)*
- `PYTHONPATH=. uv run pytest tests/test_light_hot.py tests/test_light_zero_max_hp.py` *(fails: pre-existing assertion in tests/test_light_hot.py when Stats instances retain full HP after base max changes)*

------
https://chatgpt.com/codex/tasks/task_b_68d13befe838832c844d5f87e2ac87ba