### PR TITLE
Fix reactive loop when loading battle review details

### DIFF
--- a/frontend/src/lib/components/battle-review/BattleReviewMenu.svelte
+++ b/frontend/src/lib/components/battle-review/BattleReviewMenu.svelte
@@ -118,9 +118,13 @@
 
   $: if (selectedRunId) {
     loadRunDetails(selectedRunId);
-  } else {
+  }
+
+  $: if (!selectedRunId) {
     runDetails = null;
-    runStatus = runsStatus === 'ready' ? 'idle' : runStatus;
+    if (runsStatus === 'ready') {
+      runStatus = 'idle';
+    }
   }
 
   $: floors = groupBattleSummariesByFloor(


### PR DESCRIPTION
## Summary
- stop the run detail loader effect from depending on run status updates
- reset idle state for runs without re-triggering the fetch loop

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68dc5230e5dc832c991961bce26d6265