### PR TITLE
Stage battle animations across turn phases

### DIFF
--- a/frontend/tests/__fixtures__/BattleEventFloaters.stub.svelte
+++ b/frontend/tests/__fixtures__/BattleEventFloaters.stub.svelte
@@ -8,4 +8,17 @@
   export let staggerMs = 0;
 </script>
 
-<div data-testid="floaters-probe"></div>
+<script>
+  $: eventCount = Array.isArray(events) ? events.length : 0;
+  $: eventTypes = Array.isArray(events) ? events.map(evt => evt?.type || '').join(',') : '';
+  $: totalAmount = Array.isArray(events)
+    ? events.reduce((sum, evt) => sum + Number(evt?.amount ?? 0), 0)
+    : 0;
+</script>
+
+<div
+  data-testid="floaters-probe"
+  data-count={eventCount}
+  data-types={eventTypes}
+  data-total={totalAmount}
+></div>


### PR DESCRIPTION
## Summary
- Stage elemental, ultimate, heal, and DoT visuals using start-phase metadata before HP adjustments apply
- Defer floater creation and HP bar transitions until resolve snapshots via queued batches and target fractions
- Expand turn-phase tests and floater stub diagnostics to cover normal attacks, ultimates, healing, and DoT sequencing
- Align ultimate cinematic effect mapping with the game's supported damage types

## Testing
- bun x vitest run tests/battle-turn-phase.vitest.js *(fails: TypeError: Cannot read properties of undefined (reading 'config') from @sveltejs/vite-plugin-svelte)*

------
https://chatgpt.com/codex/tasks/task_b_68db095e99cc832c98ea94e717e6e611