### PR TITLE
refactor: wrap battle review chip around fighter card

### DIFF
--- a/frontend/.codex/implementation/battle-review-ui.md
+++ b/frontend/.codex/implementation/battle-review-ui.md
@@ -6,7 +6,7 @@ The Battle Review overlay is now organized around a timeline-first layout backed
 
 - **State management** lives in `frontend/src/lib/systems/battleReview/state.js`. The exported `createBattleReviewState` helper fetches summaries and events, tracks loading status, derives overview metrics, and exposes the active tab/timeline data. Components access the state via the shared `BATTLE_REVIEW_CONTEXT_KEY` context.
 - **`BattleReview.svelte`** sets up the state and renders the high-level header. It also owns the event-log toggle and pushes the state object into context for child components.
-- **`TabsShell.svelte`** renders the metric tabs and composes the grid for the timeline viewport and per-entity metrics panel.
+- **`TabsShell.svelte`** renders the metric tabs and composes the grid for the timeline viewport and per-entity metrics panel. The tab chips use `BattleReviewFighterChip.svelte`, which wraps the modern `BattleFighterCard` portrait so the battle review can share the same glow, motion, and cycling behaviors without maintaining a separate clone.
 - **`TimelineRegion.svelte`** visualizes the most recent combat events in a scrolling list. It consumes the derived `timeline` store so it can update reactively once events finish streaming from the backend.
 - **`EntityTableContainer.svelte`** handles both the overview aggregate presentation and the entity-specific breakdowns. It renders a stats side panel in addition to the central metrics tables to keep the new "side panel" design consistent with the timeline-first layout.
 - **`EventsDrawer.svelte`** shows the raw event log when toggled. It subscribes to `eventsOpen` and lazily loads events when the drawer opens.

--- a/frontend/src/lib/components/battle-review/BattleReviewFighterChip.svelte
+++ b/frontend/src/lib/components/battle-review/BattleReviewFighterChip.svelte
@@ -1,0 +1,79 @@
+<script>
+  import BattleFighterCard from '../../battle/BattleFighterCard.svelte';
+
+  const SIZE_MAP = {
+    chip: 72,
+    small: 56,
+    medium: 96
+  };
+
+  export let fighter = {};
+  export let rankTag = null;
+  export let reducedMotion = false;
+  export let highlight = false;
+  export let size = 'chip';
+  export let sizePx = 0;
+  export let position = 'top';
+
+  $: portraitSize = Number(sizePx) > 0 ? Number(sizePx) : SIZE_MAP[size] || SIZE_MAP.chip;
+  $: decoratedFighter = rankTag != null ? { ...fighter, rank: rankTag } : fighter || {};
+</script>
+
+<div class="review-fighter-chip" style={`--portrait-size: ${portraitSize}px;`}>
+  <BattleFighterCard
+    fighter={decoratedFighter}
+    position={position}
+    reducedMotion={reducedMotion}
+    highlight={highlight}
+    size="small"
+    sizePx={portraitSize}
+  />
+</div>
+
+<style>
+  .review-fighter-chip {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: var(--portrait-size);
+    height: var(--portrait-size);
+  }
+
+  .review-fighter-chip :global(.modern-fighter-card) {
+    width: var(--portrait-size);
+    height: var(--portrait-size);
+    min-width: var(--portrait-size);
+    min-height: var(--portrait-size);
+  }
+
+  .review-fighter-chip :global(.fighter-portrait) {
+    border-radius: 50%;
+    box-shadow: none;
+  }
+
+  .review-fighter-chip :global(.overlay-ui),
+  .review-fighter-chip :global(.name-chip) {
+    display: none !important;
+  }
+
+  .review-fighter-chip :global(.fighter-portrait::after) {
+    display: none;
+  }
+
+  .review-fighter-chip :global(.fighter-portrait .element-effect) {
+    filter: blur(0.75px);
+  }
+
+  .review-fighter-chip :global(.fighter-portrait .ult-glow),
+  .review-fighter-chip :global(.fighter-portrait .ult-pulse) {
+    opacity: 0.55;
+  }
+
+  .review-fighter-chip :global(.fighter-portrait .ult-gauge) {
+    display: none;
+  }
+
+  .review-fighter-chip :global(.fighter-portrait .passive-indicators) {
+    display: none;
+  }
+</style>

--- a/frontend/src/lib/components/battle-review/TabsShell.svelte
+++ b/frontend/src/lib/components/battle-review/TabsShell.svelte
@@ -1,7 +1,7 @@
 <script>
   import { getContext } from 'svelte';
   import { Swords, User } from 'lucide-svelte';
-  import LegacyFighterPortrait from '../battle/LegacyFighterPortrait.svelte';
+  import BattleReviewFighterChip from './BattleReviewFighterChip.svelte';
   import TimelineRegion from './TimelineRegion.svelte';
   import EntityTableContainer from './EntityTableContainer.svelte';
   import { BATTLE_REVIEW_CONTEXT_KEY } from '../../systems/battleReview/state.js';
@@ -28,10 +28,13 @@
           <Swords size={18} />
         {:else if tab.entity}
           <div class="portrait-chip">
-            <LegacyFighterPortrait
+            <BattleReviewFighterChip
               fighter={tab.entity}
               rankTag={tab.rank ?? tab.entity.rank}
               reducedMotion={$reducedMotion}
+              highlight={$activeTab === tab.id}
+              position={tab.type === 'foe' ? 'top' : 'bottom'}
+              sizePx={44}
             />
           </div>
         {:else}
@@ -98,9 +101,10 @@
     justify-content: center;
   }
 
-  .portrait-chip :global(.portrait-wrap) {
-    border-radius: 8px;
-    overflow: hidden;
+  .portrait-chip :global(.review-fighter-chip) {
+    --portrait-size: var(--portrait-size);
+    width: var(--portrait-size);
+    height: var(--portrait-size);
   }
 
   .tab-label {

--- a/frontend/src/lib/components/battle-review/utils.js
+++ b/frontend/src/lib/components/battle-review/utils.js
@@ -14,7 +14,7 @@ export const effectTooltips = {
 export function fmt(n) {
   try {
     return Number(n).toLocaleString();
-  } catch (err) {
+  } catch {
     return String(n ?? 0);
   }
 }

--- a/frontend/src/lib/systems/battleReview/state.js
+++ b/frontend/src/lib/systems/battleReview/state.js
@@ -286,7 +286,7 @@ export function createBattleReviewState(initialProps = {}) {
       const data = await getBattleEvents(battleIndex);
       events.set(Array.isArray(data) ? data : []);
       eventsStatus.set('ready');
-    } catch (err) {
+    } catch {
       eventsStatus.set('error');
     }
   }


### PR DESCRIPTION
## Summary
- replace the bespoke battle review portrait implementation with a thin wrapper around BattleFighterCard so both views share motion and glow logic
- pass entity position through tab chips and update styling to hide battle-only overlays while keeping the modern portrait presentation
- refresh the battle review implementation notes to mention the shared BattleFighterCard wrapper

## Testing
- bun run lint

------
https://chatgpt.com/codex/tasks/task_b_68d567ea39dc832caa6bddedab4fa759