### PR TITLE
Fix nested overlay surfaces for popup overlays

### DIFF
--- a/frontend/src/lib/components/OverlayHost.svelte
+++ b/frontend/src/lib/components/OverlayHost.svelte
@@ -277,36 +277,34 @@
 {/if}
 
 {#if $overlayView === 'warp-info'}
-  <OverlaySurface zIndex={1350}>
-    <PopupWindow
-      title="Warp Mechanics"
-      maxWidth="640px"
-      zIndex={1350}
-      on:close={() => dispatch('back')}
-    >
-      <div class="warp-info-body">
-        <p>
-          Warps spend gacha tickets to roll from the current banner. Each pull advances pity,
-          steadily improving the odds of 5★ and 6★ rewards until a top rarity is found.
-        </p>
-        <ul class="warp-info-list">
-          <li>Single pulls cost 1 ticket, while ×5 and ×10 options spend 5 or 10 at once.</li>
-          <li>
-            Pity carries across all banners and resets after any 5★ or 6★ reward, whichever comes
-            first.
-          </li>
-          <li>Duplicate characters grant upgrade materials instead of extra copies.</li>
-        </ul>
-        <p class="warp-info-note">
-          Tip: Saving up for larger batches guarantees the animation plays once per session while still
-          honoring your current pity level.
-        </p>
-        <div class="stained-glass-row" style="justify-content: flex-end; margin-top: 0.75rem;">
-          <button class="icon-btn" on:click={() => dispatch('back')}>Back to pulls</button>
-        </div>
+  <PopupWindow
+    title="Warp Mechanics"
+    maxWidth="640px"
+    zIndex={1350}
+    on:close={() => dispatch('back')}
+  >
+    <div class="warp-info-body">
+      <p>
+        Warps spend gacha tickets to roll from the current banner. Each pull advances pity,
+        steadily improving the odds of 5★ and 6★ rewards until a top rarity is found.
+      </p>
+      <ul class="warp-info-list">
+        <li>Single pulls cost 1 ticket, while ×5 and ×10 options spend 5 or 10 at once.</li>
+        <li>
+          Pity carries across all banners and resets after any 5★ or 6★ reward, whichever comes
+          first.
+        </li>
+        <li>Duplicate characters grant upgrade materials instead of extra copies.</li>
+      </ul>
+      <p class="warp-info-note">
+        Tip: Saving up for larger batches guarantees the animation plays once per session while still
+        honoring your current pity level.
+      </p>
+      <div class="stained-glass-row" style="justify-content: flex-end; margin-top: 0.75rem;">
+        <button class="icon-btn" on:click={() => dispatch('back')}>Back to pulls</button>
       </div>
-    </PopupWindow>
-  </OverlaySurface>
+    </div>
+  </PopupWindow>
 {/if}
 
   {#if $overlayView === 'pull-results'}
@@ -374,54 +372,52 @@
 {/if}
 
 {#if rewardOpen}
-  <OverlaySurface zIndex={1100} noScroll={true}>
-    <PopupWindow
-      title={(roomData?.card_choices?.length || 0) > 0 ? 'Choose a Card' : 'Choose a Relic'}
-      maxWidth="880px"
-      maxHeight="100%"
-      zIndex={1100}
-      on:close={() => { /* block closing while choices remain */ }}
-    >
-      <RewardOverlay
-        cards={roomData.card_choices || []}
-        relics={roomData.relic_choices || []}
-        items={roomData.loot?.items || []}
-        gold={roomData.loot?.gold || 0}
-        {fullIdleMode}
-        on:select={(e) => dispatch('rewardSelect', e.detail)}
-        on:next={() => dispatch('nextRoom')}
-        on:lootAcknowledge={() => dispatch('lootAcknowledge')}
-      />
-    </PopupWindow>
-  </OverlaySurface>
+  <PopupWindow
+    title={(roomData?.card_choices?.length || 0) > 0 ? 'Choose a Card' : 'Choose a Relic'}
+    maxWidth="880px"
+    maxHeight="100%"
+    zIndex={1100}
+    surfaceNoScroll={true}
+    on:close={() => { /* block closing while choices remain */ }}
+  >
+    <RewardOverlay
+      cards={roomData.card_choices || []}
+      relics={roomData.relic_choices || []}
+      items={roomData.loot?.items || []}
+      gold={roomData.loot?.gold || 0}
+      {fullIdleMode}
+      on:select={(e) => dispatch('rewardSelect', e.detail)}
+      on:next={() => dispatch('nextRoom')}
+      on:lootAcknowledge={() => dispatch('lootAcknowledge')}
+    />
+  </PopupWindow>
 {/if}
 
 {#if reviewOpen && !rewardOpen && reviewReady && !skipBattleReview}
-  <OverlaySurface zIndex={1100} noScroll={true}>
-    <PopupWindow
-      title="Battle Review"
-      maxWidth="1200px"
-      maxHeight="100%"
-      zIndex={1100}
-      on:close={() => dispatch('nextRoom')}
-    >
-      {#key reviewKey}
-        <BattleReview
-          runId={runId}
-          battleIndex={roomData?.battle_index || 0}
-          prefetchedSummary={reviewSummary}
-          partyData={reviewPartyData}
-          foeData={(battleSnapshot?.foes && battleSnapshot?.foes.length) ? battleSnapshot.foes : (roomData?.foes || [])}
-          cards={[]}
-          relics={[]}
-          {reducedMotion}
-        />
-      {/key}
-      <div slot="footer" class="stained-glass-row" style="justify-content: flex-end; margin-top: 0.75rem;">
-        <button class="icon-btn" on:click={() => dispatch('nextRoom')}>Next Room</button>
-      </div>
-    </PopupWindow>
-  </OverlaySurface>
+  <PopupWindow
+    title="Battle Review"
+    maxWidth="1200px"
+    maxHeight="100%"
+    zIndex={1100}
+    surfaceNoScroll={true}
+    on:close={() => dispatch('nextRoom')}
+  >
+    {#key reviewKey}
+      <BattleReview
+        runId={runId}
+        battleIndex={roomData?.battle_index || 0}
+        prefetchedSummary={reviewSummary}
+        partyData={reviewPartyData}
+        foeData={(battleSnapshot?.foes && battleSnapshot?.foes.length) ? battleSnapshot.foes : (roomData?.foes || [])}
+        cards={[]}
+        relics={[]}
+        {reducedMotion}
+      />
+    {/key}
+    <div slot="footer" class="stained-glass-row" style="justify-content: flex-end; margin-top: 0.75rem;">
+      <button class="icon-btn" on:click={() => dispatch('nextRoom')}>Next Room</button>
+    </div>
+  </PopupWindow>
 {/if}
 
 {#if roomData && roomData.result === 'shop'}

--- a/frontend/src/lib/components/PopupWindow.svelte
+++ b/frontend/src/lib/components/PopupWindow.svelte
@@ -11,13 +11,15 @@
   export let maxWidth = '820px';
   export let maxHeight = '85vh';
   export let zIndex = 1000;
+  export let bareSurface = false;
+  export let surfaceNoScroll = false;
 
   function close() {
     dispatch('close');
   }
 </script>
 
-<OverlaySurface {zIndex}>
+{#if bareSurface}
   <div class="box" style={`--max-w: ${maxWidth}; --max-h: ${maxHeight}` }>
     <div class="inner">
       <div class="content-wrap">
@@ -36,7 +38,28 @@
       </div>
     </div>
   </div>
-</OverlaySurface>
+{:else}
+  <OverlaySurface {zIndex} noScroll={surfaceNoScroll}>
+    <div class="box" style={`--max-w: ${maxWidth}; --max-h: ${maxHeight}` }>
+      <div class="inner">
+        <div class="content-wrap">
+          <MenuPanel class="panel-body" {padding}>
+            {#if title}
+              <header class="head">
+                <h3>{title}</h3>
+                <button class="mini" title="Close" on:click={close}>✕</button>
+              </header>
+            {/if}
+            <slot />
+          </MenuPanel>
+          <div class="panel-footer">
+            <slot name="footer" />
+          </div>
+        </div>
+      </div>
+    </div>
+  </OverlaySurface>
+{/if}
 
 <style>
   .head {


### PR DESCRIPTION
## Summary
- remove redundant OverlaySurface wrappers around popup overlays to prevent double-stacked glass frames
- add configuration to PopupWindow so callers can opt into custom overlay handling while keeping reward and review overlays on a single surface

## Testing
- bun run lint

------
https://chatgpt.com/codex/tasks/task_b_68d943bd4cb4832c9b69d778d38606ef