### PR TITLE
Add Rusty Buckle effect charge snapshots

### DIFF
--- a/backend/autofighter/rooms/battle/engine.py
+++ b/backend/autofighter/rooms/battle/engine.py
@@ -20,6 +20,7 @@ from autofighter.summons.base import Summon
 from autofighter.summons.manager import SummonManager
 
 from ...party import Party
+from . import snapshots as _snapshots
 from .events import handle_battle_end
 from .events import handle_battle_start
 from .pacing import _EXTRA_TURNS
@@ -266,6 +267,7 @@ async def run_battle(
             "items": [],
         }
         dealt, taken = _damage_totals()
+        effects_charge = _snapshots.get_effect_charges(run_id)
         if run_id is not None:
             try:
                 await log_battle_summary(
@@ -307,6 +309,7 @@ async def run_battle(
             "rdr": temp_rdr,
             "action_queue": action_queue_snapshot,
             "ended": True,
+            **({"effects_charge": effects_charge} if effects_charge is not None else {}),
         }
 
     dealt, taken = _damage_totals()
@@ -345,6 +348,7 @@ async def run_battle(
         action_queue_snapshot=action_queue_snapshot,
         battle_logger=battle_logger,
         exp_reward=exp_reward,
+        run_id=run_id,
     )
 
 

--- a/backend/autofighter/rooms/battle/events.py
+++ b/backend/autofighter/rooms/battle/events.py
@@ -81,6 +81,10 @@ async def handle_battle_end(
     except Exception:
         pass
 
+    run_id = _resolve_run_id(*members, *foes)
+    if run_id:
+        _snapshots.clear_effect_charges(run_id)
+
 
 def _resolve_run_id(*entities: Any) -> str | None:
     return _snapshots.resolve_run_id(*entities)

--- a/backend/autofighter/rooms/battle/progress.py
+++ b/backend/autofighter/rooms/battle/progress.py
@@ -214,6 +214,9 @@ async def build_battle_progress_payload(
         status_phase = _snapshots.get_status_phase(run_id)
         if status_phase is not None:
             payload["status_phase"] = status_phase
+        charges = _snapshots.get_effect_charges(run_id)
+        if charges is not None:
+            payload["effects_charge"] = charges
 
     if ended is not None:
         payload["ended"] = ended

--- a/backend/autofighter/rooms/battle/resolution.py
+++ b/backend/autofighter/rooms/battle/resolution.py
@@ -16,6 +16,7 @@ from plugins.damage_types import ALL_DAMAGE_TYPES
 from plugins.relics.fallback_essence import FallbackEssence
 
 from ...party import Party
+from . import snapshots as _snapshots
 from .rewards import _apply_rdr_to_stars
 from .rewards import _calc_gold
 from .rewards import _pick_card_stars
@@ -51,6 +52,7 @@ async def resolve_rewards(
     action_queue_snapshot: dict[str, Any],
     battle_logger: BattleLogger | None,
     exp_reward: int,
+    run_id: str | None,
 ) -> dict[str, Any]:
     """Assemble the battle victory payload including loot and choices."""
 
@@ -187,7 +189,7 @@ async def resolve_rewards(
         items,
     )
 
-    return {
+    result = {
         "result": "boss" if room.strength > 1.0 else "battle",
         "party": party_data,
         "party_summons": party_summons,
@@ -211,3 +213,7 @@ async def resolve_rewards(
         "action_queue": action_queue_snapshot,
         "ended": True,
     }
+    charges = _snapshots.get_effect_charges(run_id)
+    if charges is not None:
+        result["effects_charge"] = charges
+    return result

--- a/backend/plugins/relics/rusty_buckle.py
+++ b/backend/plugins/relics/rusty_buckle.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 from dataclasses import field
 import random
 
+from autofighter.rooms.battle import snapshots as battle_snapshots
 from autofighter.stats import BUS
 from plugins.effects.aftertaste import Aftertaste
 from plugins.relics._base import RelicBase
@@ -48,6 +49,50 @@ class RustyBuckle(RelicBase):
 
             for ally in party.members:
                 state["prev_hp"][id(ally)] = ally.hp
+
+        def _build_charge_payload() -> list[dict[str, object]] | None:
+            current_state = getattr(party, "_rusty_buckle_state", None)
+            if not isinstance(current_state, dict):
+                return None
+            stacks = max(int(current_state.get("stacks", 0)), 0)
+            party_max_hp = int(current_state.get("party_max_hp", 0))
+            hp_lost = int(current_state.get("hp_lost", 0))
+            triggers = max(int(current_state.get("triggers", 0)), 0)
+            if stacks <= 0 or party_max_hp <= 0:
+                return None
+            threshold = party_max_hp * (1 + 0.5 * (stacks - 1))
+            if threshold <= 0:
+                progress = 0.0
+            else:
+                spent = threshold * triggers
+                remaining = max(float(hp_lost) - float(spent), 0.0)
+                progress = remaining / float(threshold)
+            progress = max(0.0, min(progress, 1.0))
+            lost_pct = (hp_lost / party_max_hp) if party_max_hp else 0.0
+            dmg = int(party_max_hp * lost_pct * 0.005)
+            hits = max(0, 5 + 3 * (stacks - 1))
+            payload = {
+                "id": self.id,
+                "name": self.name,
+                "stacks": stacks,
+                "progress": progress,
+                "hp_lost": hp_lost,
+                "threshold_per_charge": int(threshold),
+                "triggers": triggers,
+                "hits": hits,
+                "estimated_damage_per_hit": dmg,
+                "estimated_total_damage": dmg * hits,
+            }
+            return [payload]
+
+        def _update_charge_snapshot() -> None:
+            run_id = battle_snapshots.resolve_run_id(party)
+            if not run_id:
+                return
+            payload = _build_charge_payload()
+            battle_snapshots.set_effect_charges(run_id, payload)
+
+        _update_charge_snapshot()
 
         async def _turn_start(entity) -> None:
             from plugins.characters.foe_base import FoeBase
@@ -133,10 +178,13 @@ class RustyBuckle(RelicBase):
                         foe = random.choice(current_state["foes"])
                         safe_async_task(Aftertaste(base_pot=dmg).apply(target, foe))
 
+            _update_charge_snapshot()
+
         def _heal(target, healer, _amount, *_args) -> None:
             current_state = getattr(party, "_rusty_buckle_state", state)
             if target in party.members:
                 current_state["prev_hp"][id(target)] = target.hp
+            _update_charge_snapshot()
 
         def _cleanup(*_args) -> None:
             self.clear_subscriptions(party)
@@ -145,6 +193,7 @@ class RustyBuckle(RelicBase):
                 current_state["foes"].clear()
             if current_state is state:
                 delattr(party, "_rusty_buckle_state")
+            _update_charge_snapshot()
 
         self.subscribe(party, "turn_start", _turn_start)
         self.subscribe(party, "damage_taken", _damage)

--- a/backend/tests/test_battle_snapshots_module.py
+++ b/backend/tests/test_battle_snapshots_module.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import importlib
+from pathlib import Path
 import sys
 import types
-from pathlib import Path
 
 import pytest
 
@@ -94,3 +94,19 @@ def test_mutate_snapshot_overlay_updates_snapshot_fields(snapshot_env) -> None:
     assert snapshot["recent_events"] == [event_payload]
 
     assert snapshots_module.get_status_phase(run_id) == status_payload
+
+
+def test_prepare_snapshot_overlay_clears_effect_charges(snapshot_env) -> None:
+    snapshots_module, battle_snapshots = snapshot_env
+    run_id = "snapshot-effects"
+
+    combatant = Stats()
+    combatant.id = "effect-tester"
+
+    snapshots_module.set_effect_charges(run_id, {"id": "example", "progress": 1.0})
+    assert battle_snapshots[run_id]["effects_charge"][0]["id"] == "example"
+
+    snapshots_module.prepare_snapshot_overlay(run_id, [combatant])
+
+    assert snapshots_module.get_effect_charges(run_id) is None
+    assert "effects_charge" not in battle_snapshots[run_id]

--- a/backend/tests/test_rdr.py
+++ b/backend/tests/test_rdr.py
@@ -171,6 +171,7 @@ async def test_floor_boss_guarantees_ticket_drop(monkeypatch):
         action_queue_snapshot={},
         battle_logger=None,
         exp_reward=0,
+        run_id=None,
     )
     tickets = [item for item in result["loot"]["items"] if item["id"] == "ticket"]
     assert tickets and tickets[0]["stars"] == 0


### PR DESCRIPTION
## Summary
- add helpers in the battle snapshot module to persist effect charge payloads and clear them on battle start or end
- propagate stored effect charge data through battle progress, defeat, and resolution payloads so downstream consumers always receive it
- update Rusty Buckle to publish structured charge metadata and add tests covering the new snapshot flow

## Testing
- uv run ruff check autofighter/rooms/battle/snapshots.py autofighter/rooms/battle/events.py autofighter/rooms/battle/progress.py autofighter/rooms/battle/engine.py autofighter/rooms/battle/resolution.py plugins/relics/rusty_buckle.py tests/test_battle_snapshots_module.py tests/test_rdr.py tests/test_rusty_buckle.py
- uv run pytest *(fails: missing battle_logging and tracking test dependencies in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68dd94f6b9f0832c83ff2c5d7d50661f