### PR TITLE
Fix enrage progress test stub turn_phase handling

### DIFF
--- a/backend/tests/test_enrage_progress_updates.py
+++ b/backend/tests/test_enrage_progress_updates.py
@@ -160,6 +160,7 @@ async def test_player_phase_emits_snapshot_on_enrage(monkeypatch: pytest.MonkeyP
         active_target_id=None,
         include_summon_foes=False,
         ended=None,
+        turn_phase: str | None = None,
     ) -> None:
         updates.append(
             {
@@ -171,6 +172,7 @@ async def test_player_phase_emits_snapshot_on_enrage(monkeypatch: pytest.MonkeyP
                 "include_summon_foes": include_summon_foes,
                 "ended": ended,
                 "turn": turn,
+                "turn_phase": turn_phase,
             }
         )
 


### PR DESCRIPTION
## Summary
- update the enrage progress test stub to accept the new optional turn_phase argument
- capture the provided turn_phase value in the recorded snapshot for future assertions

## Testing
- uv run pytest backend/tests/test_enrage_progress_updates.py *(fails: missing dependency `cryptography` in test environment)*

------
https://chatgpt.com/codex/tasks/task_b_68da8e608354832ca01967a7fb62b818