### PR TITLE
Add turn phase metadata to battle progress updates

### DIFF
--- a/backend/autofighter/rooms/battle/engine.py
+++ b/backend/autofighter/rooms/battle/engine.py
@@ -150,6 +150,7 @@ async def run_battle(
                 active_target_id=None,
                 visual_queue=visual_queue,
                 ended=True,
+                turn_phase="battle_teardown",
             )
         except Exception:
             pass

--- a/backend/autofighter/rooms/battle/progress.py
+++ b/backend/autofighter/rooms/battle/progress.py
@@ -49,6 +49,7 @@ class BattleProgressPayload(TypedDict, total=False):
 
     result: str
     turn: int
+    turn_phase: str
     party: list[BattleEntityPayload]
     foes: list[BattleEntityPayload]
     party_summons: SummonSnapshotMap
@@ -157,6 +158,7 @@ async def build_battle_progress_payload(
     include_summon_foes: bool = False,
     visual_queue: "ActionQueue" | None = None,
     ended: bool | None = None,
+    turn_phase: str | None = None,
 ) -> BattleProgressPayload:
     """Assemble the payload dispatched to progress callbacks."""
 
@@ -201,6 +203,9 @@ async def build_battle_progress_payload(
         "active_id": active_id,
         "active_target_id": active_target_id,
     }
+
+    if turn_phase is not None:
+        payload["turn_phase"] = turn_phase
 
     if run_id:
         events = _snapshots.get_recent_events(run_id)

--- a/backend/autofighter/rooms/battle/turn_loop/turn_end.py
+++ b/backend/autofighter/rooms/battle/turn_loop/turn_end.py
@@ -48,6 +48,7 @@ async def finish_turn(
         actor,
         context.turn,
         context.run_id,
+        turn_phase="turn_end",
     )
     if cycle_count:
         context.turn += cycle_count

--- a/backend/autofighter/rooms/battle/turns.py
+++ b/backend/autofighter/rooms/battle/turns.py
@@ -46,6 +46,7 @@ async def push_progress_update(
     include_summon_foes: bool = False,
     visual_queue: Any | None = None,
     ended: bool | None = None,
+    turn_phase: str | None = None,
 ) -> None:
     """Send a progress update if a callback is available."""
 
@@ -64,6 +65,7 @@ async def push_progress_update(
         include_summon_foes=include_summon_foes,
         visual_queue=visual_queue,
         ended=ended,
+        turn_phase=turn_phase,
     )
     await progress(payload)
 
@@ -92,6 +94,8 @@ async def dispatch_turn_end_snapshot(
     actor: Stats,
     turn: int,
     run_id: str | None,
+    *,
+    turn_phase: str | None = "turn_end",
 ) -> int:
     """Advance the visual queue and emit an updated snapshot."""
 
@@ -109,6 +113,7 @@ async def dispatch_turn_end_snapshot(
         active_id=getattr(actor, "id", None),
         active_target_id=None,
         visual_queue=visual_queue,
+        turn_phase=turn_phase,
     )
     return cycle_count
 

--- a/backend/tests/test_turn_loop_summon_updates.py
+++ b/backend/tests/test_turn_loop_summon_updates.py
@@ -111,6 +111,8 @@ def _setup_common_player_patches(monkeypatch: pytest.MonkeyPatch, module) -> lis
         active_target_id=None,
         include_summon_foes=False,
         ended=None,
+        visual_queue=None,
+        turn_phase=None,
     ):
         updates.append(
             {
@@ -120,6 +122,7 @@ def _setup_common_player_patches(monkeypatch: pytest.MonkeyPatch, module) -> lis
                 "active_id": active_id,
                 "active_target_id": active_target_id,
                 "turn": turn,
+                "turn_phase": turn_phase,
             }
         )
         if progress_cb is not None:


### PR DESCRIPTION
## Summary
- allow battle progress updates to accept an optional turn_phase flag and surface it in the payload when provided
- propagate turn_phase through turn-end snapshots and the battle teardown progress broadcast
- extend the turn loop summon tests to accommodate the new argument

## Testing
- uv run ruff check autofighter/rooms/battle/turns.py autofighter/rooms/battle/progress.py autofighter/rooms/battle/engine.py autofighter/rooms/battle/turn_loop/turn_end.py
- uv run pytest tests/test_battle_progress_helpers.py
- uv run pytest tests/test_turn_loop_summon_updates.py

------
https://chatgpt.com/codex/tasks/task_b_68da8aebb5c0832c819f47d71c5aeaa5