### PR TITLE
feat: wire radiant aegis event hooks

### DIFF
--- a/backend/plugins/damage_types/light.py
+++ b/backend/plugins/damage_types/light.py
@@ -59,12 +59,27 @@ class Light(DamageTypeBase):
                 ally.effect_manager = mgr
 
             # Remove all DoTs from the ally and their effect manager
+            removed_dots = []
             for dot in list(mgr.dots):
                 try:
                     mgr.dots.remove(dot)
                     ally.dots.remove(dot.id)
+                    removed_dots.append(dot)
                 except ValueError:
                     pass
+
+            for dot in removed_dots:
+                BUS.emit_batched(
+                    "dot_cleansed",
+                    actor,
+                    ally,
+                    getattr(dot, "id", None),
+                    {
+                        "dot_name": getattr(dot, "name", None),
+                        "remaining_turns": getattr(dot, "turns", None),
+                        "dot_damage": getattr(dot, "damage", None),
+                    },
+                )
 
             missing = ally.max_hp - ally.hp
             if missing > 0:

--- a/backend/plugins/passives/normal/lady_light_radiant_aegis.py
+++ b/backend/plugins/passives/normal/lady_light_radiant_aegis.py
@@ -1,8 +1,14 @@
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
+from typing import Callable
 from typing import ClassVar
+from typing import Mapping
+from typing import Optional
+from weakref import ref
 
 from autofighter.stat_effect import StatEffect
+from autofighter.stats import BUS
+from autofighter.stats import get_enrage_percent
 
 if TYPE_CHECKING:
     from autofighter.stats import Stats
@@ -20,6 +26,9 @@ class LadyLightRadiantAegis:
 
     # Class-level tracking of attack bonuses from cleansing DoTs
     _attack_bonuses: ClassVar[dict[int, int]] = {}
+    _effect_callbacks: ClassVar[dict[int, Callable[..., object]]] = {}
+    _cleanse_callbacks: ClassVar[dict[int, Callable[..., object]]] = {}
+    _cleanup_callbacks: ClassVar[dict[int, Callable[..., object]]] = {}
 
     async def apply(self, target: "Stats") -> None:
         """Apply Lady Light's HoT enhancement mechanics."""
@@ -38,6 +47,87 @@ class LadyLightRadiantAegis:
                 source=self.id,
             )
             target.add_effect(attack_bonus_effect)
+
+        cls = self.__class__
+        if entity_id not in cls._effect_callbacks:
+            target_ref = ref(target)
+
+            async def _on_effect_applied(
+                effect_name: str,
+                entity: Optional["Stats"],
+                details: Mapping[str, object] | None = None,
+            ) -> None:
+                tracked = target_ref()
+                if tracked is None:
+                    teardown()
+                    return
+
+                if (
+                    entity is None
+                    or details is None
+                    or details.get("effect_type") != "hot"
+                ):
+                    return
+
+                effect_id = details.get("effect_id")
+                if effect_id is None:
+                    return
+
+                mgr = getattr(entity, "effect_manager", None)
+                if mgr is None:
+                    return
+
+                for hot in getattr(mgr, "hots", []):
+                    if getattr(hot, "id", None) != effect_id:
+                        continue
+                    if getattr(hot, "source", None) is not tracked:
+                        continue
+                    if getattr(hot, "_radiant_aegis_registered", False):
+                        continue
+
+                    hot_amount = self._calculate_hot_amount(
+                        tracked,
+                        entity,
+                        hot,
+                        details,
+                    )
+                    hot._radiant_aegis_registered = True  # type: ignore[attr-defined]
+                    if hot_amount <= 0:
+                        continue
+                    await self.on_hot_applied(tracked, entity, hot_amount)
+                    break
+
+            async def _on_dot_cleansed(
+                cleanser: Optional["Stats"],
+                cleansed_ally: Optional["Stats"],
+                _dot_id: str | None = None,
+                _metadata: Mapping[str, object] | None = None,
+            ) -> None:
+                tracked = target_ref()
+                if tracked is None:
+                    teardown()
+                    return
+
+                if cleanser is not tracked or cleansed_ally is None:
+                    return
+
+                await self.on_dot_cleanse(tracked, cleansed_ally)
+
+            def teardown(*_args: object, **_kwargs: object) -> None:
+                BUS.unsubscribe("effect_applied", _on_effect_applied)
+                BUS.unsubscribe("dot_cleansed", _on_dot_cleansed)
+                BUS.unsubscribe("battle_end", teardown)
+                cls._effect_callbacks.pop(entity_id, None)
+                cls._cleanse_callbacks.pop(entity_id, None)
+                cls._cleanup_callbacks.pop(entity_id, None)
+
+            BUS.subscribe("effect_applied", _on_effect_applied)
+            BUS.subscribe("dot_cleansed", _on_dot_cleansed)
+            BUS.subscribe("battle_end", teardown)
+
+            cls._effect_callbacks[entity_id] = _on_effect_applied
+            cls._cleanse_callbacks[entity_id] = _on_dot_cleansed
+            cls._cleanup_callbacks[entity_id] = teardown
 
     async def on_hot_applied(self, target: "Stats", healed_ally: "Stats", hot_amount: int) -> None:
         """Enhance HoTs with shields and effect resistance."""
@@ -96,3 +186,44 @@ class LadyLightRadiantAegis:
             "HoTs grant shields equal to 50% of the heal and +5% effect resistance for one turn. "
             "Cleansing a DoT heals 5% of max HP and gives Lady Light +2% attack per cleanse."
         )
+
+    def _calculate_hot_amount(
+        self,
+        healer: "Stats",
+        ally: "Stats",
+        hot: object,
+        details: Mapping[str, object] | None,
+    ) -> int:
+        base_value = None
+        if details is not None:
+            base_value = details.get("healing")
+        if base_value is None:
+            base_value = getattr(hot, "healing", None)
+        if base_value is None:
+            return 0
+
+        heal_amount = float(base_value)
+        dtype = getattr(hot, "damage_type", None)
+        if dtype is None:
+            dtype = getattr(healer, "damage_type", None)
+
+        if dtype is not None:
+            heal_amount = dtype.on_hot_heal_received(heal_amount, healer, ally)
+            heal_amount = dtype.on_party_hot_heal_received(heal_amount, healer, ally)
+
+        healer_type = getattr(healer, "damage_type", None)
+        if healer_type is not None and healer_type is not dtype:
+            heal_amount = healer_type.on_party_hot_heal_received(
+                heal_amount,
+                healer,
+                ally,
+            )
+
+        heal_amount *= getattr(healer, "vitality", 1.0)
+        heal_amount *= getattr(ally, "vitality", 1.0)
+
+        enrage = get_enrage_percent()
+        if enrage > 0:
+            heal_amount *= max(1.0 - enrage, 0.0)
+
+        return max(0, int(heal_amount))


### PR DESCRIPTION
## Summary
- subscribe Radiant Aegis to relevant event-bus hooks so HoT applications and cleanses trigger the passive automatically
- emit a dot_cleansed event from the Light ultimate after removing DoTs to notify passives about cleanses
- add focused tests that exercise HoT application via the event bus and cleanse handling through the Light ultimate

## Testing
- uv run ruff check plugins/passives/normal/lady_light_radiant_aegis.py plugins/damage_types/light.py tests/test_lady_light_radiant_aegis.py --fix
- uv run pytest tests/test_lady_light_radiant_aegis.py


------
https://chatgpt.com/codex/tasks/task_b_68dda0d1e0e4832cb403c4fcb1c2e74d