### PR TITLE
feat: drive battle effects via turn phases

### DIFF
--- a/frontend/tests/__fixtures__/BattleEffects.stub.svelte
+++ b/frontend/tests/__fixtures__/BattleEffects.stub.svelte
@@ -1,5 +1,11 @@
 <script>
   export let cue = '';
+  let lastCue = '';
+  $: {
+    if (cue && String(cue).trim()) {
+      lastCue = cue;
+    }
+  }
 </script>
 
-<div data-testid="effects-probe" data-cue={cue ?? ''}></div>
+<div data-testid="effects-probe" data-cue={cue ?? ''} data-last-cue={lastCue}></div>


### PR DESCRIPTION
## Summary
- trigger battle effect cues when turn_phase snapshots reach the start state and map the current damage metadata to element-themed animations
- hold HP overlay drains until resolve/end phases and gracefully reset battle state when runs halt or restart
- expand the BattleView tests to cover the start→resolve→end flow and the legacy snapshots without turn_phase, adding a stub probe to capture the last effect cue

## Testing
- bun x vitest run battle-turn-phase.vitest.js *(fails: upstream Svelte/Vitest integration lacks loader context as documented in frontend/.codex/implementation/metadata-conditional-checklist.md)*

------
https://chatgpt.com/codex/tasks/task_b_68dafc86b370832ca2aeb444f9aee902