### PR TITLE
Fix Arcane Repeater hit_landed subscription

### DIFF
--- a/backend/plugins/cards/arcane_repeater.py
+++ b/backend/plugins/cards/arcane_repeater.py
@@ -22,8 +22,21 @@ class ArcaneRepeater(CardBase):
     async def apply(self, party) -> None:  # type: ignore[override]
         await super().apply(party)
 
-        async def _attack(attacker, target, amount) -> None:
+        async def _hit_landed(
+            attacker,
+            target,
+            amount,
+            source_type: str | None = "attack",
+            source_name: str | None = None,
+            *_args,
+        ) -> None:
             if attacker not in party.members:
+                return
+            if source_type != "attack":
+                return
+            if target is None:
+                return
+            if amount is None:
                 return
             if random.random() >= 0.30:
                 return
@@ -42,4 +55,4 @@ class ArcaneRepeater(CardBase):
             )
             safe_async_task(target.apply_damage(dmg, attacker=attacker))
 
-        self.subscribe("attack_used", _attack)
+        self.subscribe("hit_landed", _hit_landed)

--- a/backend/tests/test_card_effects.py
+++ b/backend/tests/test_card_effects.py
@@ -110,7 +110,7 @@ async def test_arcane_repeater_repeats_attack():
 
     dmg = loop.run_until_complete(foe.apply_damage(ally.atk, attacker=ally))
     with patch("random.random", return_value=0.1):
-        await BUS.emit_async("attack_used", ally, foe, dmg)
+        await BUS.emit_async("hit_landed", ally, foe, dmg, "attack")
         loop.run_until_complete(asyncio.sleep(0))
     expected = dmg + int(dmg * 0.5)
     assert foe.hp == 1000 - expected


### PR DESCRIPTION
## Summary
- subscribe Arcane Repeater to the hit_landed bus event and guard repeats to normal attacks only
- update the Arcane Repeater card test to emit the new event payload

## Testing
- uv run ruff check plugins/cards/arcane_repeater.py tests/test_card_effects.py --fix
- uv run pytest tests/test_card_effects.py::test_arcane_repeater_repeats_attack (fails: pytest-asyncio strict mode forbids nested event loops even on main branch)


------
https://chatgpt.com/codex/tasks/task_b_68dda584d904832caaf8bcec9bbfff63