### PR TITLE
Handle null turn_phase snapshots in BattleView

### DIFF
--- a/frontend/src/lib/components/BattleView.svelte
+++ b/frontend/src/lib/components/BattleView.svelte
@@ -1169,11 +1169,14 @@
         snapshotActiveTargetId = snap.active_target_id ?? null;
       }
       if ('turn_phase' in snap) {
-        const nextTurnPhase =
-          snap.turn_phase && typeof snap.turn_phase === 'object'
-            ? { ...snap.turn_phase }
-            : snap.turn_phase;
-        applyTurnPhaseSnapshot(nextTurnPhase);
+        const rawTurnPhase = snap.turn_phase;
+        if (rawTurnPhase === null || rawTurnPhase === undefined) {
+          resetTurnPhaseState();
+        } else {
+          const nextTurnPhase =
+            typeof rawTurnPhase === 'object' ? { ...rawTurnPhase } : rawTurnPhase;
+          applyTurnPhaseSnapshot(nextTurnPhase);
+        }
       } else if (!turnPhaseSeen) {
         resetTurnPhaseState();
       }

--- a/frontend/tests/battle-turn-phase.vitest.js
+++ b/frontend/tests/battle-turn-phase.vitest.js
@@ -227,4 +227,42 @@ describe('BattleView turn phase handling', () => {
     component.$set({ active: false });
     await settle();
   });
+
+  it('treats null turn_phase values as absent snapshots', async () => {
+    const snapshots = [
+      buildSnapshot({ turnPhase: null }),
+      buildSnapshot({}),
+    ];
+
+    roomAction.mockImplementation(() =>
+      Promise.resolve(clone(snapshots.length ? snapshots.shift() : snapshots[0]))
+    );
+
+    const { component } = render(BattleView, {
+      props: {
+        runId: 'null-turn-phase',
+        active: true,
+        framerate: 10000,
+        showStatusTimeline: true,
+        showHud: false,
+        showFoes: true,
+      },
+    });
+
+    await settle();
+
+    const overlay = await screen.findByTestId('overlay-probe');
+    expect(overlay.dataset.phasePresent).toBe('no');
+    expect(overlay.dataset.attacker).toBe('hero');
+    expect(screen.getByTestId('queue-probe').dataset.activeId).toBe('hero');
+
+    await vi.advanceTimersByTimeAsync(1);
+    await settle();
+
+    expect(screen.getByTestId('overlay-probe').dataset.attacker).toBe('hero');
+    expect(screen.getByTestId('queue-probe').dataset.activeId).toBe('hero');
+
+    component.$set({ active: false });
+    await settle();
+  });
 });


### PR DESCRIPTION
## Summary
- treat snapshots with a null `turn_phase` value as absent so the legacy targeting fallback remains active
- add a regression test covering null turn phase snapshots to verify overlay behavior stays intact

## Testing
- bun x vitest run tests/battle-turn-phase.vitest.js *(fails: vite-plugin-svelte config TypeError)*

------
https://chatgpt.com/codex/tasks/task_b_68daf646eda8832c9de8cd0bb031858f