### PR TITLE
fix: auto-clean relic event subscriptions

### DIFF
--- a/backend/plugins/relics/_base.py
+++ b/backend/plugins/relics/_base.py
@@ -83,8 +83,10 @@ class RelicBase:
         from autofighter.stats import BUS
 
         store = self._ensure_subscription_store(party)
-        store.setdefault(self.id, []).append((event, callback))
+        entries = store.setdefault(self.id, [])
+        entries.append((event, callback, False))
         BUS.subscribe(event, callback)
+        self._ensure_cleanup_subscription(party, entries, BUS)
         return callback
 
     def unsubscribe(self, party: Party, event: str, callback: Callable[..., object]) -> None:
@@ -97,16 +99,19 @@ class RelicBase:
         entries = store.get(self.id)
         if not entries:
             return
-        store[self.id] = [pair for pair in entries if pair != (event, callback)]
+        store[self.id] = [pair for pair in entries if pair[:2] != (event, callback)]
         if not store[self.id]:
             store.pop(self.id, None)
 
     def clear_subscriptions(self, party: Party) -> None:
+        from autofighter.stats import BUS
+
         store = getattr(party, "_relic_bus_subscriptions", None)
         if not store:
             return
-        for event, callback in list(store.pop(self.id, [])):
-            self.unsubscribe(party, event, callback)
+        entries = store.pop(self.id, [])
+        for event, callback, _ in entries:
+            BUS.unsubscribe(event, callback)
 
     def _reset_subscriptions(self, party: Party) -> None:
         from autofighter.stats import BUS
@@ -115,13 +120,30 @@ class RelicBase:
         if not store:
             return
         callbacks = store.pop(self.id, [])
-        for event, callback in callbacks:
+        for event, callback, _ in callbacks:
             BUS.unsubscribe(event, callback)
 
     @staticmethod
-    def _ensure_subscription_store(party: Party) -> dict[str, list[tuple[str, Callable[..., object]]]]:
+    def _ensure_subscription_store(
+        party: Party,
+    ) -> dict[str, list[tuple[str, Callable[..., object], bool]]]:
         store = getattr(party, "_relic_bus_subscriptions", None)
         if store is None:
             store = {}
             setattr(party, "_relic_bus_subscriptions", store)
         return store
+
+    def _ensure_cleanup_subscription(
+        self,
+        party: Party,
+        entries: list[tuple[str, Callable[..., object], bool]],
+        bus: object,
+    ) -> None:
+        if any(entry[2] for entry in entries):
+            return
+
+        def _cleanup(*_args: object, **_kwargs: object) -> None:
+            self.clear_subscriptions(party)
+
+        entries.append(("battle_end", _cleanup, True))
+        bus.subscribe("battle_end", _cleanup)


### PR DESCRIPTION
## Summary
- ensure relic event subscriptions register a single battle_end cleanup hook per party
- track relic subscription metadata so cleanup callbacks are removed along with other listeners

## Testing
- uv run ruff check plugins/relics/_base.py
- uv run pytest *(fails: existing suite import errors and async syntax issues outside this change)*

------
https://chatgpt.com/codex/tasks/task_b_68d391afc200832c80d8077772ff9111