### PR TITLE
fix(frontend): apply reduced motion override

### DIFF
--- a/frontend/src/lib/components/battle/EffectsChargeContainer.svelte
+++ b/frontend/src/lib/components/battle/EffectsChargeContainer.svelte
@@ -218,9 +218,12 @@
     opacity: 0.82;
   }
 
-  .effects-charge-container.reduced .charge-fill,
+  .effects-charge-container.reduced .charge-fill {
+    transition: none;
+  }
+
   @media (prefers-reduced-motion: reduce) {
-    .charge-fill {
+    .effects-charge-container .charge-fill {
       transition: none;
     }
   }


### PR DESCRIPTION
## Summary
- separate the reduced-motion override selector from the media query block so custom reducedMotion props disable transitions
- retain the prefers-reduced-motion media query override for OS-level motion preferences

## Testing
- not run (CSS-only change)


------
https://chatgpt.com/codex/tasks/task_b_68dcd7ffbb94832c9d4e3ce02be5253a