### PR TITLE
Fix multi-item shop purchases to run sequentially

### DIFF
--- a/frontend/src/lib/systems/shopPurchases.js
+++ b/frontend/src/lib/systems/shopPurchases.js
@@ -1,0 +1,157 @@
+function readFiniteNumber(value) {
+  const num = Number(value);
+  return Number.isFinite(num) ? num : null;
+}
+
+export function extractShopPricing(entry) {
+  if (!entry || typeof entry !== 'object') {
+    return { base: null, taxed: null, tax: null };
+  }
+  const base = (() => {
+    const candidates = [
+      entry.base_cost,
+      entry.base_price,
+      entry.pricing?.base,
+      entry.price,
+      entry.cost
+    ];
+    for (const candidate of candidates) {
+      const resolved = readFiniteNumber(candidate);
+      if (resolved !== null) return resolved;
+    }
+    return null;
+  })();
+  const taxed = (() => {
+    const candidates = [
+      entry.taxed_cost,
+      entry.pricing?.taxed,
+      entry.price,
+      entry.cost,
+      base
+    ];
+    for (const candidate of candidates) {
+      const resolved = readFiniteNumber(candidate);
+      if (resolved !== null) return resolved;
+    }
+    return base;
+  })();
+  const tax = (() => {
+    const candidates = [
+      entry.tax,
+      entry.pricing?.tax,
+      (taxed !== null && base !== null) ? taxed - base : null
+    ];
+    for (const candidate of candidates) {
+      const resolved = readFiniteNumber(candidate);
+      if (resolved !== null) return resolved < 0 ? 0 : resolved;
+    }
+    if (taxed !== null && base !== null) {
+      const diff = taxed - base;
+      return Number.isFinite(diff) && diff > 0 ? diff : 0;
+    }
+    return null;
+  })();
+  return { base, taxed, tax };
+}
+
+export function normalizeShopPurchase(entry) {
+  if (!entry || typeof entry !== 'object') {
+    return null;
+  }
+  const id = entry.id ?? entry.item ?? null;
+  if (!id) {
+    return null;
+  }
+  const { base, taxed, tax } = extractShopPricing(entry);
+  const normalized = { id };
+  if (base !== null) {
+    normalized.base_cost = base;
+    normalized.base_price = base;
+  }
+  if (taxed !== null) {
+    normalized.cost = taxed;
+    normalized.price = taxed;
+    normalized.taxed_cost = taxed;
+  }
+  if (tax !== null) {
+    normalized.tax = tax;
+  }
+  return normalized;
+}
+
+const COST_KEYS = ['base_cost', 'base_price', 'cost', 'price', 'taxed_cost', 'tax'];
+
+export function refreshPurchasePricing(entry, roomData) {
+  if (!entry || typeof entry !== 'object') {
+    return entry;
+  }
+  if (!roomData || typeof roomData !== 'object') {
+    return entry;
+  }
+  const stockList = Array.isArray(roomData.stock) ? roomData.stock : [];
+  const match = stockList.find((stock) => {
+    if (!stock || typeof stock !== 'object') return false;
+    const stockId = stock.id ?? stock.item ?? null;
+    return stockId === entry.id;
+  });
+  if (!match) {
+    return entry;
+  }
+  const pricing = normalizeShopPurchase(match);
+  if (!pricing) {
+    return entry;
+  }
+  const updated = { ...entry };
+  for (const key of COST_KEYS) {
+    if (Object.prototype.hasOwnProperty.call(pricing, key)) {
+      updated[key] = pricing[key];
+    }
+  }
+  return updated;
+}
+
+export function buildShopPurchasePayload(entry) {
+  if (!entry || typeof entry !== 'object') {
+    return null;
+  }
+  return { ...entry, items: { ...entry } };
+}
+
+const noopWait = async () => {};
+
+export async function processSequentialPurchases(
+  purchases,
+  {
+    submit,
+    initialRoomData = null,
+    waitBetween = noopWait,
+    reprice = refreshPurchasePricing,
+    buildPayload = buildShopPurchasePayload
+  } = {}
+) {
+  if (typeof submit !== 'function') {
+    throw new TypeError('submit must be a function');
+  }
+  if (!Array.isArray(purchases) || purchases.length === 0) {
+    return initialRoomData ?? null;
+  }
+  const queue = purchases.map((entry) => ({ ...entry }));
+  let roomData = initialRoomData ?? null;
+  for (let index = 0; index < queue.length; index += 1) {
+    const total = queue.length;
+    const current = roomData ? reprice(queue[index], roomData) : queue[index];
+    queue[index] = current;
+    const payload = buildPayload(current);
+    if (!payload) {
+      continue;
+    }
+    const result = await submit(payload, index, total);
+    if (result !== undefined) {
+      roomData = result;
+    }
+    if (index < total - 1) {
+      await waitBetween(index, total);
+    }
+  }
+  return roomData;
+}

--- a/frontend/tests/shop-purchase-sequence.test.js
+++ b/frontend/tests/shop-purchase-sequence.test.js
@@ -1,0 +1,82 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  normalizeShopPurchase,
+  processSequentialPurchases
+} from '../src/lib/systems/shopPurchases.js';
+
+function taxedCost(basePrice, pressure, itemsBought) {
+  if (itemsBought <= 0) {
+    return basePrice;
+  }
+  const rate = 0.01 * (pressure + 1) * itemsBought;
+  const tax = Math.ceil(basePrice * rate);
+  return basePrice + tax;
+}
+
+describe('sequential shop purchases', () => {
+  test('reprices remaining selections so multi-buy succeeds on the first attempt', async () => {
+    const pressure = 3;
+    const stockEntries = [
+      { id: 'alpha', base_price: 100 },
+      { id: 'beta', base_price: 200 }
+    ];
+
+    const initialStock = stockEntries.map((entry) => {
+      const taxed = taxedCost(entry.base_price, pressure, 0);
+      return {
+        id: entry.id,
+        base_price: entry.base_price,
+        price: taxed,
+        cost: taxed,
+        tax: taxed - entry.base_price
+      };
+    });
+
+    const purchases = initialStock
+      .map((entry) => normalizeShopPurchase(entry))
+      .filter((entry) => entry !== null);
+
+    let itemsBought = 0;
+    let remainingStock = [...initialStock];
+    let submitCalls = 0;
+
+    const submit = async (payload) => {
+      submitCalls += 1;
+      const original = stockEntries.find((entry) => entry.id === payload.id);
+      expect(original, 'purchase should reference a known stock entry').toBeTruthy();
+      const expectedCost = taxedCost(original.base_price, pressure, itemsBought);
+      expect(payload.cost).toBe(expectedCost);
+      expect(payload.taxed_cost).toBe(expectedCost);
+      expect(payload.items).toBeTruthy();
+      expect(payload.items.id).toBe(payload.id);
+
+      itemsBought += 1;
+      remainingStock = remainingStock
+        .filter((entry) => entry.id !== payload.id)
+        .map((entry) => {
+          const taxed = taxedCost(entry.base_price, pressure, itemsBought);
+          return {
+            ...entry,
+            price: taxed,
+            cost: taxed,
+            tax: taxed - entry.base_price
+          };
+        });
+
+      return {
+        items_bought: itemsBought,
+        stock: remainingStock
+      };
+    };
+
+    const finalState = await processSequentialPurchases(purchases, {
+      initialRoomData: { stock: initialStock, items_bought: 0 },
+      submit,
+      waitBetween: async () => {}
+    });
+
+    expect(submitCalls).toBe(2);
+    expect(itemsBought).toBe(2);
+    expect(finalState?.items_bought ?? 0).toBe(2);
+  });
+});

--- a/frontend/tests/shopmenu.test.js
+++ b/frontend/tests/shopmenu.test.js
@@ -4,7 +4,7 @@ import { join } from 'path';
 
 const shopMenuPath = join(import.meta.dir, '../src/lib/components/ShopMenu.svelte');
 const overlayHostPath = join(import.meta.dir, '../src/lib/components/OverlayHost.svelte');
-const pagePath = join(import.meta.dir, '../src/routes/+page.svelte');
+const purchaseUtilsPath = join(import.meta.dir, '../src/lib/systems/shopPurchases.js');
 
 describe('Shop menu tax metadata', () => {
   test('exposes surcharge props and UI affordances', () => {
@@ -21,10 +21,11 @@ describe('Shop menu tax metadata', () => {
     expect(content).toContain('itemsBought={roomData.items_bought}');
   });
 
-  test('shop buy payload includes base and taxed costs', () => {
-    const content = readFileSync(pagePath, 'utf8');
-    expect(content).toContain('payload.base_cost');
-    expect(content).toContain('payload.taxed_cost');
-    expect(content).toContain('payload.tax');
+  test('shop purchase helpers include base and taxed costs', () => {
+    const content = readFileSync(purchaseUtilsPath, 'utf8');
+    expect(content).toContain('normalized.base_cost');
+    expect(content).toContain('normalized.taxed_cost');
+    expect(content).toContain('normalized.tax');
+    expect(content).toContain('buildShopPurchasePayload');
   });
 });


### PR DESCRIPTION
## Summary
- add a shared shop purchase helper that normalizes pricing and runs sequential requests
- update the page shop handler to use sequential processing while keeping the existing queue gate
- extend shop tests to cover the helper utilities and multi-item purchase sequencing

## Testing
- `bun run lint`
- `bun test tests/shopmenu.test.js`
- `bun test tests/shop-purchase-sequence.test.js`


------
https://chatgpt.com/codex/tasks/task_b_68da8fee77f8832cbc050feb00695451