### PR TITLE
feat: add explicit loading states to battle review

### DIFF
--- a/frontend/src/lib/components/battle-review/EventsDrawer.svelte
+++ b/frontend/src/lib/components/battle-review/EventsDrawer.svelte
@@ -1,6 +1,7 @@
 <script>
   import { getContext } from 'svelte';
   import { BATTLE_REVIEW_CONTEXT_KEY } from '../../systems/battleReview/state.js';
+  import TripleRingSpinner from '../TripleRingSpinner.svelte';
 
   const MAX_EVENTS = 250;
   const context = getContext(BATTLE_REVIEW_CONTEXT_KEY);
@@ -11,7 +12,8 @@
     loadEvents,
     timeline,
     timelineCursor,
-    setTimelineCursor
+    setTimelineCursor,
+    reducedMotion
   } = context;
 
   $: if ($eventsOpen && $eventsStatus === 'idle') {
@@ -22,7 +24,7 @@
   $: emptyMessage = buildEmptyMessage($eventsStatus, filteredEvents, $timeline?.hasData ?? false);
 
   function buildEmptyMessage(status, events, hasData) {
-    if (status === 'loading') return 'Loading events…';
+    if (status === 'loading') return '';
     if (events.length) return '';
     if (!hasData) return 'No timeline data is available yet.';
     return 'No events matched the current filters.';
@@ -64,7 +66,12 @@
       <button type="button" class="close-btn" on:click={toggleEvents}>Close</button>
     </header>
     <div class="drawer-body">
-      {#if emptyMessage}
+      {#if $eventsStatus === 'loading'}
+        <div class="drawer-loading" role="status" aria-live="polite">
+          <TripleRingSpinner reducedMotion={$reducedMotion} />
+          <span>Loading events…</span>
+        </div>
+      {:else if emptyMessage}
         <p class="drawer-message">{emptyMessage}</p>
       {:else}
         <ul class="events-list">
@@ -144,6 +151,20 @@
   .drawer-body {
     flex: 1;
     overflow-y: auto;
+  }
+
+  .drawer-loading {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 0.75rem;
+    padding: 1.5rem 0;
+    color: rgba(226, 232, 240, 0.85);
+  }
+
+  .drawer-loading span {
+    font-size: 0.85rem;
   }
 
   .drawer-message {

--- a/frontend/src/lib/components/battle-review/TimelineRegion.svelte
+++ b/frontend/src/lib/components/battle-review/TimelineRegion.svelte
@@ -5,6 +5,7 @@
     BATTLE_REVIEW_CONTEXT_KEY,
     createDefaultTimelineFilters
   } from '../../systems/battleReview/state.js';
+  import TripleRingSpinner from '../TripleRingSpinner.svelte';
 
   const context = getContext(BATTLE_REVIEW_CONTEXT_KEY);
   const {
@@ -20,7 +21,8 @@
     displayFoes,
     currentTab,
     eventsStatus,
-    loadEvents
+    loadEvents,
+    reducedMotion
   } = context;
 
   const FILTER_ID_PATTERN = /[^a-z0-9._:-]/gi;
@@ -438,6 +440,13 @@
     </button>
   </div>
 
+  {#if $eventsStatus === 'loading'}
+    <div class="events-loading" role="status" aria-live="polite">
+      <TripleRingSpinner reducedMotion={$reducedMotion} duration="1s" />
+      <span>Loading events…</span>
+    </div>
+  {/if}
+
   {#if projection?.hasData}
     <div class="timeline-summary">
       <div class="summary-chip">
@@ -635,6 +644,18 @@
     align-items: center;
     font-size: 0.78rem;
     color: rgba(226, 232, 240, 0.85);
+  }
+
+  .events-loading {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.6rem;
+    margin: 0.5rem 0 0;
+    color: rgba(226, 232, 240, 0.85);
+  }
+
+  .events-loading span {
+    font-size: 0.85rem;
   }
 
   .control-group {

--- a/frontend/tests/battle-review-architecture.test.js
+++ b/frontend/tests/battle-review-architecture.test.js
@@ -8,6 +8,7 @@ import {
 } from '../src/lib/systems/battleReview/state.js';
 
 const tabsShell = readFileSync(join(import.meta.dir, '../src/lib/components/battle-review/TabsShell.svelte'), 'utf8');
+const battleReview = readFileSync(join(import.meta.dir, '../src/lib/components/BattleReview.svelte'), 'utf8');
 
 function sampleSummary() {
   return {
@@ -100,5 +101,11 @@ describe('battle review shell layout', () => {
     expect(tabsShell).toContain('timeline-wrapper');
     expect(tabsShell).toContain('<TimelineRegion />');
     expect(tabsShell).toContain('<EntityTableContainer />');
+  });
+
+  test('battle review gate keeps layout behind summary status', () => {
+    expect(battleReview).toContain('<TripleRingSpinner');
+    expect(battleReview).toContain("$summaryStatus === 'ready'");
+    expect(battleReview).toContain("status-banner loading");
   });
 });


### PR DESCRIPTION
## Summary
- gate the battle review layout on the summary status and surface loading and error banners that respect reduced motion
- surface event loading affordances in the timeline region and events drawer using the shared spinner component
- extend the battle review architecture test to assert the spinner reference and summary status guard

## Testing
- bun test ./tests/battle-review-architecture.test.js

------
https://chatgpt.com/codex/tasks/task_b_68dc85a31b74832c8a151375cd72369d