### PR TITLE
Fix battle completion detection for polling orchestrator

### DIFF
--- a/frontend/src/lib/systems/pollingOrchestrator.js
+++ b/frontend/src/lib/systems/pollingOrchestrator.js
@@ -385,7 +385,7 @@ export function createBattlePollingController({
       }
 
       const snapHasRewards = hasRewards(snap);
-      const snapCompleted = Boolean(snap?.awaiting_next) || Boolean(snap?.next_room) || snap?.result === 'defeat';
+      const snapCompleted = Boolean(snap?.awaiting_next) || snap?.result === 'defeat';
       const partyDead = Array.isArray(snap?.party) && snap.party.length > 0 && snap.party.every((m) => (m?.hp ?? 1) <= 0);
       const foesDead = Array.isArray(snap?.foes) && snap.foes.length > 0 && snap.foes.every((f) => (f?.hp ?? 1) <= 0);
       const combatOver = partyDead || foesDead;


### PR DESCRIPTION
## Summary
- stop treating `next_room` as a battle completion signal so in-progress fights keep polling
- continue syncing `next_room` metadata once completion is confirmed to keep room headers updated

## Testing
- bun run lint

------
https://chatgpt.com/codex/tasks/task_b_68dcc1a35c3c832c96e00e7985c4cd2a