### PR TITLE
Clarify Greed Engine HP loss text

### DIFF
--- a/backend/plugins/relics/greed_engine.py
+++ b/backend/plugins/relics/greed_engine.py
@@ -8,13 +8,16 @@ from plugins.relics._base import safe_async_task
 
 @dataclass
 class GreedEngine(RelicBase):
-    """Lose HP each turn but gain extra gold and rare drops."""
+    """Lose HP on every combat action but gain extra gold and rare drops."""
 
     id: str = "greed_engine"
     name: str = "Greed Engine"
     stars: int = 3
     effects: dict[str, float] = field(default_factory=dict)
-    about: str = "Lose HP each turn but gain extra gold and rare drops."
+    about: str = (
+        "Party loses HP on every combat action via the shared turn_start hook "
+        "but gains extra gold and rare drops."
+    )
 
     async def apply(self, party) -> None:
         await super().apply(party)
@@ -69,6 +72,6 @@ class GreedEngine(RelicBase):
         hp = 1 + 0.5 * (stacks - 1)
         rdr = 0.5 + 0.1 * (stacks - 1)
         return (
-            f"Party loses {hp:.1f}% HP each turn, gains {gold:.0f}% more gold, "
+            f"Party loses {hp:.1f}% HP on every combat action, gains {gold:.0f}% more gold, "
             f"and increases rare drop rate by {rdr:.1f}%."
         )

--- a/backend/tests/test_relic_effects_advanced.py
+++ b/backend/tests/test_relic_effects_advanced.py
@@ -19,11 +19,12 @@ from autofighter.relics import award_relic
 from autofighter.rooms.battle.turn_loop import player_turn
 from autofighter.stats import BUS
 from autofighter.stats import Stats
+from plugins.characters._base import PlayerBase
 from plugins.effects.aftertaste import Aftertaste
 import plugins.event_bus as event_bus_module
-from plugins.characters._base import PlayerBase
 import plugins.relics._base as relic_base_module
 import plugins.relics.echoing_drum as echoing_drum_module
+from plugins.relics.greed_engine import GreedEngine
 import plugins.relics.timekeepers_hourglass as hourglass_module
 
 
@@ -322,6 +323,22 @@ async def test_greed_engine_stacks():
     assert a.hp == 200 - int(200 * (0.01 + 0.005))
     await BUS.emit_async("gold_earned", 100)
     assert party.gold == int(100 * (0.5 + 0.25))
+
+
+def test_greed_engine_text_updates():
+    relic = GreedEngine()
+
+    assert (
+        relic.about
+        == "Party loses HP on every combat action via the shared turn_start hook "
+        "but gains extra gold and rare drops."
+    )
+
+    assert (
+        relic.describe(1)
+        == "Party loses 1.0% HP on every combat action, gains 50% more gold, and "
+        "increases rare drop rate by 0.5%."
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- clarify the Greed Engine blurb to note HP loss on every combat action via the shared turn_start hook while keeping reward messaging
- sync the describe helper wording and add a regression test that locks the tooltip text

## Testing
- [x] Backend tests (`uv run pytest tests/test_relic_effects_advanced.py -k greed_engine_text_updates`)
- [ ] Frontend tests
- [x] Linting (`uv run ruff check plugins/relics/greed_engine.py tests/test_relic_effects_advanced.py`)
- [ ] Doc sync updates (README and `.codex/implementation` docs; link tasks below)

## Checklist
- [ ] Linked or updated relevant `.codex/tasks` entries
- [ ] Updated player roster and foe docs if adding or modifying fighters or enemies
- [ ] Referenced `.codex/implementation/ui-animation-guidelines.md` when adding UI animations

------
https://chatgpt.com/codex/tasks/task_b_68dcd0deb71c832c94e1ce700ca28eca