### PR TITLE
Fix battle review caching between identical rooms

### DIFF
--- a/frontend/src/lib/components/reviewCache.js
+++ b/frontend/src/lib/components/reviewCache.js
@@ -1,0 +1,20 @@
+export function getReviewKeyTransition({ reviewOpen, reviewKey, lastKey }) {
+  if (!reviewOpen) {
+    return {
+      open: false,
+      nextKey: null,
+      shouldFetch: false,
+      shouldReset: lastKey !== null,
+      clearedKey: lastKey
+    };
+  }
+
+  const changed = reviewKey !== lastKey;
+  return {
+    open: true,
+    nextKey: reviewKey,
+    shouldFetch: changed,
+    shouldReset: changed,
+    clearedKey: null
+  };
+}

--- a/frontend/tests/overlay-state.test.js
+++ b/frontend/tests/overlay-state.test.js
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, test } from 'bun:test';
 import { get } from 'svelte/store';
+import { getReviewKeyTransition } from '../src/lib/components/reviewCache.js';
 import {
   overlayStateStore,
   overlayBlocking,
@@ -66,5 +67,38 @@ describe('overlay state gating helpers', () => {
     });
     expect(get(overlayBlocking)).toBe(false);
     expect(get(haltSync)).toBe(false);
+  });
+
+  test('review key transition keeps review ready after repeated battle index', () => {
+    const reviewKey = 'run-1|5';
+    let lastKey = null;
+
+    let transition = getReviewKeyTransition({
+      reviewOpen: true,
+      reviewKey,
+      lastKey
+    });
+    expect(transition.shouldFetch).toBe(true);
+    if (transition.shouldReset) {
+      setReviewOverlayState({ open: true, ready: false });
+    }
+    lastKey = transition.nextKey;
+
+    setReviewOverlayState({ ready: true });
+    expect(overlayStateStore.getSnapshot().reviewReady).toBe(true);
+
+    transition = getReviewKeyTransition({
+      reviewOpen: true,
+      reviewKey,
+      lastKey
+    });
+    expect(transition.shouldFetch).toBe(false);
+    if (transition.shouldReset) {
+      setReviewOverlayState({ open: true, ready: false });
+    } else {
+      setReviewOverlayState({ open: true });
+    }
+
+    expect(overlayStateStore.getSnapshot().reviewReady).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- track the last processed battle review key in `OverlayHost` so repeated room updates keep their cached summary
- factor the key transition logic into a dedicated helper for reuse and regression coverage
- extend the overlay state tests to cover repeated battle index updates and ensure the review overlay stays ready once loaded

## Testing
- ./run-tests.sh *(fails: known backend/unit expectations currently unmet)*
- bun test tests/overlay-state.test.js

------
https://chatgpt.com/codex/tasks/task_b_68dc8a4b124c832c9fd96ddda71de289