### PR TITLE
fix: restore battle review menu styles after MenuPanel wrap

### DIFF
--- a/frontend/src/lib/components/battle-review/BattleReviewMenu.svelte
+++ b/frontend/src/lib/components/battle-review/BattleReviewMenu.svelte
@@ -256,7 +256,7 @@
 </MenuPanel>
 
 <style>
-  .battle-review-menu {
+  :global(.battle-review-menu) {
     gap: 1rem;
     color: #fff;
   }


### PR DESCRIPTION
## Summary
- mark the battle review menu root class as global so MenuPanel still receives the intended spacing and text color

## Testing
- not run (not needed)

------
https://chatgpt.com/codex/tasks/task_b_68dcc4a3e414832cb65129c70bf1c5da