### PR TITLE
Fix Bubble Burst passive hit tracking

### DIFF
--- a/backend/tests/test_bubbles_bubble_burst_logic.py
+++ b/backend/tests/test_bubbles_bubble_burst_logic.py
@@ -7,7 +7,6 @@ from autofighter.stats import set_battle_active
 from plugins.damage_types import ALL_DAMAGE_TYPES
 from plugins.damage_types import load_damage_type
 from plugins.damage_types.generic import Generic
-from plugins.passives.normal.bubbles_bubble_burst import BubblesBubbleBurst
 
 
 @pytest.mark.asyncio
@@ -23,6 +22,8 @@ async def test_bubbles_random_damage_type():
 async def test_bubble_burst_stacks_and_dot():
     set_battle_active(True)
     try:
+        registry = PassiveRegistry()
+        bubble_cls = registry._registry["bubbles_bubble_burst"]
         bubbles = Stats(hp=1000, damage_type=load_damage_type("Fire"))
         bubbles.set_base_stat("atk", 100)
         ally = Stats(hp=1000, damage_type=Generic())
@@ -32,17 +33,17 @@ async def test_bubble_burst_stacks_and_dot():
         enemy2.effect_manager = EffectManager(enemy2)
         bubbles.allies = [bubbles, ally]
         bubbles.enemies = [enemy1, enemy2]
+        bubbles.passives = ["bubbles_bubble_burst"]
 
-        passive = BubblesBubbleBurst()
         for _ in range(2):
-            await passive.on_hit_enemy(bubbles, enemy1)
-        await passive.on_hit_enemy(bubbles, enemy2)
-        assert BubblesBubbleBurst.get_bubble_stacks(bubbles, enemy1) == 2
-        assert BubblesBubbleBurst.get_bubble_stacks(bubbles, enemy2) == 1
+            await registry.trigger_hit_landed(bubbles, enemy1, 100, "attack")
+        await registry.trigger_hit_landed(bubbles, enemy2, 100, "attack")
+        assert bubble_cls.get_bubble_stacks(bubbles, enemy1) == 2
+        assert bubble_cls.get_bubble_stacks(bubbles, enemy2) == 1
 
-        await passive.on_hit_enemy(bubbles, enemy1)
-        assert BubblesBubbleBurst.get_bubble_stacks(bubbles, enemy1) == 0
-        assert BubblesBubbleBurst.get_bubble_stacks(bubbles, enemy2) == 1
+        await registry.trigger_hit_landed(bubbles, enemy1, 100, "attack")
+        assert bubble_cls.get_bubble_stacks(bubbles, enemy1) == 0
+        assert bubble_cls.get_bubble_stacks(bubbles, enemy2) == 1
         assert bubbles.hp < 1000
         assert ally.hp < 1000
         assert enemy1.hp < 1000
@@ -53,3 +54,18 @@ async def test_bubble_burst_stacks_and_dot():
         assert enemy2.effect_manager.dots[0].turns == 2
     finally:
         set_battle_active(False)
+
+
+@pytest.mark.asyncio
+async def test_bubble_burst_cleanup_on_defeat():
+    registry = PassiveRegistry()
+    bubble_cls = registry._registry["bubbles_bubble_burst"]
+    bubbles = Stats(hp=1000, damage_type=load_damage_type("Fire"))
+    enemy = Stats(hp=1000, damage_type=Generic())
+    bubbles.passives = ["bubbles_bubble_burst"]
+
+    await registry.trigger_hit_landed(bubbles, enemy, 100, "attack")
+    assert bubble_cls.get_bubble_stacks(bubbles, enemy) == 1
+
+    await registry.trigger_defeat(bubbles)
+    assert bubble_cls.get_bubble_stacks(bubbles, enemy) == 0


### PR DESCRIPTION
## Summary
- update Bubble Burst passive to listen for `hit_landed` events and clear stored stacks when defeated
- drive the Bubble Burst tests through the passive registry hit handler and verify stacking plus cleanup behavior

## Testing
- uv run pytest tests/test_bubbles_bubble_burst_logic.py

------
https://chatgpt.com/codex/tasks/task_b_68dda0d33a20832c8f51f015c1c9bcb0