### PR TITLE
Add configurable mitigation passes for tank characters

### DIFF
--- a/backend/autofighter/stats.py
+++ b/backend/autofighter/stats.py
@@ -141,6 +141,7 @@ class Stats:
     _base_effect_resistance: float = field(default=0.05, init=False)
     _base_vitality: float = field(default=1.0, init=False)
     _base_spd: int = field(default=10, init=False)
+    damage_reduction_passes: int = 1
 
     # Damage type and other permanent attributes
     damage_type: DamageTypeBase = field(default_factory=Generic)
@@ -747,7 +748,16 @@ class Stats:
         vit = vit if vit > EPS else EPS
         mit = mit if mit > EPS else EPS
         denom = defense_term * vit * mit
-        amount = ((amount ** 2) * src_vit) / denom
+        passes = getattr(self, "damage_reduction_passes", 1)
+        try:
+            passes = int(passes)
+        except Exception:
+            passes = 1
+        passes = max(1, passes)
+        mitigated_amount = amount
+        for _ in range(passes):
+            mitigated_amount = ((mitigated_amount ** 2) * src_vit) / denom
+        amount = mitigated_amount
         # Enrage: increase damage taken globally by N% per enrage stack
         enr = get_enrage_percent()
         if enr > 0:

--- a/backend/plugins/characters/carly.py
+++ b/backend/plugins/characters/carly.py
@@ -24,6 +24,7 @@ class Carly(PlayerBase):
 
     def __post_init__(self) -> None:
         super().__post_init__()
+        self.damage_reduction_passes = 2
         self.set_base_stat("mitigation", 4.0)
         self.set_base_stat("defense", 220)
         self.set_base_stat("max_hp", 1600)

--- a/backend/plugins/characters/persona_ice.py
+++ b/backend/plugins/characters/persona_ice.py
@@ -27,6 +27,7 @@ class PersonaIce(PlayerBase):
 
     def __post_init__(self) -> None:
         super().__post_init__()
+        self.damage_reduction_passes = 2
         self.set_base_stat("mitigation", 4.0)
         self.set_base_stat("defense", 210)
         self.set_base_stat("max_hp", 1650)

--- a/backend/plugins/characters/persona_light_and_dark.py
+++ b/backend/plugins/characters/persona_light_and_dark.py
@@ -29,6 +29,7 @@ class PersonaLightAndDark(PlayerBase):
 
     def __post_init__(self) -> None:
         super().__post_init__()
+        self.damage_reduction_passes = 2
         self.set_base_stat("mitigation", 4.0)
         self.set_base_stat("defense", 240)
         self.set_base_stat("max_hp", 1700)

--- a/backend/tests/test_damage_reduction_passes.py
+++ b/backend/tests/test_damage_reduction_passes.py
@@ -1,0 +1,70 @@
+import pytest
+
+from autofighter.stats import get_enrage_percent
+from autofighter.stats import set_battle_active
+from plugins.characters.carly import Carly
+
+
+def _calculate_expected_damage(stats: Carly, raw_amount: float, passes: int) -> int:
+    src_vit = 1.0
+    eps = 1e-6
+    defense_term = max(stats.defense ** 5, 1)
+    vit = float(stats.vitality)
+    vit = vit if vit > eps else eps
+    mit = float(stats.mitigation)
+    mit = mit if mit > eps else eps
+    denom = defense_term * vit * mit
+    try:
+        passes = int(passes)
+    except Exception:
+        passes = 1
+    passes = max(1, passes)
+    mitigated = raw_amount
+    for _ in range(passes):
+        mitigated = ((mitigated ** 2) * src_vit) / denom
+    enrage = get_enrage_percent()
+    if enrage > 0:
+        mitigated *= 1.0 + enrage
+    return max(int(mitigated), 1)
+
+
+@pytest.mark.asyncio
+async def test_carly_damage_reduction_uses_two_passes():
+    raw_damage = 50
+
+    carly = Carly()
+    carly.set_base_stat("defense", 10)
+    carly.set_base_stat("mitigation", 1.0)
+    carly.set_base_stat("vitality", 1.0)
+    carly.hp = carly.max_hp
+
+    set_battle_active(True)
+    try:
+        expected = _calculate_expected_damage(
+            carly,
+            raw_damage,
+            getattr(carly, "damage_reduction_passes", 1),
+        )
+        damage = await carly.apply_damage(raw_damage)
+    finally:
+        set_battle_active(False)
+
+    assert damage == expected
+    assert carly.last_damage_taken == expected
+
+    baseline = Carly()
+    baseline.set_base_stat("defense", 10)
+    baseline.set_base_stat("mitigation", 1.0)
+    baseline.set_base_stat("vitality", 1.0)
+    baseline.damage_reduction_passes = 1
+    baseline.hp = baseline.max_hp
+
+    set_battle_active(True)
+    try:
+        baseline_expected = _calculate_expected_damage(baseline, raw_damage, 1)
+        baseline_damage = await baseline.apply_damage(raw_damage)
+    finally:
+        set_battle_active(False)
+
+    assert baseline_damage == baseline_expected
+    assert damage <= baseline_damage


### PR DESCRIPTION
## Summary
- add a configurable `damage_reduction_passes` field to `Stats` and loop mitigation accordingly
- configure Carly, Persona Light and Dark, and Persona Ice to leverage two reduction passes
- cover the new behavior with a regression test that validates the double-pass mitigation result

## Testing
- uv run pytest tests/test_damage_reduction_passes.py

------
https://chatgpt.com/codex/tasks/task_b_68dafc7909b8832cb1173148a25980c6