### PR TITLE
fix: reset tank hp after baseline buff

### DIFF
--- a/backend/plugins/characters/carly.py
+++ b/backend/plugins/characters/carly.py
@@ -28,3 +28,4 @@ class Carly(PlayerBase):
         self.set_base_stat("defense", 220)
         self.set_base_stat("max_hp", 1600)
         self.base_aggro = 2.35
+        self.hp = self.max_hp

--- a/backend/plugins/characters/persona_ice.py
+++ b/backend/plugins/characters/persona_ice.py
@@ -31,3 +31,4 @@ class PersonaIce(PlayerBase):
         self.set_base_stat("defense", 210)
         self.set_base_stat("max_hp", 1650)
         self.base_aggro = 2.35
+        self.hp = self.max_hp

--- a/backend/plugins/characters/persona_light_and_dark.py
+++ b/backend/plugins/characters/persona_light_and_dark.py
@@ -33,3 +33,4 @@ class PersonaLightAndDark(PlayerBase):
         self.set_base_stat("defense", 240)
         self.set_base_stat("max_hp", 1700)
         self.base_aggro = 2.35
+        self.hp = self.max_hp


### PR DESCRIPTION
## Summary
- reset Carly, PersonaIce, and PersonaLightAndDark HP to their max after updating base stats so they spawn at full health

## Testing
- uv run pytest backend/tests/test_tank_baseline_stats.py *(fails: ModuleNotFoundError: No module named 'cryptography')*

------
https://chatgpt.com/codex/tasks/task_b_68daf9778508832cbe15b11484bf6b1c