### PR TITLE
Emit battle_end before purging run state

### DIFF
--- a/backend/routes/ui.py
+++ b/backend/routes/ui.py
@@ -13,6 +13,7 @@ from runs.encryption import get_save_manager
 from runs.lifecycle import battle_locks
 from runs.lifecycle import battle_snapshots
 from runs.lifecycle import battle_tasks
+from runs.lifecycle import emit_battle_end_for_runs
 from runs.lifecycle import load_map
 from runs.lifecycle import purge_all_run_state
 from runs.lifecycle import purge_run_state
@@ -36,7 +37,6 @@ from tracking import log_play_session_end
 from tracking import log_run_end
 
 from autofighter.rooms.shop import serialize_shop_payload
-from autofighter.stats import BUS
 
 bp = Blueprint("ui", __name__)
 
@@ -544,7 +544,7 @@ async def end_run(run_id: str) -> tuple[str, int, dict[str, Any]]:
         # End run logging
         end_run_logging()
 
-        await BUS.emit_async("battle_end", None)
+        await emit_battle_end_for_runs([run_id])
 
         # Delete from database
         existed = await asyncio.to_thread(delete_run)
@@ -581,7 +581,7 @@ async def end_all_runs() -> tuple[str, int, dict[str, Any]]:
         # End run logging
         end_run_logging()
 
-        await BUS.emit_async("battle_end", None)
+        await emit_battle_end_for_runs()
 
         # Cancel all active battle tasks and clear per-run state
         purge_all_run_state()

--- a/backend/services/run_service.py
+++ b/backend/services/run_service.py
@@ -13,6 +13,7 @@ from battle_logging.writers import start_run_logging
 from runs.encryption import get_fernet
 from runs.encryption import get_save_manager
 from runs.lifecycle import battle_snapshots
+from runs.lifecycle import emit_battle_end_for_runs
 from runs.lifecycle import load_map
 from runs.lifecycle import purge_all_run_state
 from runs.lifecycle import purge_run_state
@@ -30,7 +31,6 @@ from autofighter.mapgen import MapGenerator
 from autofighter.party import Party
 from autofighter.rooms import _choose_foe
 from autofighter.rooms import _serialize
-from autofighter.stats import BUS
 from plugins import characters as player_plugins
 from services.login_reward_service import record_room_completion
 from services.user_level_service import get_user_level
@@ -475,7 +475,7 @@ async def wipe_save() -> None:
                 "CREATE TABLE IF NOT EXISTS damage_types (id TEXT PRIMARY KEY, type TEXT)"
             )
 
-    await BUS.emit_async("battle_end", None)
+    await emit_battle_end_for_runs()
     purge_all_run_state()
     await asyncio.to_thread(do_wipe)
 
@@ -535,6 +535,6 @@ async def restore_save(blob: bytes) -> None:
                 "INSERT INTO damage_types (id, type) VALUES (?, ?)", payload["damage_types"]
             )
 
-    await BUS.emit_async("battle_end", None)
+    await emit_battle_end_for_runs()
     purge_all_run_state()
     await asyncio.to_thread(restore_data)


### PR DESCRIPTION
## Summary
- notify the stats event bus before ending individual or bulk runs so relic subscribers can clean up
- emit the same battle_end signal during wipe/restore flows to keep async subscriptions in sync
- ensure battle_end emissions include each registered combatant when aborting runs or wiping data so plugin cleanup handlers trigger correctly

## Testing
- uv run ruff check backend/routes/ui.py backend/services/run_service.py backend/runs/lifecycle.py backend/autofighter/rooms/battle/snapshots.py

------
https://chatgpt.com/codex/tasks/task_b_68d861bd43c4832cb81efd15815eecf9