### PR TITLE
Update persona duality stack presentation

### DIFF
--- a/backend/plugins/passives/normal/persona_light_and_dark_duality.py
+++ b/backend/plugins/passives/normal/persona_light_and_dark_duality.py
@@ -23,8 +23,8 @@ class PersonaLightAndDarkDuality:
     id = "persona_light_and_dark_duality"
     name = "Twin Bastion Cycle"
     trigger = ["turn_start", "action_taken"]
-    max_stacks = 1
-    stack_display = "toggle"
+    max_stacks = 5
+    stack_display = "pips"
 
     _persona_state: ClassVar[dict[int, str]] = {}
     _stance_rank: ClassVar[dict[int, int]] = {}
@@ -335,6 +335,18 @@ class PersonaLightAndDarkDuality:
             return float(fallback)
         except Exception:
             return 0.0
+
+    @classmethod
+    def get_stacks(cls, target: "Stats") -> dict[str, int | str | None]:
+        entity_id = id(target)
+        rank = cls._stance_rank.get(entity_id, 1)
+        persona = cls._persona_state.get(entity_id)
+        return {
+            "count": min(rank, 3),
+            "rank": rank,
+            "persona": persona,
+            "flips": cls._flip_counts.get(entity_id, 0),
+        }
 
     @classmethod
     def get_persona(cls, target: "Stats") -> str | None:


### PR DESCRIPTION
## Summary
- switch Twin Bastion Cycle to pip-based stack reporting with capped counts and persona details
- add a passive stack test that exercises PassiveRegistry.describe for the persona duality passive

## Testing
- [x] Backend tests (`uv run pytest tests/test_passive_stacks.py`)
- [ ] Frontend tests
- [x] Linting (`uv run ruff check plugins/passives/normal/persona_light_and_dark_duality.py tests/test_passive_stacks.py --fix`)
- [ ] Doc sync updates (README and `.codex/implementation` docs; link tasks below)


------
https://chatgpt.com/codex/tasks/task_b_68db001ea970832c83b777b093dd7840