### PR TITLE
Preserve shop state in UI polling

### DIFF
--- a/backend/routes/ui.py
+++ b/backend/routes/ui.py
@@ -18,6 +18,7 @@ from services.asset_service import get_asset_manifest
 from services.reward_service import select_card
 from services.reward_service import select_relic
 from services.room_service import room_action
+from services.room_service import snapshot_shop_room
 from services.run_service import advance_room
 from services.run_service import backup_save
 from services.run_service import get_battle_events
@@ -28,7 +29,6 @@ from services.run_service import update_party
 from services.run_service import wipe_save
 from tracking import log_game_action
 from tracking import log_menu_action
-from tracking import log_overlay_action
 from tracking import log_play_session_end
 from tracking import log_run_end
 
@@ -191,7 +191,12 @@ async def get_ui_state() -> tuple[str, int, dict[str, Any]]:
 
             # Check if there's an active battle snapshot
             snap = battle_snapshots.get(run_id)
-            if snap is not None and current_room_type in {"battle-weak", "battle-normal", "battle-boss-floor"}:
+            if current_room_type == "shop" and not state.get("awaiting_next"):
+                try:
+                    current_room_data = await snapshot_shop_room(run_id)
+                except Exception:
+                    current_room_data = None
+            elif snap is not None and current_room_type in {"battle-weak", "battle-normal", "battle-boss-floor"}:
                 current_room_data = snap
             elif (
                 current_room_type in {"battle-weak", "battle-normal", "battle-boss-floor"}

--- a/frontend/.codex/implementation/battle-polling.md
+++ b/frontend/.codex/implementation/battle-polling.md
@@ -6,7 +6,10 @@ three coordinated loops:
 
 1. **UI state polling** — mirrors `/ui` responses, applies them to
    `runStateStore`, and notifies registered handlers. This loop pauses whenever
-   `overlayBlocking`, `haltSync`, or a non-main overlay view is active.
+   `overlayBlocking`, `haltSync`, or a non-main overlay view is active. Shops now
+   return their full payloads on every `/ui` poll so `roomData` survives
+   repeated refreshes and the overlay stays mounted while players browse stock
+   or pending purchases.
 2. **Battle snapshot polling** — automatically starts when
    `runStateStore.battleActive` flips to `true` and a run id is present. The
    controller fetches `room_action(snapshot)` payloads, normalizes fighter


### PR DESCRIPTION
## Summary
- ensure the UI state endpoint pulls shop payload snapshots so polling keeps overlays mounted
- refactor the shop room handler to support read-only snapshots and update async tracking stubs for tests
- add a regression test covering shop state persistence and document the polling contract adjustment

## Testing
- uv run ruff check backend/routes/ui.py backend/services/room_service.py backend/tests/test_app.py backend/tests/conftest.py
- uv run pytest backend/tests/test_app.py -k shop_state


------
https://chatgpt.com/codex/tasks/task_b_68d779721c3c832cb81ec8eb83863ead