### PR TITLE
Fix asset glob fallback after Vite transform

### DIFF
--- a/frontend/src/lib/systems/assetRegistry.js
+++ b/frontend/src/lib/systems/assetRegistry.js
@@ -19,7 +19,7 @@ const normalizeAssetUrl = src => {
 };
 
 const globOrEmpty = (factory, fallbackFactory) => {
-  if (typeof import.meta?.glob === 'function') {
+  if (typeof factory === 'function') {
     try {
       return factory();
     } catch {}


### PR DESCRIPTION
## Summary
- ensure the asset glob factory executes even when Vite removes import.meta.glob

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d61158f628832ca526a3e34d90bdc6