### PR TITLE
Track battle turn phase state

### DIFF
--- a/frontend/src/lib/components/BattleTargetingOverlay.svelte
+++ b/frontend/src/lib/components/BattleTargetingOverlay.svelte
@@ -7,6 +7,11 @@
   export let combatants = [];
   export let events = [];
   export let reducedMotion = false;
+  export let turnPhase = null;
+
+  let phaseState = '';
+  let phaseContextAvailable = false;
+  let phaseAllowsArrow = true;
 
   const markerId = `target-arrow-${Math.random().toString(36).slice(2, 8)}`;
   const CANVAS_SIZE = 1000;
@@ -22,6 +27,15 @@
     if (value === undefined || value === null) return '';
     try {
       return String(value);
+    } catch {
+      return '';
+    }
+  }
+
+  function normalizePhaseState(value) {
+    if (value === undefined || value === null) return '';
+    try {
+      return String(value).trim().toLowerCase();
     } catch {
       return '';
     }
@@ -96,6 +110,9 @@
   $: targetPoint = toPoint(targetAnchor);
   $: attackerCanvas = toCanvas(attackerPoint);
   $: targetCanvas = toCanvas(targetPoint);
+  $: phaseState = normalizePhaseState(turnPhase?.state);
+  $: phaseContextAvailable = turnPhase !== null && turnPhase !== undefined;
+  $: phaseAllowsArrow = phaseContextAvailable ? ['start', 'resolve'].includes(phaseState) : true;
 
   $: arrowEvent = findColorSource();
   $: arrowColor = (() => {
@@ -111,12 +128,13 @@
   })();
 
   $: arrowVisible =
+    phaseAllowsArrow &&
     attackerCanvas &&
     targetCanvas &&
     (Math.abs(attackerCanvas.x - targetCanvas.x) > 1 || Math.abs(attackerCanvas.y - targetCanvas.y) > 1);
 
-  $: showAttackerPulse = Boolean(attackerCanvas);
-  $: showTargetPulse = Boolean(targetCanvas);
+  $: showAttackerPulse = phaseAllowsArrow && Boolean(attackerCanvas);
+  $: showTargetPulse = phaseAllowsArrow && Boolean(targetCanvas);
 </script>
 
 {#if showAttackerPulse || showTargetPulse}

--- a/frontend/src/lib/components/BattleView.svelte
+++ b/frontend/src/lib/components/BattleView.svelte
@@ -48,6 +48,17 @@
   let combatants = [];
   let activeId = null;
   let activeTargetId = null;
+  let snapshotActiveId = null;
+  let snapshotActiveTargetId = null;
+  let turnPhaseSeen = false;
+  let rawTurnPhase = null;
+  let turnPhaseState = '';
+  let turnPhaseAttackerId = null;
+  let turnPhaseTargetId = null;
+  let storedTurnPhase = null;
+  let normalizedTurnPhaseState = '';
+  let turnPhaseIsActive = false;
+  let phaseAllowsOverlays = true;
   let currentTurn = null;
   let statusPhase = null;
   let statusTimeline = [];
@@ -85,6 +96,45 @@
   // If a combatant disappears, clear stale targeting ids
   $: if (activeId && !combatantById.has(String(activeId))) activeId = null;
   $: if (activeTargetId && !combatantById.has(String(activeTargetId))) activeTargetId = null;
+  $: if (snapshotActiveId && !combatantById.has(String(snapshotActiveId))) {
+    snapshotActiveId = null;
+  }
+  $: if (snapshotActiveTargetId && !combatantById.has(String(snapshotActiveTargetId))) {
+    snapshotActiveTargetId = null;
+  }
+  $: if (turnPhaseSeen && turnPhaseAttackerId && !combatantById.has(String(turnPhaseAttackerId))) {
+    turnPhaseAttackerId = null;
+  }
+  $: if (turnPhaseSeen && turnPhaseTargetId && !combatantById.has(String(turnPhaseTargetId))) {
+    turnPhaseTargetId = null;
+  }
+
+  $: normalizedTurnPhaseState = normalizePhaseState(turnPhaseState);
+  $: turnPhaseIsActive = turnPhaseSeen && (normalizedTurnPhaseState === 'start' || normalizedTurnPhaseState === 'resolve');
+  $: storedTurnPhase = turnPhaseSeen
+    ? {
+      ...(rawTurnPhase || {}),
+      state: normalizedTurnPhaseState,
+      attacker_id: turnPhaseAttackerId ?? null,
+      target_id: turnPhaseTargetId ?? null,
+    }
+    : null;
+  $: phaseAllowsOverlays = turnPhaseSeen ? turnPhaseIsActive : true;
+  $: {
+    const nextActive = turnPhaseIsActive
+      ? (turnPhaseAttackerId ?? snapshotActiveId ?? null)
+      : turnPhaseSeen
+        ? null
+        : snapshotActiveId ?? null;
+    if (activeId !== nextActive) activeId = nextActive;
+
+    const nextTarget = turnPhaseIsActive
+      ? (turnPhaseTargetId ?? snapshotActiveTargetId ?? null)
+      : turnPhaseSeen
+        ? null
+        : snapshotActiveTargetId ?? null;
+    if (activeTargetId !== nextTarget) activeTargetId = nextTarget;
+  }
   $: foeCount = (foes || []).length;
   $: displayActionValues = Boolean(showActionValues || serverShowActionValues);
   function getFoeSizePx(count) {
@@ -138,6 +188,9 @@
     recentEvents = [];
     activeId = null;
     activeTargetId = null;
+    snapshotActiveId = null;
+    snapshotActiveTargetId = null;
+    resetTurnPhaseState();
     statusPhase = null;
     clearStatusTimeline();
     lastRunId = runId;
@@ -150,6 +203,9 @@
     recentEvents = [];
     activeId = null;
     activeTargetId = null;
+    snapshotActiveId = null;
+    snapshotActiveTargetId = null;
+    resetTurnPhaseState();
     statusPhase = null;
     clearStatusTimeline();
     currentTurn = null;
@@ -627,6 +683,75 @@
     }
   }
 
+  function normalizePhaseState(value) {
+    if (value === undefined || value === null) return '';
+    try {
+      return String(value).trim().toLowerCase();
+    } catch {
+      return '';
+    }
+  }
+
+  function extractPhaseId(phase, keys) {
+    if (!phase || typeof phase !== 'object') return undefined;
+    for (const key of keys) {
+      if (Object.prototype.hasOwnProperty.call(phase, key)) {
+        return phase[key];
+      }
+    }
+    return undefined;
+  }
+
+  function resetTurnPhaseState() {
+    turnPhaseSeen = false;
+    rawTurnPhase = null;
+    turnPhaseState = '';
+    turnPhaseAttackerId = null;
+    turnPhaseTargetId = null;
+    storedTurnPhase = null;
+    normalizedTurnPhaseState = '';
+    turnPhaseIsActive = false;
+    phaseAllowsOverlays = true;
+  }
+
+  function applyTurnPhaseSnapshot(phase) {
+    turnPhaseSeen = true;
+    if (!phase || typeof phase !== 'object') {
+      rawTurnPhase = null;
+      turnPhaseState = '';
+      turnPhaseAttackerId = null;
+      turnPhaseTargetId = null;
+      return;
+    }
+    rawTurnPhase = { ...phase };
+    turnPhaseState = normalizePhaseState(
+      phase.state ?? phase.phase_state ?? phase.phase ?? phase.status,
+    );
+    const attacker = extractPhaseId(phase, [
+      'attacker_id',
+      'attackerId',
+      'source_id',
+      'actor_id',
+      'active_id',
+    ]);
+    if (attacker !== undefined) {
+      turnPhaseAttackerId = attacker ?? null;
+    }
+    const target = extractPhaseId(phase, [
+      'target_id',
+      'targetId',
+      'defender_id',
+      'target',
+    ]);
+    if (target !== undefined) {
+      turnPhaseTargetId = target ?? null;
+    }
+    if (turnPhaseState === 'end') {
+      turnPhaseAttackerId = null;
+      turnPhaseTargetId = null;
+    }
+  }
+
   function resolveCombatantNameById(id) {
     const key = normalizeId(id);
     if (!key) return '';
@@ -1038,10 +1163,19 @@
       }
 
       if ('active_id' in snap) {
-        activeId = snap.active_id ?? null;
+        snapshotActiveId = snap.active_id ?? null;
       }
       if ('active_target_id' in snap) {
-        activeTargetId = snap.active_target_id ?? null;
+        snapshotActiveTargetId = snap.active_target_id ?? null;
+      }
+      if ('turn_phase' in snap) {
+        const nextTurnPhase =
+          snap.turn_phase && typeof snap.turn_phase === 'object'
+            ? { ...snap.turn_phase }
+            : snap.turn_phase;
+        applyTurnPhaseSnapshot(nextTurnPhase);
+      } else if (!turnPhaseSeen) {
+        resetTurnPhaseState();
       }
       if ('status_phase' in snap) {
         const nextPhase = snap.status_phase && typeof snap.status_phase === 'object' ? { ...snap.status_phase } : null;
@@ -1145,8 +1279,9 @@
     {combatants}
     events={recentEvents}
     reducedMotion={effectiveReducedMotion}
+    turnPhase={storedTurnPhase}
   />
-  {#if showStatusTimeline && statusTimeline.length}
+  {#if showStatusTimeline && statusTimeline.length && phaseAllowsOverlays}
     <div class:reduced={effectiveReducedMotion} class="status-timeline overlay-layer" aria-live="polite">
       {#each statusTimeline as chip (chip.key)}
         <div class="timeline-chip" data-state={chip.state} style={`--chip-color:${chip.color};`}>

--- a/frontend/tests/__fixtures__/ActionQueue.stub.svelte
+++ b/frontend/tests/__fixtures__/ActionQueue.stub.svelte
@@ -1,0 +1,18 @@
+<script>
+  export let queue = [];
+  export let combatants = [];
+  export let reducedMotion = false;
+  export let effectiveReducedMotion = false;
+  export let showActionValues = false;
+  export let activeId = null;
+  export let currentTurn = null;
+  export let enrage = { active: false, stacks: 0, turns: 0 };
+  export let showTurnCounter = true;
+  export let flashEnrageCounter = true;
+</script>
+
+<div
+  data-testid="queue-probe"
+  data-active-id={activeId ?? ''}
+  data-queue-length={Array.isArray(queue) ? queue.length : 0}
+></div>

--- a/frontend/tests/__fixtures__/BattleEffects.stub.svelte
+++ b/frontend/tests/__fixtures__/BattleEffects.stub.svelte
@@ -1,0 +1,5 @@
+<script>
+  export let cue = '';
+</script>
+
+<div data-testid="effects-probe" data-cue={cue ?? ''}></div>

--- a/frontend/tests/__fixtures__/BattleEventFloaters.stub.svelte
+++ b/frontend/tests/__fixtures__/BattleEventFloaters.stub.svelte
@@ -1,0 +1,11 @@
+<script>
+  export let events = [];
+  export let reducedMotion = false;
+  export let paceMs = 0;
+  export let anchors = {};
+  export let baseOffsetX = 0;
+  export let baseOffsetY = 0;
+  export let staggerMs = 0;
+</script>
+
+<div data-testid="floaters-probe"></div>

--- a/frontend/tests/__fixtures__/BattleFighterCard.stub.svelte
+++ b/frontend/tests/__fixtures__/BattleFighterCard.stub.svelte
@@ -1,0 +1,14 @@
+<script>
+  export let fighter = {};
+  export let position = 'bottom';
+  export let effectiveReducedMotion = false;
+  export let sizePx = 0;
+  export let highlight = false;
+</script>
+
+<div
+  data-testid="fighter-card"
+  data-id={fighter?.id ?? ''}
+  data-position={position}
+  data-highlight={highlight ? 'yes' : 'no'}
+></div>

--- a/frontend/tests/__fixtures__/BattleLog.stub.svelte
+++ b/frontend/tests/__fixtures__/BattleLog.stub.svelte
@@ -1,0 +1,7 @@
+<script>
+  export let logs = [];
+  export let highlightedId = null;
+  export let reducedMotion = false;
+</script>
+
+<div data-testid="battle-log" data-count={Array.isArray(logs) ? logs.length : 0} data-highlight={highlightedId ?? ''}></div>

--- a/frontend/tests/__fixtures__/BattleTargetingOverlay.stub.svelte
+++ b/frontend/tests/__fixtures__/BattleTargetingOverlay.stub.svelte
@@ -1,0 +1,17 @@
+<script>
+  export let activeId = null;
+  export let activeTargetId = null;
+  export let anchors = {};
+  export let combatants = [];
+  export let events = [];
+  export let reducedMotion = false;
+  export let turnPhase = null;
+</script>
+
+<div
+  data-testid="overlay-probe"
+  data-phase-state={turnPhase?.state ?? ''}
+  data-phase-present={turnPhase ? 'yes' : 'no'}
+  data-attacker={activeId ?? ''}
+  data-target={activeTargetId ?? ''}
+></div>

--- a/frontend/tests/__fixtures__/EnrageIndicator.stub.svelte
+++ b/frontend/tests/__fixtures__/EnrageIndicator.stub.svelte
@@ -1,0 +1,7 @@
+<script>
+  export let active = false;
+  export let reducedMotion = false;
+  export let enrageData = {};
+</script>
+
+<div data-testid="enrage-indicator" data-active={active ? 'yes' : 'no'}></div>

--- a/frontend/tests/__fixtures__/StatusIcons.stub.svelte
+++ b/frontend/tests/__fixtures__/StatusIcons.stub.svelte
@@ -1,0 +1,6 @@
+<script>
+  export let fighter = {};
+  export let compact = false;
+</script>
+
+<div data-testid="status-icons" data-fighter={fighter?.id ?? ''} data-compact={compact ? 'yes' : 'no'}></div>

--- a/frontend/tests/battle-turn-phase.vitest.js
+++ b/frontend/tests/battle-turn-phase.vitest.js
@@ -1,0 +1,230 @@
+import { render, screen, cleanup, waitFor } from '@testing-library/svelte';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { tick } from 'svelte';
+
+import OverlayStub from './__fixtures__/BattleTargetingOverlay.stub.svelte';
+import QueueStub from './__fixtures__/ActionQueue.stub.svelte';
+import FloatersStub from './__fixtures__/BattleEventFloaters.stub.svelte';
+import EffectsStub from './__fixtures__/BattleEffects.stub.svelte';
+import FighterCardStub from './__fixtures__/BattleFighterCard.stub.svelte';
+import EnrageIndicatorStub from './__fixtures__/EnrageIndicator.stub.svelte';
+import BattleLogStub from './__fixtures__/BattleLog.stub.svelte';
+import StatusIconsStub from './__fixtures__/StatusIcons.stub.svelte';
+
+vi.mock('$lib', () => ({
+  roomAction: vi.fn(),
+}));
+
+vi.mock('../src/lib/components/BattleTargetingOverlay.svelte', () => ({
+  default: OverlayStub,
+}));
+vi.mock('../src/lib/battle/ActionQueue.svelte', () => ({
+  default: QueueStub,
+}));
+vi.mock('../src/lib/components/BattleEventFloaters.svelte', () => ({
+  default: FloatersStub,
+}));
+vi.mock('../src/lib/effects/BattleEffects.svelte', () => ({
+  default: EffectsStub,
+}));
+vi.mock('../src/lib/battle/BattleFighterCard.svelte', () => ({
+  default: FighterCardStub,
+}));
+vi.mock('../src/lib/battle/BattleLog.svelte', () => ({
+  default: BattleLogStub,
+}));
+vi.mock('../src/lib/battle/StatusIcons.svelte', () => ({
+  default: StatusIconsStub,
+}));
+vi.mock('../src/lib/battle/EnrageIndicator.svelte', () => ({
+  default: EnrageIndicatorStub,
+}));
+
+import BattleView from '../src/lib/components/BattleView.svelte';
+import { roomAction } from '$lib';
+
+function clone(value) {
+  if (typeof structuredClone === 'function') {
+    return structuredClone(value);
+  }
+  return JSON.parse(JSON.stringify(value));
+}
+
+function buildSnapshot({ turnPhase, statusPhase, includeActiveIds = true } = {}) {
+  const snapshot = {
+    party: [
+      {
+        id: 'hero',
+        name: 'Hero',
+        hp: 100,
+        max_hp: 100,
+        damage_types: ['fire'],
+      },
+    ],
+    foes: [
+      {
+        id: 'goblin',
+        name: 'Goblin',
+        hp: 80,
+        max_hp: 80,
+        damage_types: ['earth'],
+      },
+    ],
+    queue: [
+      { id: 'hero' },
+      { id: 'goblin' },
+    ],
+    recent_events: [],
+    turn: 1,
+  };
+
+  if (includeActiveIds) {
+    snapshot.active_id = 'hero';
+    snapshot.active_target_id = 'goblin';
+  }
+
+  if (turnPhase !== undefined) {
+    snapshot.turn_phase = turnPhase;
+  }
+
+  if (statusPhase) {
+    snapshot.status_phase = statusPhase;
+  }
+
+  return snapshot;
+}
+
+async function settle() {
+  await Promise.resolve();
+  await tick();
+  await Promise.resolve();
+}
+
+describe('BattleView turn phase handling', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    roomAction.mockReset();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllTimers();
+    vi.clearAllMocks();
+    vi.useRealTimers();
+  });
+
+  it('persists attacker targeting through start/resolve and clears on end', async () => {
+    const statusPhaseTemplate = {
+      phase: 'dot',
+      state: 'start',
+      target_id: 'goblin',
+      effect_ids: ['burn'],
+      effect_names: ['Burn'],
+      order: 1,
+    };
+
+    const modernSnapshots = [
+      buildSnapshot({
+        turnPhase: { state: 'start', attacker_id: 'hero', target_id: 'goblin' },
+        statusPhase: clone(statusPhaseTemplate),
+      }),
+      buildSnapshot({
+        turnPhase: { state: 'resolve' },
+        statusPhase: clone({ ...statusPhaseTemplate, state: 'resolve' }),
+        includeActiveIds: false,
+      }),
+      buildSnapshot({
+        turnPhase: { state: 'end' },
+        statusPhase: clone({ ...statusPhaseTemplate, state: 'end' }),
+        includeActiveIds: false,
+      }),
+    ];
+    const fallbackSnapshot = modernSnapshots[modernSnapshots.length - 1];
+
+    roomAction.mockImplementation(() =>
+      Promise.resolve(clone(modernSnapshots.length ? modernSnapshots.shift() : fallbackSnapshot))
+    );
+
+    const { container, component } = render(BattleView, {
+      props: {
+        runId: 'modern-turn-phase',
+        active: true,
+        framerate: 10000,
+        showStatusTimeline: true,
+        showHud: false,
+        showFoes: true,
+      },
+    });
+
+    await settle();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('overlay-probe').dataset.phaseState).toBe('start');
+    });
+    expect(screen.getByTestId('overlay-probe').dataset.attacker).toBe('hero');
+    expect(screen.getByTestId('queue-probe').dataset.activeId).toBe('hero');
+    expect(container.querySelector('.status-timeline')).not.toBeNull();
+
+    await vi.advanceTimersByTimeAsync(1);
+    await settle();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('overlay-probe').dataset.phaseState).toBe('resolve');
+    });
+    expect(screen.getByTestId('overlay-probe').dataset.attacker).toBe('hero');
+    expect(screen.getByTestId('queue-probe').dataset.activeId).toBe('hero');
+    expect(container.querySelector('.status-timeline')).not.toBeNull();
+
+    await vi.advanceTimersByTimeAsync(1);
+    await settle();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('overlay-probe').dataset.phaseState).toBe('end');
+    });
+    expect(screen.getByTestId('overlay-probe').dataset.attacker).toBe('');
+    expect(screen.getByTestId('queue-probe').dataset.activeId).toBe('');
+    await waitFor(() => {
+      expect(container.querySelector('.status-timeline')).toBeNull();
+    });
+
+    component.$set({ active: false });
+    await settle();
+  });
+
+  it('falls back to legacy active fields when turn_phase is absent', async () => {
+    const legacySnapshot = buildSnapshot({
+      statusPhase: {
+        phase: 'dot',
+        state: 'start',
+        target_id: 'goblin',
+        effect_ids: ['burn'],
+        effect_names: ['Burn'],
+        order: 1,
+      },
+    });
+
+    roomAction.mockImplementation(() => Promise.resolve(clone(legacySnapshot)));
+
+    const { container, component } = render(BattleView, {
+      props: {
+        runId: 'legacy-turn-phase',
+        active: true,
+        framerate: 10000,
+        showStatusTimeline: true,
+        showHud: false,
+        showFoes: true,
+      },
+    });
+
+    await settle();
+
+    const overlay = await screen.findByTestId('overlay-probe');
+    expect(overlay.dataset.phasePresent).toBe('no');
+    expect(overlay.dataset.attacker).toBe('hero');
+    expect(screen.getByTestId('queue-probe').dataset.activeId).toBe('hero');
+    expect(container.querySelector('.status-timeline')).not.toBeNull();
+
+    component.$set({ active: false });
+    await settle();
+  });
+});


### PR DESCRIPTION
## Summary
- cache battle turn phase attacker and target details locally so overlays persist until an end snapshot arrives
- gate the targeting overlay and status timeline based on the stored turn phase
- add component tests (with stubbed children) covering modern and legacy snapshot formats

## Testing
- bun x vitest run tests/battle-turn-phase.vitest.js *(fails: vite-plugin-svelte environment error)*

------
https://chatgpt.com/codex/tasks/task_b_68daefc46dfc832c9a134c4617f6ee9a