### PR TITLE
Rebuild battle review timeline projection for event lanes

### DIFF
--- a/frontend/.codex/implementation/battle-review-ui.md
+++ b/frontend/.codex/implementation/battle-review-ui.md
@@ -7,7 +7,7 @@ The Battle Review overlay is now organized around a timeline-first layout backed
 - **State management** lives in `frontend/src/lib/systems/battleReview/state.js`. The exported `createBattleReviewState` helper fetches summaries and events, tracks loading status, derives overview metrics, and exposes the active tab/timeline data. Components access the state via the shared `BATTLE_REVIEW_CONTEXT_KEY` context.
 - **`BattleReview.svelte`** sets up the state and renders the high-level header. It also owns the event-log toggle and pushes the state object into context for child components.
 - **`TabsShell.svelte`** renders the metric tabs and composes the grid for the timeline viewport and per-entity metrics panel. The tab chips use `BattleReviewFighterChip.svelte`, which wraps the modern `BattleFighterCard` portrait so the battle review can share the same glow, motion, and cycling behaviors without maintaining a separate clone.
-- **`TimelineRegion.svelte`** visualizes the most recent combat events in a scrolling list. It consumes the derived `timeline` store so it can update reactively once events finish streaming from the backend.
+- **`TimelineRegion.svelte`** renders battle events as a multi-lane timeline. Markers are positioned by timestamp, grouped into damage/healing lanes, and include inline metadata for card plays and relic triggers. The component still consumes the derived `timeline` store so it can update reactively once events finish streaming from the backend.
 - **`EntityTableContainer.svelte`** handles both the overview aggregate presentation and the entity-specific breakdowns. It renders a stats side panel in addition to the central metrics tables to keep the new "side panel" design consistent with the timeline-first layout.
 - **`EventsDrawer.svelte`** shows the raw event log when toggled. It subscribes to `eventsOpen` and lazily loads events when the drawer opens.
 
@@ -74,6 +74,7 @@ Splitting the 1.5k-line `+page.svelte` root view into composable stores is an on
 - Resume an in-progress run from `localStorage` and confirm map/party data hydrates correctly (covers `runStateStore.restoreFromStorage`).
 - Trigger a reward overlay mid-run; verify polling pauses (`haltSync` becomes `true`) and resumes after the overlay closes.
 - Complete a battle and open the Battle Review overlay; ensure `battleActive` flips to `false` and the review overlay receives the cached snapshot.
+- Scrub the battle timeline while switching entity/type filters. Confirm that markers track card plays, relic triggers, damage bursts, and healing events in chronological order. Highlighted events should update when focusing a specific party member or foe.
 - Force a polling error (e.g., disconnect backend) and confirm the orchestrator retries UI polling with backoff and surfaces errors through the shared status store.
 - Run `bun test frontend/tests/run-state-store.test.js` and, once implemented, the future battle polling controller spec whenever the stores change.
 

--- a/frontend/tests/battle-review-architecture.test.js
+++ b/frontend/tests/battle-review-architecture.test.js
@@ -86,8 +86,9 @@ describe('battle review store architecture', () => {
       }
     ]);
     const timeline = get(state.timeline);
-    expect(timeline.filteredEvents).toHaveLength(2);
-    expect(timeline.filteredEvents[1].abilityName).toBe('Ultimate');
+    expect(timeline.events).toHaveLength(2);
+    expect(timeline.events[1].abilityName).toBe('Ultimate');
+    expect(timeline.events[1].action.summary).toBe('Ultimate');
 
     state.destroy();
   });


### PR DESCRIPTION
## Summary
- emit enriched chronological events from the battle review timeline projection and surface action metadata for cards and relics
- replace the timeline visualization with multi-lane markers that track damage, healing, card plays, and relic triggers along the battle window
- refresh documentation and tests to cover the new timeline behaviour and QA expectations

## Testing
- bun run lint
- bun test tests/battle-review-timeline.test.js tests/battle-review-architecture.test.js

------
https://chatgpt.com/codex/tasks/task_b_68d958ee02b0832c9e4dff813fabeb71