### PR TITLE
Limit character exports to playable classes

### DIFF
--- a/backend/plugins/characters/__init__.py
+++ b/backend/plugins/characters/__init__.py
@@ -76,11 +76,8 @@ for _character in _CHARACTER_EXPORTS:
     globals()[foe_cls.__name__] = foe_cls
 
 
-__all__ = [
-    "ADJ_CLASSES",
-    "CHARACTER_FOES",
-    "FoeBase",
-    "PlayerBase",
-] + [cls.__name__ for cls in _CHARACTER_EXPORTS] + [
-    foe_cls.__name__ for foe_cls in CHARACTER_FOES.values()
-]
+_PLAYABLE_EXPORTS = tuple(cls.__name__ for cls in _CHARACTER_EXPORTS)
+_FOE_EXPORTS = tuple(foe_cls.__name__ for foe_cls in CHARACTER_FOES.values())
+
+
+__all__ = list(_PLAYABLE_EXPORTS + _FOE_EXPORTS)


### PR DESCRIPTION
## Summary
- restrict `plugins.characters.__all__` to exported character and foe classes so iteration remains callable-safe

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68d6b8752db4832ca8ee33edf3996c1d