### PR TITLE
Fix summon portrait aliases resolving to canonical galleries

### DIFF
--- a/frontend/src/lib/systems/assetRegistry.js
+++ b/frontend/src/lib/systems/assetRegistry.js
@@ -833,6 +833,14 @@ export const getAvailableSfxKeys = () => {
   return Array.from(keys);
 };
 
+const isSummonPortraitKey = key => {
+  const normalized = normalizeKey(key);
+  if (!normalized) return false;
+  if (manifestState.summonPortraitKeys.has(normalized)) return true;
+  if (defaultSummonPortraitKeys.has(normalized)) return true;
+  return false;
+};
+
 const resolvePortraitKey = id => {
   const normalized = normalizeKey(id);
   if (!normalized) return '';
@@ -841,6 +849,18 @@ const resolvePortraitKey = id => {
   }
   if (manifestState.portraitAliases.has(normalized)) {
     return manifestState.portraitAliases.get(normalized);
+  }
+  if (metadataOverrides.summonAliases.has(normalized)) {
+    const target = metadataOverrides.summonAliases.get(normalized);
+    if (isSummonPortraitKey(target)) {
+      return target;
+    }
+  }
+  if (manifestState.summonAliases.has(normalized)) {
+    const target = manifestState.summonAliases.get(normalized);
+    if (isSummonPortraitKey(target)) {
+      return target;
+    }
   }
   return normalized;
 };
@@ -1590,6 +1610,12 @@ export const registerAssetManifest = manifest => {
     entry.aliases.forEach(alias => manifestState.summonAliases.set(alias, entry.id));
     if (entry.portrait) {
       manifestState.summonPortraitKeys.add(entry.id);
+      manifestState.portraitCanonicals.add(entry.id);
+      entry.aliases.forEach(alias => {
+        if (!manifestState.portraitAliases.has(alias)) {
+          manifestState.portraitAliases.set(alias, entry.id);
+        }
+      });
     }
   });
 

--- a/frontend/tests/assetregistry.test.js
+++ b/frontend/tests/assetregistry.test.js
@@ -5,6 +5,7 @@ if (typeof import.meta.glob !== 'function') {
 } else {
   const {
     getCharacterImage,
+    getDefaultFallback,
     getRandomFallback,
     getSummonArt,
     getSummonGallery,
@@ -59,6 +60,17 @@ if (typeof import.meta.glob !== 'function') {
       const url = getCharacterImage('becca');
       expect(typeof url).toBe('string');
       expect(url.includes('becca')).toBe(true);
+    });
+
+    test('resolves summon alias portraits from canonical gallery', () => {
+      const aliasUrl = getCharacterImage('jellyfish_electric');
+      expect(typeof aliasUrl).toBe('string');
+      expect(aliasUrl).not.toBe(getDefaultFallback());
+
+      const galleryUrls = getSummonGallery('jellyfish').map(entry => entry.url);
+      expect(Array.isArray(galleryUrls)).toBe(true);
+      expect(galleryUrls.length).toBeGreaterThan(0);
+      expect(galleryUrls).toContain(aliasUrl);
     });
 
     test('derives mimic portraits using manifest mirror rule', () => {


### PR DESCRIPTION
## Summary
- register summon portraits flagged in the manifest as portrait canonicals so aliases reuse the same gallery
- teach portrait resolution to fall back to summon aliases when the target is a portrait-capable summon
- add a regression test verifying jellyfish summon aliases return their portrait art instead of the static fallback

## Testing
- bun test tests/assetregistry.test.js

------
https://chatgpt.com/codex/tasks/task_b_68d7eee1f738832ca144e463aa5f3f4e