### PR TITLE
Align turn end progress phases

### DIFF
--- a/backend/.codex/implementation/battle-snapshots.md
+++ b/backend/.codex/implementation/battle-snapshots.md
@@ -30,8 +30,9 @@ poll for results:
   active combatant remains at the head of the queue until user interfaces
   receive and render the update.
 - A dedicated `turn_end` handler now advances the queue once damage resolution
-  and `turn_end` triggers complete. It emits a final snapshot reflecting the
-  updated queue state so clients can accurately track turn progression.
+  and `turn_end` triggers complete. It emits a final snapshot tagged with
+  `turn_phase="end"` after the queue advances so clients can accurately track
+  turn progression.
 
 - Foe snapshots include a `rank` field describing encounter difficulty.
   Supported ranks are `"normal"`, `"prime"`, `"glitched prime"`, `"boss"`, and

--- a/backend/autofighter/rooms/battle/engine.py
+++ b/backend/autofighter/rooms/battle/engine.py
@@ -150,7 +150,7 @@ async def run_battle(
                 active_target_id=None,
                 visual_queue=visual_queue,
                 ended=True,
-                turn_phase="battle_teardown",
+                turn_phase="end",
             )
         except Exception:
             pass

--- a/backend/autofighter/rooms/battle/turn_loop/turn_end.py
+++ b/backend/autofighter/rooms/battle/turn_loop/turn_end.py
@@ -49,7 +49,7 @@ async def finish_turn(
         actor,
         context.turn,
         context.run_id,
-        turn_phase="turn_end",
+        turn_phase="end",
     )
     if cycle_count:
         context.turn += cycle_count

--- a/backend/autofighter/rooms/battle/turns.py
+++ b/backend/autofighter/rooms/battle/turns.py
@@ -95,7 +95,7 @@ async def dispatch_turn_end_snapshot(
     turn: int,
     run_id: str | None,
     *,
-    turn_phase: str | None = "turn_end",
+    turn_phase: str | None = "end",
 ) -> int:
     """Advance the visual queue and emit an updated snapshot."""
 

--- a/backend/tests/test_turn_loop_summon_updates.py
+++ b/backend/tests/test_turn_loop_summon_updates.py
@@ -286,7 +286,7 @@ async def test_player_turn_emits_start_before_damage(monkeypatch):
     assert updates[damage_index]["turn_phase"] == "resolve"
 
     end_index = next(
-        (idx for idx, update in enumerate(updates) if update["turn_phase"] == "turn_end"),
+        (idx for idx, update in enumerate(updates) if update["turn_phase"] == "end"),
         None,
     )
     assert end_index is not None, "Missing turn end update"
@@ -357,7 +357,7 @@ async def test_foe_turn_emits_start_before_damage(monkeypatch):
     assert updates[damage_index]["turn_phase"] == "resolve"
 
     end_index = next(
-        (idx for idx, update in enumerate(updates) if update["turn_phase"] == "turn_end"),
+        (idx for idx, update in enumerate(updates) if update["turn_phase"] == "end"),
         None,
     )
     assert end_index is not None, "Missing turn end update"


### PR DESCRIPTION
## Summary
- tag resolve and end phase updates correctly when finishing a turn
- send the end-phase progress payload from `run_battle`
- document the new end phase and adjust summon update tests

## Testing
- uv run pytest tests/test_turn_loop_summon_updates.py

------
https://chatgpt.com/codex/tasks/task_b_68dae6d0b324832caaa49ac6291e2a20