### PR TITLE
feat: align battle review overlay with stained glass theme

### DIFF
--- a/frontend/src/lib/components/BattleReview.svelte
+++ b/frontend/src/lib/components/BattleReview.svelte
@@ -6,8 +6,9 @@
     createBattleReviewState
   } from '../systems/battleReview/state.js';
   import { buildBattleReviewLink } from '../systems/battleReview/urlState.js';
-  import TabsShell from './battle-review/TabsShell.svelte';
-  import EventsDrawer from './battle-review/EventsDrawer.svelte';
+import TabsShell from './battle-review/TabsShell.svelte';
+import EventsDrawer from './battle-review/EventsDrawer.svelte';
+import MenuPanel from './MenuPanel.svelte';
 
   export let runId = '';
   export let battleIndex = 0;
@@ -152,48 +153,50 @@
 
 <svelte:options accessors={true} />
 
-<div class="battle-review-layout">
-  <header class="review-header">
-    <div class="header-metric">Result: {$resultSummary.result}</div>
-    <div class="header-metric">
-      Duration: {$resultSummary.duration != null ? `${$resultSummary.duration}s` : '—'}
-    </div>
-    <div class="header-metric">Events: {fmt($resultSummary.eventCount)}</div>
-    <div class="header-metric">Criticals: {fmt($summary?.critical_hits ? Object.values($summary.critical_hits).reduce((a, b) => a + b, 0) : 0)}</div>
-    <span class="spacer"></span>
-    <button
-      class="events-toggle"
-      class:busy={$eventsStatus === 'loading'}
-      on:click={toggleEvents}
-      type="button"
-    >
-      {$eventsOpen ? 'Hide' : 'Show'} Event Log
-    </button>
-    <button
-      class="copy-link"
-      type="button"
-      on:click={copyLogsLink}
-      aria-live="polite"
-    >
-      {#if copyState === 'copied'}
-        Link copied!
-      {:else if copyState === 'error'}
-        Copy failed
-      {:else}
-        Copy Logs Link
-      {/if}
-    </button>
-  </header>
+<MenuPanel class="battle-review-panel" padding="1.25rem" {reducedMotion}>
+  <div class="battle-review-layout">
+    <header class="review-header">
+      <div class="header-metric">Result: {$resultSummary.result}</div>
+      <div class="header-metric">
+        Duration: {$resultSummary.duration != null ? `${$resultSummary.duration}s` : '—'}
+      </div>
+      <div class="header-metric">Events: {fmt($resultSummary.eventCount)}</div>
+      <div class="header-metric">Criticals: {fmt($summary?.critical_hits ? Object.values($summary.critical_hits).reduce((a, b) => a + b, 0) : 0)}</div>
+      <span class="spacer"></span>
+      <button
+        class="events-toggle"
+        class:busy={$eventsStatus === 'loading'}
+        on:click={toggleEvents}
+        type="button"
+      >
+        {$eventsOpen ? 'Hide' : 'Show'} Event Log
+      </button>
+      <button
+        class="copy-link"
+        type="button"
+        on:click={copyLogsLink}
+        aria-live="polite"
+      >
+        {#if copyState === 'copied'}
+          Link copied!
+        {:else if copyState === 'error'}
+          Copy failed
+        {:else}
+          Copy Logs Link
+        {/if}
+      </button>
+    </header>
 
-  <TabsShell />
-  <EventsDrawer />
-</div>
+    <TabsShell />
+    <EventsDrawer />
+  </div>
+</MenuPanel>
 
 <style>
   .battle-review-layout {
     display: flex;
     flex-direction: column;
-    gap: 1rem;
+    gap: 1.25rem;
     width: 100%;
     max-width: 100%;
     box-sizing: border-box;
@@ -206,34 +209,44 @@
     flex-wrap: wrap;
     font-size: 0.85rem;
     color: #f1f5f9;
+    padding: 0.75rem 0.9rem;
+    background: linear-gradient(0deg, rgba(255, 255, 255, 0.05), rgba(255, 255, 255, 0.05)), var(--glass-bg);
+    box-shadow: var(--glass-shadow);
+    border: var(--glass-border);
+    backdrop-filter: var(--glass-filter);
+    border-radius: 0;
   }
 
   .header-metric {
-    padding: 0.25rem 0.5rem;
-    background: rgba(255, 255, 255, 0.08);
-    border-radius: 4px;
-    border: 1px solid rgba(255, 255, 255, 0.12);
+    padding: 0.3rem 0.65rem;
+    background: color-mix(in oklab, rgba(148, 163, 184, 0.4) 32%, transparent 68%);
+    border: 1px solid rgba(148, 163, 184, 0.45);
+    border-radius: 0;
+    box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.45);
   }
 
   .spacer {
     flex: 1;
   }
 
-  .events-toggle {
+  .events-toggle,
+  .copy-link {
     appearance: none;
-    border: 1px solid rgba(148, 163, 184, 0.6);
-    background: rgba(15, 23, 42, 0.9);
+    border: 1px solid rgba(148, 163, 184, 0.55);
+    background: color-mix(in oklab, var(--glass-bg) 80%, rgba(148, 163, 184, 0.35) 20%);
     color: #e2e8f0;
     font-size: 0.78rem;
-    padding: 0.35rem 0.75rem;
-    border-radius: 4px;
+    padding: 0.4rem 0.85rem;
+    border-radius: 0;
     cursor: pointer;
-    transition: background 0.2s ease, color 0.2s ease;
+    transition: background 0.18s ease, color 0.18s ease, border-color 0.18s ease;
   }
 
-  .events-toggle:hover {
-    background: rgba(51, 65, 85, 0.8);
-    color: #f8fafc;
+  .events-toggle:hover,
+  .copy-link:hover {
+    background: color-mix(in oklab, rgba(56, 189, 248, 0.22) 45%, var(--glass-bg) 55%);
+    border-color: rgba(125, 211, 252, 0.65);
+    color: #f0f9ff;
   }
 
   .events-toggle.busy {
@@ -242,23 +255,11 @@
   }
 
   .copy-link {
-    appearance: none;
-    border: 1px solid rgba(148, 163, 184, 0.6);
-    background: rgba(30, 41, 59, 0.95);
     color: #bae6fd;
-    font-size: 0.78rem;
-    padding: 0.35rem 0.85rem;
-    border-radius: 4px;
-    cursor: pointer;
-    transition: background 0.2s ease, color 0.2s ease;
   }
 
-  .copy-link:hover {
-    background: rgba(56, 189, 248, 0.2);
-    color: #f0f9ff;
-  }
-
-  .copy-link:focus-visible {
+  .copy-link:focus-visible,
+  .events-toggle:focus-visible {
     outline: 2px solid rgba(125, 211, 252, 0.9);
     outline-offset: 2px;
   }

--- a/frontend/src/lib/components/battle-review/BattleReviewFighterChip.svelte
+++ b/frontend/src/lib/components/battle-review/BattleReviewFighterChip.svelte
@@ -46,11 +46,6 @@
     min-height: var(--portrait-size);
   }
 
-  .review-fighter-chip :global(.fighter-portrait) {
-    border-radius: 50%;
-    box-shadow: none;
-  }
-
   .review-fighter-chip :global(.overlay-ui),
   .review-fighter-chip :global(.name-chip) {
     display: none !important;

--- a/frontend/src/lib/components/battle-review/EntityDetailPanel.svelte
+++ b/frontend/src/lib/components/battle-review/EntityDetailPanel.svelte
@@ -71,10 +71,12 @@
     display: flex;
     flex-direction: column;
     gap: 1rem;
-    background: rgba(15, 23, 42, 0.35);
-    border-radius: 12px;
+    background: linear-gradient(0deg, rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0.04)), var(--glass-bg);
+    border: var(--glass-border);
+    box-shadow: var(--glass-shadow);
+    backdrop-filter: var(--glass-filter);
+    border-radius: 0;
     padding: 1rem;
-    border: 1px solid rgba(148, 163, 184, 0.2);
   }
 
   .entity-header {
@@ -135,13 +137,13 @@
     position: relative;
     height: 16px;
     background: rgba(255, 255, 255, 0.08);
-    border-radius: 4px;
+    border-radius: 0;
     overflow: hidden;
   }
 
   .damage-bar-fill {
     height: 100%;
-    border-radius: 4px;
+    border-radius: 0;
     transition: width 0.3s ease;
   }
 
@@ -174,9 +176,9 @@
     display: flex;
     justify-content: space-between;
     padding: 0.5rem;
-    background: rgba(255, 255, 255, 0.05);
-    border-radius: 6px;
-    border: 1px solid rgba(255, 255, 255, 0.08);
+    background: color-mix(in oklab, rgba(255, 255, 255, 0.08) 45%, var(--glass-bg) 55%);
+    border-radius: 0;
+    border: 1px solid rgba(148, 163, 184, 0.28);
     font-size: 0.78rem;
   }
 </style>

--- a/frontend/src/lib/components/battle-review/EventsDrawer.svelte
+++ b/frontend/src/lib/components/battle-review/EventsDrawer.svelte
@@ -47,9 +47,11 @@
 
 <style>
   .events-drawer {
-    background: rgba(15, 23, 42, 0.7);
-    border-radius: 12px;
-    border: 1px solid rgba(148, 163, 184, 0.3);
+    background: linear-gradient(0deg, rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0.04)), var(--glass-bg);
+    border: var(--glass-border);
+    box-shadow: var(--glass-shadow);
+    backdrop-filter: var(--glass-filter);
+    border-radius: 0;
     padding: 1rem;
     display: flex;
     flex-direction: column;
@@ -72,17 +74,26 @@
   .close-btn {
     margin-left: auto;
     appearance: none;
-    border: 1px solid rgba(248, 250, 252, 0.35);
-    background: rgba(15, 23, 42, 0.8);
+    border: 1px solid rgba(148, 163, 184, 0.55);
+    background: color-mix(in oklab, var(--glass-bg) 82%, rgba(148, 163, 184, 0.35) 18%);
     color: #f8fafc;
     font-size: 0.75rem;
-    padding: 0.2rem 0.6rem;
-    border-radius: 4px;
+    padding: 0.25rem 0.7rem;
+    border-radius: 0;
     cursor: pointer;
+    transition: background 0.18s ease, border-color 0.18s ease, color 0.18s ease;
   }
 
-  .close-btn:hover {
-    background: rgba(59, 130, 246, 0.25);
+  .close-btn:hover,
+  .close-btn:focus-visible {
+    background: color-mix(in oklab, rgba(56, 189, 248, 0.22) 45%, var(--glass-bg) 55%);
+    border-color: rgba(125, 211, 252, 0.6);
+    color: #e0f2fe;
+  }
+
+  .close-btn:focus-visible {
+    outline: 2px solid rgba(125, 211, 252, 0.75);
+    outline-offset: 2px;
   }
 
   .drawer-body {
@@ -112,6 +123,10 @@
     gap: 0.5rem;
     font-size: 0.76rem;
     color: rgba(226, 232, 240, 0.9);
+    padding: 0.35rem 0.4rem;
+    background: color-mix(in oklab, rgba(15, 23, 42, 0.75) 75%, transparent 25%);
+    border: 1px solid rgba(148, 163, 184, 0.18);
+    border-radius: 0;
   }
 
   .event-type {

--- a/frontend/src/lib/components/battle-review/TabsShell.svelte
+++ b/frontend/src/lib/components/battle-review/TabsShell.svelte
@@ -56,10 +56,12 @@
     display: flex;
     flex-direction: column;
     gap: 1rem;
-    background: rgba(15, 23, 42, 0.45);
-    border-radius: 12px;
     padding: 1rem;
-    border: 1px solid rgba(148, 163, 184, 0.2);
+    background: linear-gradient(0deg, rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0.04)), var(--glass-bg);
+    border: var(--glass-border);
+    box-shadow: var(--glass-shadow);
+    backdrop-filter: var(--glass-filter);
+    border-radius: 0;
   }
 
   .metric-tabs {
@@ -73,25 +75,33 @@
     display: inline-flex;
     align-items: center;
     gap: 0.5rem;
-    padding: 0.45rem 0.75rem;
-    border-radius: 999px;
-    border: 1px solid rgba(148, 163, 184, 0.4);
-    background: rgba(15, 23, 42, 0.7);
+    padding: 0.45rem 0.85rem;
+    border-radius: 0;
+    border: 1px solid rgba(148, 163, 184, 0.45);
+    background: color-mix(in oklab, var(--glass-bg) 82%, rgba(148, 163, 184, 0.35) 18%);
     color: #cbd5f5;
     cursor: pointer;
     font-size: 0.82rem;
-    transition: transform 0.2s ease, background 0.2s ease, border-color 0.2s ease;
+    transition: background 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease, color 0.2s ease;
   }
 
   .tab-chip:hover,
-  .tab-chip.active {
-    background: rgba(56, 189, 248, 0.18);
+  .tab-chip:focus-visible {
+    background: color-mix(in oklab, rgba(56, 189, 248, 0.22) 45%, var(--glass-bg) 55%);
     border-color: rgba(125, 211, 252, 0.65);
     color: #e0f2fe;
   }
 
+  .tab-chip:focus-visible {
+    outline: 2px solid rgba(125, 211, 252, 0.75);
+    outline-offset: 2px;
+  }
+
   .tab-chip.active {
-    transform: translateY(-2px);
+    background: color-mix(in oklab, rgba(56, 189, 248, 0.3) 55%, var(--glass-bg) 45%);
+    border-color: rgba(125, 211, 252, 0.75);
+    box-shadow: 0 0 0 1px rgba(56, 189, 248, 0.35);
+    color: #e0f2fe;
   }
 
   .portrait-chip {


### PR DESCRIPTION
## Summary
- wrap the battle review overlay with `MenuPanel` so its header, buttons, and controls inherit the stained-glass styling and squared edges
- restyle the tabs shell, events drawer, and entity detail panel to use square stained-glass panels and button treatments that match other overlays
- remove the circular portrait override from the fighter chips so review portraits keep the standard square card frame

## Testing
- [ ] Backend tests
- [x] Frontend tests (`bun test`) *(fails: existing suite issues — element persistence, missing card assets, legacy component expectations, and polling mocks)*
- [ ] Linting
- [ ] Doc sync updates (README and `.codex/implementation` docs; link tasks below)


------
https://chatgpt.com/codex/tasks/task_b_68d5c111c118832cac6b03896ed32d51