### PR TITLE
feat(frontend): modular battle review layout

### DIFF
--- a/frontend/src/lib/systems/battleReview/state.js
+++ b/frontend/src/lib/systems/battleReview/state.js
@@ -318,7 +318,9 @@ export function createBattleReviewState(initialProps = {}) {
     $tabs.find((tab) => tab.id === $active) || $tabs[0]
   );
 
-  const entityMetrics = derived([summary, activeTab], ([$summary, $active]) => computeEntityMetrics($summary, $active));
+  const entityMetrics = derived([summary, currentTab], ([$summary, $current]) =>
+    computeEntityMetrics($summary, $current?.id ?? 'overview')
+  );
   const overviewTotals = derived(summary, ($summary) => aggregateDamageByType($summary));
   const overviewGrand = derived(overviewTotals, ($totals) => Object.values($totals || {}).reduce((acc, cur) => acc + (cur || 0), 0));
 


### PR DESCRIPTION
## Summary
- move battle review data loading and derived metrics into `createBattleReviewState`
- split the review overlay into tabs shell, timeline region, entity metrics panel, and event drawer components
- refresh the implementation notes and add tests covering store shaping and the new shell layout
- ensure battle review reward selections dispatch through the shared context
- derive entity metrics from the currently displayed tab so the stats panel matches the UI fallback

## Testing
- bun test tests/battle-review-architecture.test.js
- bun test tests/battlepolling.test.js *(fails: ReferenceError: shouldHandleRunEndError is not defined)*
- bun test tests/floor-transition.test.js *(fails: TypeError: vi.mock is not a function)*

------
https://chatgpt.com/codex/tasks/task_b_68d563998ef4832ca2200721618b729a