### PR TITLE
fix: preserve room data between ui summaries

### DIFF
--- a/frontend/src/lib/systems/runState.js
+++ b/frontend/src/lib/systems/runState.js
@@ -137,13 +137,14 @@ export function createRunStateStore(storageCandidate) {
         updates.nextRoom = currentState.next_room_type;
       }
 
-      if (currentState?.room_data) {
-        updates.roomData = { ...currentState.room_data };
-        if (mode === 'battle' && !currentState.room_data?.snapshot_missing) {
-          updates.lastBattleSnapshot = { ...currentState.room_data };
+      if (currentState && Object.prototype.hasOwnProperty.call(currentState, 'room_data')) {
+        const roomDataPayload = currentState.room_data;
+        if (roomDataPayload != null) {
+          updates.roomData = { ...roomDataPayload };
+          if (mode === 'battle' && !roomDataPayload?.snapshot_missing) {
+            updates.lastBattleSnapshot = { ...roomDataPayload };
+          }
         }
-      } else {
-        updates.roomData = null;
       }
 
       const inBattle = mode === 'battle';

--- a/frontend/src/lib/systems/runState.js
+++ b/frontend/src/lib/systems/runState.js
@@ -139,7 +139,9 @@ export function createRunStateStore(storageCandidate) {
 
       if (currentState && Object.prototype.hasOwnProperty.call(currentState, 'room_data')) {
         const roomDataPayload = currentState.room_data;
-        if (roomDataPayload != null) {
+        if (roomDataPayload == null) {
+          updates.roomData = null;
+        } else {
           updates.roomData = { ...roomDataPayload };
           if (mode === 'battle' && !roomDataPayload?.snapshot_missing) {
             updates.lastBattleSnapshot = { ...roomDataPayload };

--- a/frontend/tests/run-state-store.test.js
+++ b/frontend/tests/run-state-store.test.js
@@ -133,4 +133,39 @@ describe('run state store', () => {
     });
     expect(storage.snapshot()).toEqual({ runState: '{"runId":"run-007"}' });
   });
+
+  test('applyUIState preserves existing room data when summary omits payload', () => {
+    const store = createRunStateStore(createMemoryStorage());
+    const shopPayload = {
+      mode: 'map',
+      active_run: 'run-008',
+      game_state: {
+        current_state: {
+          current_index: 2,
+          current_room_type: 'shop',
+          room_data: {
+            wares: ['heal_potion'],
+            discount: 0.1
+          }
+        }
+      }
+    };
+
+    store.applyUIState(shopPayload);
+    expect(store.getSnapshot().roomData).toEqual({ wares: ['heal_potion'], discount: 0.1 });
+
+    const summaryWithoutRoom = {
+      mode: 'map',
+      active_run: 'run-008',
+      game_state: {
+        current_state: {
+          current_index: 2,
+          current_room_type: 'shop'
+        }
+      }
+    };
+
+    store.applyUIState(summaryWithoutRoom);
+    expect(store.getSnapshot().roomData).toEqual({ wares: ['heal_potion'], discount: 0.1 });
+  });
 });


### PR DESCRIPTION
## Summary
- keep existing roomData when UI state summaries omit a room_data payload while still capturing new battle snapshots
- add a regression test to ensure shop room data persists across UI polls without new room_data information

## Testing
- bun test tests/run-state-store.test.js

------
https://chatgpt.com/codex/tasks/task_b_68d76da5e1e8832c8fe38a324cfea8ae