### PR TITLE
Align BattleView snapshot polling with orchestrator

### DIFF
--- a/frontend/src/lib/components/BattleView.svelte
+++ b/frontend/src/lib/components/BattleView.svelte
@@ -1522,7 +1522,7 @@
     dispatch('snapshot-start');
     let haltedDuringFetch = false;
     try {
-      const snap = await roomAction(runId, 'battle', 'snapshot');
+      const snap = await roomAction('0', { action: 'snapshot', run_id: runId });
       if (isSyncHalted()) {
         haltedDuringFetch = true;
         return;

--- a/frontend/tests/battle-turn-phase.vitest.js
+++ b/frontend/tests/battle-turn-phase.vitest.js
@@ -113,6 +113,27 @@ describe('BattleView turn phase handling', () => {
     vi.useRealTimers();
   });
 
+  it('requests snapshots with the orchestrator payload shape', async () => {
+    const snapshot = buildSnapshot({ turnPhase: { state: 'start' } });
+    roomAction.mockImplementation(() => Promise.resolve(clone(snapshot)));
+
+    render(BattleView, {
+      props: {
+        runId: 'snapshot-run',
+        active: true,
+        framerate: 60,
+      },
+    });
+
+    await settle();
+
+    await waitFor(() => {
+      expect(roomAction).toHaveBeenCalled();
+    });
+
+    expect(roomAction).toHaveBeenCalledWith('0', { action: 'snapshot', run_id: 'snapshot-run' });
+  });
+
   it('persists attacker targeting through start/resolve and clears on end', async () => {
     const statusPhaseTemplate = {
       phase: 'dot',


### PR DESCRIPTION
## Summary
- Update BattleView snapshot polling to call `roomAction` with the orchestrator-style payload.
- Add regression coverage that ensures BattleView requests snapshots using the orchestrator payload shape.

## Testing
- bun run lint
- bunx vitest run tests/battle-turn-phase.vitest.js *(fails: @sveltejs/vite-plugin-svelte load-custom expects server.config in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68dec085de6c832c9f4954a4e324a929