### PR TITLE
feat(ui): allow updating run party via UI action

### DIFF
--- a/backend/.codex/implementation/party-picker-endpoint.md
+++ b/backend/.codex/implementation/party-picker-endpoint.md
@@ -3,5 +3,8 @@
 `POST /run/start` accepts a JSON payload with a `party` array of 1–5 owned character IDs (including `player`) and an optional `damage_type` for the player chosen from Light, Dark, Wind, Lightning, Fire, or Ice.
 The backend validates the roster, persists the player's damage type, seeds a new map, and returns the run ID, map data, and passive names for each party member.
 
+`POST /ui/action` also exposes an `update_party` action for updating an existing run's roster. The request body should include `{"action": "update_party", "params": {"party": [...]}}` (optionally provide `run_id` inside `params` to target a specific run). The validation rules match `start_run`: the roster must include the `player`, contain 1–5 unique members, exclude `mimic`, and only include characters present in `owned_players`. Successful calls persist the new roster in the `runs` table and return the updated party payload.
+
 ## Testing
 - `uv run pytest backend/tests/test_party_endpoint.py`
+- `uv run pytest backend/tests/test_ui_party_update.py`

--- a/backend/services/run_service.py
+++ b/backend/services/run_service.py
@@ -20,6 +20,10 @@ from runs.party_manager import _assign_damage_type
 from runs.party_manager import _describe_passives
 from runs.party_manager import _load_player_customization
 from runs.party_manager import load_party
+from tracking import log_game_action
+from tracking import log_menu_action
+from tracking import log_play_session_start
+from tracking import log_run_start
 
 from autofighter.mapgen import MapGenerator
 from autofighter.party import Party
@@ -29,24 +33,10 @@ from plugins import characters as player_plugins
 from services.login_reward_service import record_room_completion
 from services.user_level_service import get_user_level
 
-from tracking import (
-    log_game_action,
-    log_menu_action,
-    log_play_session_start,
-    log_run_start,
-)
-
 log = logging.getLogger(__name__)
 
 
-async def start_run(
-    members: list[str],
-    damage_type: str = "",
-    pressure: int = 0,
-) -> dict[str, object]:
-    """Create a new run and return its initial state."""
-    damage_type = (damage_type or "").capitalize()
-
+async def _validate_party_members(members: list[str]) -> None:
     if (
         "player" not in members
         or not 1 <= len(members) <= 5
@@ -65,6 +55,17 @@ async def start_run(
             raise ValueError("invalid party")
         if mid != "player" and mid not in owned:
             raise ValueError("unowned character")
+
+
+async def start_run(
+    members: list[str],
+    damage_type: str = "",
+    pressure: int = 0,
+) -> dict[str, object]:
+    """Create a new run and return its initial state."""
+    damage_type = (damage_type or "").capitalize()
+
+    await _validate_party_members(members)
 
     if damage_type:
         allowed = {"Light", "Dark", "Wind", "Lightning", "Fire", "Ice"}
@@ -210,6 +211,54 @@ async def start_run(
         },
     )
     return {"run_id": run_id, "map": state, "party": party_info}
+
+
+async def update_party(run_id: str, members: list[str]) -> dict[str, object]:
+    """Update an existing run's party roster after validating membership."""
+
+    await _validate_party_members(members)
+
+    def update_roster() -> dict[str, object]:
+        with get_save_manager().connection() as conn:
+            cur = conn.execute("SELECT party FROM runs WHERE id = ?", (run_id,))
+            row = cur.fetchone()
+            if not row:
+                raise LookupError("run not found")
+
+            party_blob = json.loads(row[0]) if row[0] else {}
+            snapshot = party_blob.get("player", {})
+            exp_source = party_blob.get("exp", {})
+            level_source = party_blob.get("level", {})
+            multiplier_source = party_blob.get("exp_multiplier", {})
+
+            exp = {mid: exp_source.get(mid, 0) for mid in members}
+            level = {mid: level_source.get(mid, 1) for mid in members}
+            exp_multiplier = {mid: multiplier_source.get(mid, 1.0) for mid in members}
+
+            party_blob.update(
+                {
+                    "members": members,
+                    "exp": exp,
+                    "level": level,
+                    "exp_multiplier": exp_multiplier,
+                    "player": snapshot,
+                }
+            )
+
+            conn.execute(
+                "UPDATE runs SET party = ? WHERE id = ?",
+                (json.dumps(party_blob), run_id),
+            )
+
+            return party_blob
+
+    updated = await asyncio.to_thread(update_roster)
+    await log_menu_action(
+        "Run",
+        "party_updated",
+        {"run_id": run_id, "members": members},
+    )
+    return updated
 
 
 async def get_map(run_id: str) -> dict[str, object]:

--- a/backend/tests/test_ui_party_update.py
+++ b/backend/tests/test_ui_party_update.py
@@ -1,0 +1,110 @@
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import importlib
+import json
+
+import pytest
+from quart import Quart
+import sqlcipher3
+
+importlib.invalidate_caches()
+sys.modules.pop("services", None)
+sys.modules.pop("tracking", None)
+sys.modules.pop("battle_logging", None)
+sys.modules.pop("battle_logging.writers", None)
+from routes.ui import bp as ui_bp
+
+
+@pytest.fixture()
+def app_with_db(tmp_path, monkeypatch):
+    db_path = tmp_path / "save.db"
+    monkeypatch.setenv("AF_DB_PATH", str(db_path))
+    monkeypatch.setenv("AF_DB_KEY", "testkey")
+    monkeypatch.setenv("UV_EXTRA", "test")
+
+    app = Quart(__name__)
+    app.register_blueprint(ui_bp)
+    app.testing = True
+    return app, db_path
+
+
+@pytest.mark.asyncio
+async def test_update_party_success(app_with_db):
+    app, db_path = app_with_db
+    client = app.test_client()
+
+    start_resp = await client.post("/run/start", json={"party": ["player"]})
+    assert start_resp.status_code == 200
+
+    conn = sqlcipher3.connect(db_path)
+    conn.execute("PRAGMA key = 'testkey'")
+    conn.execute("CREATE TABLE IF NOT EXISTS owned_players (id TEXT PRIMARY KEY)")
+    conn.execute("INSERT OR IGNORE INTO owned_players (id) VALUES (?)", ("ally",))
+    conn.commit()
+
+    resp = await client.post(
+        "/ui/action",
+        json={"action": "update_party", "params": {"party": ["player", "ally"]}},
+    )
+    assert resp.status_code == 200
+    data = await resp.get_json()
+    assert data["party"]["members"] == ["player", "ally"]
+
+    cur = conn.execute("SELECT party FROM runs")
+    row = cur.fetchone()
+    assert row is not None
+    party_state = json.loads(row[0])
+    assert party_state["members"] == ["player", "ally"]
+    assert set(party_state["exp"]) == {"player", "ally"}
+    assert set(party_state["level"]) == {"player", "ally"}
+
+
+@pytest.mark.asyncio
+async def test_update_party_missing_run(app_with_db):
+    app, _ = app_with_db
+    client = app.test_client()
+
+    resp = await client.post(
+        "/ui/action",
+        json={
+            "action": "update_party",
+            "params": {"run_id": "missing", "party": ["player"]},
+        },
+    )
+    assert resp.status_code == 404
+    data = await resp.get_json()
+    assert data["error"] == "Run not found"
+
+
+@pytest.mark.asyncio
+async def test_update_party_invalid_members(app_with_db):
+    app, _ = app_with_db
+    client = app.test_client()
+
+    start_resp = await client.post("/run/start", json={"party": ["player"]})
+    assert start_resp.status_code == 200
+
+    duplicate_resp = await client.post(
+        "/ui/action",
+        json={
+            "action": "update_party",
+            "params": {"party": ["player", "player"]},
+        },
+    )
+    assert duplicate_resp.status_code == 400
+    duplicate_data = await duplicate_resp.get_json()
+    assert duplicate_data["error"] == "invalid party"
+
+    unowned_resp = await client.post(
+        "/ui/action",
+        json={
+            "action": "update_party",
+            "params": {"party": ["player", "becca"]},
+        },
+    )
+    assert unowned_resp.status_code == 400
+    unowned_data = await unowned_resp.get_json()
+    assert unowned_data["error"] == "unowned character"


### PR DESCRIPTION
## Summary
- add an `update_party` helper in the run service and route the new `update_party` UI action to it, reusing existing party validation before persisting changes
- extend backend documentation to describe the new UI action contract
- add regression tests that cover successful roster updates as well as missing run and invalid party failures

## Testing
- uv run pytest tests/test_ui_party_update.py

------
https://chatgpt.com/codex/tasks/task_b_68d766d219c0832c87fe24cbd5cda312