### PR TITLE
Inline asset registry globs for Vite compatibility

### DIFF
--- a/frontend/src/lib/systems/assetRegistry.js
+++ b/frontend/src/lib/systems/assetRegistry.js
@@ -18,15 +18,17 @@ const normalizeAssetUrl = src => {
   return new URL(src, import.meta.url).href;
 };
 
-const globOrEmpty = (pattern, options) => {
-  try {
-    if (typeof import.meta?.glob === 'function') {
-      return import.meta.glob(pattern, options);
-    }
-    if (typeof globalThis.__assetRegistryGlob === 'function') {
-      return globalThis.__assetRegistryGlob(pattern, options) || {};
-    }
-  } catch {}
+const globOrEmpty = (factory, fallbackFactory) => {
+  if (typeof import.meta?.glob === 'function') {
+    try {
+      return factory();
+    } catch {}
+  }
+  if (typeof globalThis.__assetRegistryGlob === 'function' && typeof fallbackFactory === 'function') {
+    try {
+      return fallbackFactory(globalThis.__assetRegistryGlob) || {};
+    } catch {}
+  }
   return {};
 };
 
@@ -36,92 +38,189 @@ const createModuleMap = modules =>
   );
 
 const characterModules = createModuleMap(
-  globOrEmpty('../assets/characters/**/*.png', {
-    eager: true,
-    import: 'default',
-    query: '?url'
-  })
+  globOrEmpty(
+    () =>
+      import.meta.glob('../assets/characters/**/*.png', {
+        eager: true,
+        import: 'default',
+        query: '?url'
+      }),
+    glob =>
+      glob('../assets/characters/**/*.png', {
+        eager: true,
+        import: 'default',
+        query: '?url'
+      })
+  )
 );
 
 const fallbackModules = createModuleMap(
-  globOrEmpty('../assets/characters/fallbacks/*.png', {
-    eager: true,
-    import: 'default',
-    query: '?url'
-  })
+  globOrEmpty(
+    () =>
+      import.meta.glob('../assets/characters/fallbacks/*.png', {
+        eager: true,
+        import: 'default',
+        query: '?url'
+      }),
+    glob =>
+      glob('../assets/characters/fallbacks/*.png', {
+        eager: true,
+        import: 'default',
+        query: '?url'
+      })
+  )
 );
 
 const backgroundModules = createModuleMap(
-  globOrEmpty('../assets/backgrounds/*.png', {
-    eager: true,
-    import: 'default',
-    query: '?url'
-  })
+  globOrEmpty(
+    () =>
+      import.meta.glob('../assets/backgrounds/*.png', {
+        eager: true,
+        import: 'default',
+        query: '?url'
+      }),
+    glob =>
+      glob('../assets/backgrounds/*.png', {
+        eager: true,
+        import: 'default',
+        query: '?url'
+      })
+  )
 );
 
 const summonModules = createModuleMap(
-  globOrEmpty('../assets/summons/**/*.png', {
-    eager: true,
-    import: 'default',
-    query: '?url'
-  })
+  globOrEmpty(
+    () =>
+      import.meta.glob('../assets/summons/**/*.png', {
+        eager: true,
+        import: 'default',
+        query: '?url'
+      }),
+    glob =>
+      glob('../assets/summons/**/*.png', {
+        eager: true,
+        import: 'default',
+        query: '?url'
+      })
+  )
 );
 
 const cardArtModules = createModuleMap(
-  globOrEmpty('../assets/cards/*/*.png', {
-    eager: true,
-    import: 'default',
-    query: '?url'
-  })
+  globOrEmpty(
+    () =>
+      import.meta.glob('../assets/cards/*/*.png', {
+        eager: true,
+        import: 'default',
+        query: '?url'
+      }),
+    glob =>
+      glob('../assets/cards/*/*.png', {
+        eager: true,
+        import: 'default',
+        query: '?url'
+      })
+  )
 );
 
 const relicArtModules = createModuleMap(
-  globOrEmpty('../assets/relics/*/*.png', {
-    eager: true,
-    import: 'default',
-    query: '?url'
-  })
+  globOrEmpty(
+    () =>
+      import.meta.glob('../assets/relics/*/*.png', {
+        eager: true,
+        import: 'default',
+        query: '?url'
+      }),
+    glob =>
+      glob('../assets/relics/*/*.png', {
+        eager: true,
+        import: 'default',
+        query: '?url'
+      })
+  )
 );
 
 const materialIconModules = createModuleMap(
-  globOrEmpty('../assets/items/*/*.png', {
-    eager: true,
-    import: 'default',
-    query: '?url'
-  })
+  globOrEmpty(
+    () =>
+      import.meta.glob('../assets/items/*/*.png', {
+        eager: true,
+        import: 'default',
+        query: '?url'
+      }),
+    glob =>
+      glob('../assets/items/*/*.png', {
+        eager: true,
+        import: 'default',
+        query: '?url'
+      })
+  )
 );
 
 const cardGlyphModules = createModuleMap(
-  globOrEmpty('../assets/cards/Art/*.png', {
-    eager: true,
-    import: 'default',
-    query: '?url'
-  })
+  globOrEmpty(
+    () =>
+      import.meta.glob('../assets/cards/Art/*.png', {
+        eager: true,
+        import: 'default',
+        query: '?url'
+      }),
+    glob =>
+      glob('../assets/cards/Art/*.png', {
+        eager: true,
+        import: 'default',
+        query: '?url'
+      })
+  )
 );
 
 const relicGlyphModules = createModuleMap(
-  globOrEmpty('../assets/relics/Art/*.png', {
-    eager: true,
-    import: 'default',
-    query: '?url'
-  })
+  globOrEmpty(
+    () =>
+      import.meta.glob('../assets/relics/Art/*.png', {
+        eager: true,
+        import: 'default',
+        query: '?url'
+      }),
+    glob =>
+      glob('../assets/relics/Art/*.png', {
+        eager: true,
+        import: 'default',
+        query: '?url'
+      })
+  )
 );
 
 const musicModules = Object.entries(
-  globOrEmpty('../assets/music/**/*.{mp3,ogg,wav}', {
-    eager: true,
-    as: 'url'
-  })
+  globOrEmpty(
+    () =>
+      import.meta.glob('../assets/music/**/*.{mp3,ogg,wav}', {
+        eager: true,
+        as: 'url'
+      }),
+    glob =>
+      glob('../assets/music/**/*.{mp3,ogg,wav}', {
+        eager: true,
+        as: 'url'
+      })
+  )
 ).reduce((acc, [path, url]) => {
   acc[path] = normalizeAssetUrl(url);
   return acc;
 }, {});
 
 const sfxModules = Object.entries(
-  globOrEmpty('../assets/sfx/**/*.{mp3,ogg,wav}', {
-    eager: true,
-    as: 'url'
-  })
+  globOrEmpty(
+    () =>
+      import.meta.glob('../assets/sfx/**/*.{mp3,ogg,wav}', {
+        eager: true,
+        as: 'url'
+      }),
+    glob =>
+      glob('../assets/sfx/**/*.{mp3,ogg,wav}', {
+        eager: true,
+        as: 'url'
+      })
+  )
 ).reduce((acc, [path, url]) => {
   acc[path] = normalizeAssetUrl(url);
   return acc;


### PR DESCRIPTION
## Summary
- inline each assetRegistry import.meta.glob call with a literal path while retaining the non-Vite fallback
- refactor globOrEmpty to take factories that execute the literal glob and the fallback implementation

## Testing
- VITE_API_BASE=http://localhost bun run build

------
https://chatgpt.com/codex/tasks/task_b_68d60f330bf0832c95cda682b41df66d