### PR TITLE
Fix run teardown to purge battle state

### DIFF
--- a/backend/tests/test_battle_defeat.py
+++ b/backend/tests/test_battle_defeat.py
@@ -2,6 +2,7 @@ import importlib.util
 from pathlib import Path
 
 import pytest
+from runs.lifecycle import battle_locks
 
 from autofighter.mapgen import MapNode
 from autofighter.party import Party
@@ -72,4 +73,5 @@ async def test_run_battle_handles_defeat_cleanup(app_with_db, monkeypatch):
     with app_module.get_save_manager().connection() as conn:
         row = conn.execute("SELECT id FROM runs WHERE id = ?", (run_id,)).fetchone()
     assert row is None
-    assert app_module.battle_snapshots[run_id]["ended"] is True
+    assert run_id not in app_module.battle_snapshots
+    assert run_id not in battle_locks


### PR DESCRIPTION
## Summary
- add a shared purge_run_state helper that removes battle tasks, snapshots, and locks for a run
- update manual run teardown flows to use the helper so locks are cleared during end_run and end_all_runs
- clear battle state during defeat, wipe, and restore paths and update the defeat cleanup test accordingly

## Testing
- `uv run ruff check routes/ui.py runs/lifecycle.py services/run_service.py tests/test_battle_defeat.py --fix`
- `uv run pytest tests/test_battle_defeat.py` *(fails: ImportError: cannot import name 'set_option' from 'options')*

------
https://chatgpt.com/codex/tasks/task_b_68d7f412b858832c8944ca9b4b0ff55a