### PR TITLE
Fix foe turn progress update sequencing

### DIFF
--- a/backend/autofighter/rooms/battle/turn_loop/foe_turn.py
+++ b/backend/autofighter/rooms/battle/turn_loop/foe_turn.py
@@ -124,6 +124,21 @@ async def _run_foe_turn_iteration(
         active_id=getattr(acting_foe, "id", None),
         active_target_id=getattr(target, "id", None),
     )
+    await push_progress_update(
+        context.progress,
+        context.combat_party.members,
+        context.foes,
+        context.enrage_state,
+        context.temp_rdr,
+        _EXTRA_TURNS,
+        context.turn,
+        run_id=context.run_id,
+        active_id=getattr(acting_foe, "id", None),
+        active_target_id=getattr(target, "id", None),
+        include_summon_foes=True,
+        visual_queue=context.visual_queue,
+        turn_phase="start",
+    )
     await pace_sleep(YIELD_MULTIPLIER)
 
     target_effect = target.effect_manager
@@ -198,6 +213,21 @@ async def _run_foe_turn_iteration(
             and acting_foe.hp > 0
             and not battle_over
         ):
+            await push_progress_update(
+                context.progress,
+                context.combat_party.members,
+                context.foes,
+                context.enrage_state,
+                context.temp_rdr,
+                _EXTRA_TURNS,
+                context.turn,
+                run_id=context.run_id,
+                active_id=getattr(acting_foe, "id", None),
+                active_target_id=getattr(target, "id", None),
+                include_summon_foes=True,
+                visual_queue=context.visual_queue,
+                turn_phase="resolve",
+            )
             _EXTRA_TURNS[id(acting_foe)] -= 1
             await _pace(action_start)
             return FoeTurnIterationResult(repeat=True, battle_over=False)
@@ -294,6 +324,7 @@ async def _run_foe_turn_iteration(
                 active_target_id=getattr(target, "id", None),
                 include_summon_foes=True,
                 visual_queue=context.visual_queue,
+                turn_phase="resolve",
             )
             await pace_sleep(YIELD_MULTIPLIER)
     except Exception:
@@ -318,6 +349,21 @@ async def _run_foe_turn_iteration(
         and acting_foe.hp > 0
         and not battle_over
     ):
+        await push_progress_update(
+            context.progress,
+            context.combat_party.members,
+            context.foes,
+            context.enrage_state,
+            context.temp_rdr,
+            _EXTRA_TURNS,
+            context.turn,
+            run_id=context.run_id,
+            active_id=getattr(acting_foe, "id", None),
+            active_target_id=getattr(target, "id", None),
+            include_summon_foes=True,
+            visual_queue=context.visual_queue,
+            turn_phase="resolve",
+        )
         _EXTRA_TURNS[id(acting_foe)] -= 1
         await _pace(action_start)
         await pace_sleep(YIELD_MULTIPLIER)


### PR DESCRIPTION
## Summary
- emit a foe turn start-phase progress update immediately after snapshot overlay mutation
- ensure foe skips, extra turns, and summon additions send resolve-phase progress updates
- add a regression test that verifies foe start snapshots precede damage snapshots and assert summon updates carry resolve phase metadata

## Testing
- [x] Backend tests (`uv run pytest tests/test_turn_loop_summon_updates.py -k "foe_turn_emits_start_before_damage or foe_phase_pushes_update_for_new_summons"`)
- [ ] Frontend tests
- [x] Linting (`uv run ruff check autofighter/rooms/battle/turn_loop/foe_turn.py tests/test_turn_loop_summon_updates.py`)
- [ ] Doc sync updates (README and `.codex/implementation` docs; link tasks below)

## Checklist
- [ ] Linked or updated relevant `.codex/tasks` entries
- [ ] Updated player roster and foe docs if adding or modifying fighters or enemies
- [ ] Referenced `.codex/implementation/ui-animation-guidelines.md` when adding UI animations

------
https://chatgpt.com/codex/tasks/task_b_68da9516dae8832c9b7b9795d04fcd36