### PR TITLE
[FIX] Gate UI sync while manually halted

### DIFF
--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -1347,6 +1347,11 @@
   let uiState = null;
 
   function applyUIStatePayload(newUIState) {
+    const incomingMode = typeof newUIState?.mode === 'string' ? newUIState.mode : undefined;
+    if (haltSync && incomingMode !== 'menu') {
+      return;
+    }
+
     if (newUIState?.asset_manifest) {
       try {
         registerAssetManifest(newUIState.asset_manifest);


### PR DESCRIPTION
## Summary
- skip applying UI state payloads when manual sync halt is active unless the payload is for the menu

## Testing
- bun run lint

------
https://chatgpt.com/codex/tasks/task_b_68da7edc0990832cbeebb1959fa6b869