### PR TITLE
Fix effect charge snapshot retrieval around battle end

### DIFF
--- a/backend/autofighter/rooms/battle/engine.py
+++ b/backend/autofighter/rooms/battle/engine.py
@@ -156,6 +156,8 @@ async def run_battle(
         except Exception:
             pass
 
+    effects_charge = _snapshots.get_effect_charges(run_id)
+
     await handle_battle_end(foes, combat_party.members)
 
     battle_result = (
@@ -267,7 +269,6 @@ async def run_battle(
             "items": [],
         }
         dealt, taken = _damage_totals()
-        effects_charge = _snapshots.get_effect_charges(run_id)
         if run_id is not None:
             try:
                 await log_battle_summary(
@@ -349,6 +350,7 @@ async def run_battle(
         battle_logger=battle_logger,
         exp_reward=exp_reward,
         run_id=run_id,
+        effects_charge=effects_charge,
     )
 
 

--- a/backend/autofighter/rooms/battle/resolution.py
+++ b/backend/autofighter/rooms/battle/resolution.py
@@ -53,6 +53,7 @@ async def resolve_rewards(
     battle_logger: BattleLogger | None,
     exp_reward: int,
     run_id: str | None,
+    effects_charge: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     """Assemble the battle victory payload including loot and choices."""
 
@@ -213,7 +214,9 @@ async def resolve_rewards(
         "action_queue": action_queue_snapshot,
         "ended": True,
     }
-    charges = _snapshots.get_effect_charges(run_id)
+    charges = effects_charge
+    if charges is None:
+        charges = _snapshots.get_effect_charges(run_id)
     if charges is not None:
         result["effects_charge"] = charges
     return result


### PR DESCRIPTION
## Summary
- capture the stored effect charge snapshot before the battle end handler clears it
- plumb the preserved effect charge data into reward resolution so victory payloads include the metadata

## Testing
- uv run ruff check autofighter/rooms/battle/engine.py autofighter/rooms/battle/resolution.py

------
https://chatgpt.com/codex/tasks/task_b_68dd99f7730c832c8c63bcaa3d65ad58