### PR TITLE
Fix: hide enemy summons from main foe roster

### DIFF
--- a/frontend/src/lib/components/BattleView.svelte
+++ b/frontend/src/lib/components/BattleView.svelte
@@ -1675,8 +1675,35 @@
       }
 
       if (snap.foes) {
+        const foeSummonIds = (() => {
+          const set = new Set();
+          try {
+            for (const list of foeSummons.values()) {
+              for (const s of list) {
+                const ident = getSummonIdentifier(s);
+                if (ident) set.add(ident);
+                if (Array.isArray(s?.anchorIds)) {
+                  for (const anchor of s.anchorIds) {
+                    if (anchor === undefined || anchor === null) continue;
+                    try {
+                      const str = String(anchor);
+                      if (str) set.add(str);
+                    } catch {}
+                  }
+                }
+              }
+            }
+          } catch {}
+          return set;
+        })();
+
         const prevById = new Map((foes || []).map(f => [f.id, f]));
-        const enrichedFoes = (snap.foes || []).map(f => {
+        const baseFoes = (snap.foes || []).filter(f => {
+          const id = (typeof f === 'object' ? f?.id : f) || '';
+          const isSummon = typeof f === 'object' && (f?.summon_type || f?.type === 'summon' || f?.is_summon);
+          return id && !isSummon && !foeSummonIds.has(id);
+        });
+        const enrichedFoes = baseFoes.map(f => {
           const hpKey = combatantKey('foe', f?.id);
           trackHp(hpKey, f?.hp, f?.max_hp);
           let elem =


### PR DESCRIPTION
## Summary
- filter battle snapshots to drop foe entries that are clearly summons or match recorded summon identifiers
- continue enriching the remaining foes so summon lists only surface in the dedicated summon slots

## Testing
- [ ] Backend tests
- [ ] Frontend tests (blocked: vite build waits on unavailable backend service)
- [x] Linting
- [ ] Doc sync updates (README and `.codex/implementation` docs; link tasks below)

## Checklist
- [ ] Linked or updated relevant `.codex/tasks` entries
- [ ] Updated player roster and foe docs if adding or modifying fighters or enemies
- [ ] Referenced `.codex/implementation/ui-animation-guidelines.md` when adding UI animations

------
https://chatgpt.com/codex/tasks/task_b_68dc3c0917d8832ca014cea21df362dc