### PR TITLE
Fix duplicate battle review chrome

### DIFF
--- a/frontend/src/lib/components/BattleReview.svelte
+++ b/frontend/src/lib/components/BattleReview.svelte
@@ -6,9 +6,8 @@
     createBattleReviewState
   } from '../systems/battleReview/state.js';
   import { buildBattleReviewLink } from '../systems/battleReview/urlState.js';
-import TabsShell from './battle-review/TabsShell.svelte';
-import EventsDrawer from './battle-review/EventsDrawer.svelte';
-import MenuPanel from './MenuPanel.svelte';
+  import TabsShell from './battle-review/TabsShell.svelte';
+  import EventsDrawer from './battle-review/EventsDrawer.svelte';
 
   export let runId = '';
   export let battleIndex = 0;
@@ -153,7 +152,7 @@ import MenuPanel from './MenuPanel.svelte';
 
 <svelte:options accessors={true} />
 
-<MenuPanel class="battle-review-panel" padding="1.25rem" {reducedMotion}>
+<div class="battle-review-panel">
   <div class="battle-review-layout">
     <header class="review-header">
       <div class="header-metric">Result: {$resultSummary.result}</div>
@@ -190,9 +189,17 @@ import MenuPanel from './MenuPanel.svelte';
     <TabsShell />
     <EventsDrawer />
   </div>
-</MenuPanel>
+</div>
 
 <style>
+  .battle-review-panel {
+    display: flex;
+    flex-direction: column;
+    flex: 1 1 auto;
+    min-height: 0;
+    width: 100%;
+  }
+
   .battle-review-layout {
     display: flex;
     flex-direction: column;

--- a/frontend/src/lib/components/OverlayHost.svelte
+++ b/frontend/src/lib/components/OverlayHost.svelte
@@ -58,6 +58,7 @@
   };
   $: effectiveReducedMotion = reducedMotion || motionSettings.globalReducedMotion;
   $: simplifiedTransitions = motionSettings.simplifyOverlayTransitions;
+  $: overlayReducedMotion = simplifiedTransitions ? true : effectiveReducedMotion;
 
   const dispatch = createEventDispatcher();
   const now = () => new Date().toISOString();
@@ -399,6 +400,8 @@
     maxWidth="1200px"
     maxHeight="100%"
     zIndex={1100}
+    padding="1.25rem"
+    reducedMotion={overlayReducedMotion}
     surfaceNoScroll={true}
     on:close={() => dispatch('nextRoom')}
   >
@@ -411,7 +414,7 @@
         foeData={(battleSnapshot?.foes && battleSnapshot?.foes.length) ? battleSnapshot.foes : (roomData?.foes || [])}
         cards={[]}
         relics={[]}
-        {reducedMotion}
+        reducedMotion={overlayReducedMotion}
       />
     {/key}
     <div slot="footer" class="stained-glass-row" style="justify-content: flex-end; margin-top: 0.75rem;">

--- a/frontend/src/lib/components/PopupWindow.svelte
+++ b/frontend/src/lib/components/PopupWindow.svelte
@@ -13,6 +13,7 @@
   export let zIndex = 1000;
   export let bareSurface = false;
   export let surfaceNoScroll = false;
+  export let reducedMotion = false;
 
   function close() {
     dispatch('close');
@@ -23,7 +24,7 @@
   <div class="box" style={`--max-w: ${maxWidth}; --max-h: ${maxHeight}` }>
     <div class="inner">
       <div class="content-wrap">
-        <MenuPanel class="panel-body" {padding}>
+        <MenuPanel class="panel-body" {padding} {reducedMotion}>
           {#if title}
             <header class="head">
               <h3>{title}</h3>
@@ -43,7 +44,7 @@
     <div class="box" style={`--max-w: ${maxWidth}; --max-h: ${maxHeight}` }>
       <div class="inner">
         <div class="content-wrap">
-          <MenuPanel class="panel-body" {padding}>
+          <MenuPanel class="panel-body" {padding} {reducedMotion}>
             {#if title}
               <header class="head">
                 <h3>{title}</h3>


### PR DESCRIPTION
## Summary
- replace the inner MenuPanel in BattleReview with a flex shell to avoid double chrome
- allow PopupWindow to forward reducedMotion so overlays can honor motion settings
- update OverlayHost to pass the shared overlayReducedMotion value and battle review padding to PopupWindow

## Testing
- bun test tests/battle-review-architecture.test.js tests/battle-review-timeline.test.js tests/battle-review-routing.test.js

------
https://chatgpt.com/codex/tasks/task_b_68d94e1a5498832cbae56a0606a56ac1