### PR TITLE
Stabilize Becca passive tracking across battles

### DIFF
--- a/backend/plugins/passives/normal/becca_menagerie_bond.py
+++ b/backend/plugins/passives/normal/becca_menagerie_bond.py
@@ -22,18 +22,34 @@ class BeccaMenagerieBond:
     stack_display = "spinner"
 
     # Class-level tracking of summon state and spirit bonuses
-    _summon_cooldown: ClassVar[dict[int, int]] = {}  # entity_id -> turns_remaining
-    _spirit_stacks: ClassVar[dict[int, int]] = {}  # entity_id -> spirit_count
-    _last_summon: ClassVar[dict[int, str]] = {}  # entity_id -> last_summon_type
-    _applied_spirit_stacks: ClassVar[dict[int, int]] = {}
-    _buffed_summons: ClassVar[dict[int, set[int]]] = {}
+    _summon_cooldown: ClassVar[dict[str, int]] = {}  # entity_key -> turns_remaining
+    _spirit_stacks: ClassVar[dict[str, int]] = {}  # entity_key -> spirit_count
+    _last_summon: ClassVar[dict[str, str]] = {}  # entity_key -> last_summon_type
+    _applied_spirit_stacks: ClassVar[dict[str, int]] = {}
+    _buffed_summons: ClassVar[dict[str, set[int]]] = {}
 
     # Available jellyfish types
     JELLYFISH_TYPES = ["healing", "electric", "poison", "shielding"]
 
+    @staticmethod
+    def _resolve_entity_key(target: "Stats") -> str:
+        """Return a stable identifier for tracking Becca's summons."""
+
+        target_id = getattr(target, "id", None)
+        if target_id:
+            return str(target_id)
+        return str(id(target))
+
+    @classmethod
+    def _get_summoner_id(cls, target: "Stats") -> str:
+        """Return the identifier used by the SummonManager for ``target``."""
+
+        return cls._resolve_entity_key(target)
+
     async def apply(self, target: "Stats") -> None:
         """Apply Becca's Menagerie Bond mechanics."""
-        entity_id = id(target)
+        entity_key = self._resolve_entity_key(target)
+        summoner_id = self._get_summoner_id(target)
 
         if hasattr(target, "ensure_permanent_summon_slots"):
             target.ensure_permanent_summon_slots(1)
@@ -41,19 +57,19 @@ class BeccaMenagerieBond:
         setattr(target, "_becca_menagerie_passive", self)
 
         # Initialize tracking if not present
-        if entity_id not in self._summon_cooldown:
-            self._summon_cooldown[entity_id] = 0
-            self._spirit_stacks[entity_id] = 0
-            self._applied_spirit_stacks[entity_id] = 0
-            self._buffed_summons[entity_id] = set()
+        if entity_key not in self._summon_cooldown:
+            self._summon_cooldown[entity_key] = 0
+            self._spirit_stacks[entity_key] = 0
+            self._applied_spirit_stacks[entity_key] = 0
+            self._buffed_summons[entity_key] = set()
 
-        current_spirit_stacks = self._spirit_stacks[entity_id]
-        applied_stacks = self._applied_spirit_stacks.get(entity_id, 0)
+        current_spirit_stacks = self._spirit_stacks[entity_key]
+        applied_stacks = self._applied_spirit_stacks.get(entity_key, 0)
 
-        summons = SummonManager.get_summons(getattr(target, "id", str(id(target))))
+        summons = SummonManager.get_summons(summoner_id)
         jellyfish_summons = [s for s in summons if s.summon_source == self.id]
         current_ids = {id(s) for s in jellyfish_summons}
-        buffed_ids = self._buffed_summons.setdefault(entity_id, set())
+        buffed_ids = self._buffed_summons.setdefault(entity_key, set())
 
         if current_spirit_stacks != applied_stacks:
             spirit_attack_bonus = int(target._base_atk * 0.05 * current_spirit_stacks)
@@ -82,8 +98,8 @@ class BeccaMenagerieBond:
                 )
                 summon.add_effect(pet_effect)
 
-            self._applied_spirit_stacks[entity_id] = current_spirit_stacks
-            self._buffed_summons[entity_id] = current_ids
+            self._applied_spirit_stacks[entity_key] = current_spirit_stacks
+            self._buffed_summons[entity_key] = current_ids
         else:
             new_ids = current_ids - buffed_ids
             if new_ids:
@@ -105,8 +121,8 @@ class BeccaMenagerieBond:
             buffed_ids.intersection_update(current_ids)
 
         # Handle summon cooldown
-        if self._summon_cooldown[entity_id] > 0:
-            self._summon_cooldown[entity_id] -= 1
+        if self._summon_cooldown[entity_key] > 0:
+            self._summon_cooldown[entity_key] -= 1
 
     async def on_action_taken(self, target: "Stats", **kwargs) -> None:
         """Attempt to summon a jellyfish when Becca takes an action.
@@ -139,13 +155,13 @@ class BeccaMenagerieBond:
         If a ``party`` is provided, the new summon will be appended so it can
         participate in combat immediately.
         """
-        entity_id = id(target)
-        target_id = getattr(target, 'id', str(id(target)))
+        entity_key = self._resolve_entity_key(target)
+        target_id = self._get_summoner_id(target)
 
         # Initialize if not present
-        if entity_id not in self._summon_cooldown:
-            self._summon_cooldown[entity_id] = 0
-            self._spirit_stacks[entity_id] = 0
+        if entity_key not in self._summon_cooldown:
+            self._summon_cooldown[entity_key] = 0
+            self._spirit_stacks[entity_key] = 0
 
         if hasattr(target, "ensure_permanent_summon_slots"):
             target.ensure_permanent_summon_slots(1)
@@ -153,7 +169,7 @@ class BeccaMenagerieBond:
             setattr(target, "_becca_menagerie_passive", self)
 
         # Check cooldown
-        if self._summon_cooldown[entity_id] > 0:
+        if self._summon_cooldown[entity_key] > 0:
             return False
 
         # Check HP cost (10% of current HP)
@@ -169,7 +185,7 @@ class BeccaMenagerieBond:
 
         # If a healthy jellyfish exists and no type change is requested, skip summoning
         if jellyfish_summons and not decision["should_resummon"]:
-            if jellyfish_type is None or jellyfish_type == self._last_summon.get(entity_id):
+            if jellyfish_type is None or jellyfish_type == self._last_summon.get(entity_key):
                 return False
 
         # Pay HP cost using proper damage system
@@ -184,7 +200,7 @@ class BeccaMenagerieBond:
         current_summons = SummonManager.get_summons(target_id)
         jellyfish_summons = [s for s in current_summons if s.summon_source == self.id]
 
-        if jellyfish_summons and jellyfish_type != self._last_summon.get(entity_id):
+        if jellyfish_summons and jellyfish_type != self._last_summon.get(entity_key):
             # Remove old summon and create spirit
             for old_summon in jellyfish_summons:
                 SummonManager.remove_summon(old_summon, "replaced")
@@ -206,8 +222,8 @@ class BeccaMenagerieBond:
         if summon:
             if party is not None:
                 SummonManager.add_summons_to_party(party)
-            self._last_summon[entity_id] = jellyfish_type
-            self._summon_cooldown[entity_id] = 1  # One turn cooldown
+            self._last_summon[entity_key] = jellyfish_type
+            self._summon_cooldown[entity_key] = 1  # One turn cooldown
             return True
 
         return False
@@ -229,12 +245,12 @@ class BeccaMenagerieBond:
 
     async def _create_spirit(self, target: "Stats") -> None:
         """Create a spirit from the previous summon."""
-        entity_id = id(target)
-        self._spirit_stacks[entity_id] = self._spirit_stacks.get(entity_id, 0) + 1
+        entity_key = self._resolve_entity_key(target)
+        self._spirit_stacks[entity_key] = self._spirit_stacks.get(entity_key, 0) + 1
 
     async def on_summon_defeat(self, target: "Stats") -> None:
         """Handle summon defeat - still creates a spirit."""
-        target_id = getattr(target, 'id', str(id(target)))
+        target_id = self._get_summoner_id(target)
 
         # Check if any of our jellyfish were defeated
         current_summons = SummonManager.get_summons(target_id)
@@ -246,7 +262,7 @@ class BeccaMenagerieBond:
     @classmethod
     def get_active_summon_type(cls, target: "Stats") -> str:
         """Get current active summon type."""
-        target_id = getattr(target, 'id', str(id(target)))
+        target_id = cls._get_summoner_id(target)
         summons = SummonManager.get_summons(target_id)
         jellyfish_summons = [s for s in summons if s.summon_source == cls.id]
 
@@ -261,12 +277,18 @@ class BeccaMenagerieBond:
     @classmethod
     def get_spirit_stacks(cls, target: "Stats") -> int:
         """Get current spirit stack count."""
-        return cls._spirit_stacks.get(id(target), 0)
+        return cls._spirit_stacks.get(cls._resolve_entity_key(target), 0)
 
     @classmethod
     def get_cooldown(cls, target: "Stats") -> int:
         """Get remaining summon cooldown."""
-        return cls._summon_cooldown.get(id(target), 0)
+        return cls._summon_cooldown.get(cls._resolve_entity_key(target), 0)
+
+    @classmethod
+    def get_last_summon_type(cls, target: "Stats") -> str | None:
+        """Return the most recently summoned jellyfish type, if any."""
+
+        return cls._last_summon.get(cls._resolve_entity_key(target))
 
     @classmethod
     def get_description(cls) -> str:

--- a/backend/tests/test_summons_system.py
+++ b/backend/tests/test_summons_system.py
@@ -3,6 +3,7 @@ Tests for the unified summons system.
 """
 
 import asyncio
+import copy
 from pathlib import Path
 import sys
 
@@ -20,9 +21,22 @@ from autofighter.summons.manager import SummonManager
 from plugins.cards.phantom_ally import PhantomAlly
 from plugins.damage_types.lightning import Lightning
 from plugins.characters.foe_base import FoeBase
-from plugins.passives.normal.becca_menagerie_bond import BeccaMenagerieBond
 from plugins.characters.ally import Ally
 from plugins.characters.becca import Becca
+from plugins.passives.normal.becca_menagerie_bond import BeccaMenagerieBond
+
+
+def _reset_becca_passive_state() -> None:
+    """Clear global Becca Menagerie Bond tracking between tests."""
+
+    for store in (
+        BeccaMenagerieBond._summon_cooldown,
+        BeccaMenagerieBond._spirit_stacks,
+        BeccaMenagerieBond._last_summon,
+        BeccaMenagerieBond._applied_spirit_stacks,
+        BeccaMenagerieBond._buffed_summons,
+    ):
+        store.clear()
 
 
 @pytest.mark.asyncio
@@ -215,11 +229,51 @@ async def test_phantom_ally_new_system(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_becca_menagerie_bond_persists_between_battles(monkeypatch):
+    """Becca's passive should retain summon history across battle clones."""
+
+    monkeypatch.setattr(torch_checker, "is_torch_available", lambda: False)
+
+    _reset_becca_passive_state()
+    SummonManager.reset_all()
+
+    passive = BeccaMenagerieBond()
+    template_becca = Becca()
+    template_becca.id = "becca_passive_persistence"
+
+    battle_one_becca = copy.deepcopy(template_becca)
+    await passive.apply(battle_one_becca)
+
+    assert await passive.summon_jellyfish(battle_one_becca, jellyfish_type="electric")
+
+    key = BeccaMenagerieBond._resolve_entity_key(battle_one_becca)
+    passive._summon_cooldown[key] = 0
+
+    assert await passive.summon_jellyfish(battle_one_becca, jellyfish_type="poison")
+
+    assert BeccaMenagerieBond.get_spirit_stacks(battle_one_becca) == 1
+    assert BeccaMenagerieBond.get_last_summon_type(battle_one_becca) == "poison"
+
+    SummonManager.reset_all()
+
+    battle_two_becca = copy.deepcopy(template_becca)
+    await passive.apply(battle_two_becca)
+
+    assert BeccaMenagerieBond.get_spirit_stacks(battle_two_becca) == 1
+    assert BeccaMenagerieBond.get_last_summon_type(battle_two_becca) == "poison"
+    assert BeccaMenagerieBond.get_active_summon_type(battle_two_becca) is None
+
+    _reset_becca_passive_state()
+    SummonManager.reset_all()
+
+
+@pytest.mark.asyncio
 async def test_becca_jellyfish_after_phantom(monkeypatch):
     """Becca can still summon a jellyfish after Phantom Ally adds a copy."""
 
     monkeypatch.setattr(torch_checker, "is_torch_available", lambda: False)
 
+    _reset_becca_passive_state()
     SummonManager.cleanup()
 
     becca = Becca()
@@ -251,6 +305,7 @@ async def test_becca_jellyfish_summoning(monkeypatch):
     """Test Becca's jellyfish summoning using new system."""
     monkeypatch.setattr(torch_checker, "is_torch_available", lambda: False)
 
+    _reset_becca_passive_state()
     SummonManager.cleanup()
 
     # Create Becca
@@ -284,6 +339,7 @@ async def test_becca_summon_added_to_party(monkeypatch):
     """Summoning a jellyfish adds it to the party for battle."""
     monkeypatch.setattr(torch_checker, "is_torch_available", lambda: False)
 
+    _reset_becca_passive_state()
     SummonManager.cleanup()
 
     becca = Becca()
@@ -305,6 +361,7 @@ async def test_collect_summons_grouped_by_owner(monkeypatch):
     """Ensure snapshot helper groups summons by summoner id."""
     monkeypatch.setattr(torch_checker, "is_torch_available", lambda: False)
 
+    _reset_becca_passive_state()
     SummonManager.cleanup()
 
     becca = Becca()
@@ -327,6 +384,7 @@ async def test_becca_jellyfish_replacement_creates_spirit(monkeypatch):
     """Test that replacing jellyfish creates spirit stacks."""
     monkeypatch.setattr(torch_checker, "is_torch_available", lambda: False)
 
+    _reset_becca_passive_state()
     SummonManager.cleanup()
 
     # Create Becca
@@ -342,7 +400,7 @@ async def test_becca_jellyfish_replacement_creates_spirit(monkeypatch):
     assert passive.get_spirit_stacks(becca) == 0
 
     # Wait for cooldown
-    passive._summon_cooldown[id(becca)] = 0
+    passive._summon_cooldown[BeccaMenagerieBond._resolve_entity_key(becca)] = 0
     becca.hp = 100  # Reset HP
 
     # Summon different jellyfish (should create spirit)
@@ -360,6 +418,7 @@ async def test_spirit_spawn_on_summon_defeat(monkeypatch):
     """Becca gains a spirit stack when her jellyfish is defeated."""
     monkeypatch.setattr(torch_checker, "is_torch_available", lambda: False)
 
+    _reset_becca_passive_state()
     SummonManager.cleanup()
 
     becca = Becca()


### PR DESCRIPTION
## Summary
- use stable summon tracking keys based on character ids so Becca's passive persists through clones
- expose helper to query the last summoned jellyfish type and clean up summon bookkeeping on defeat
- reset Becca passive state in tests and add a regression that simulates consecutive battles

## Testing
- uv run pytest tests/test_summons_system.py

------
https://chatgpt.com/codex/tasks/task_b_68dd9aa8e2ec832c9bbd488bfe006f81