### PR TITLE
Align aftertaste metadata with battle snapshots

### DIFF
--- a/backend/plugins/effects/aftertaste.py
+++ b/backend/plugins/effects/aftertaste.py
@@ -91,12 +91,24 @@ class Aftertaste:
 
             # Emit event before applying damage to track aftertaste as relic effect
             from autofighter.stats import BUS
-            await BUS.emit_async("relic_effect", "aftertaste", attacker, "damage", amount, {
-                "effect_type": "aftertaste",
-                "base_damage": self.base_pot,
-                "random_damage_type": random_damage_type.id if hasattr(random_damage_type, 'id') else str(random_damage_type),
-                "actual_damage": amount
-            })
+            await BUS.emit_async(
+                "relic_effect",
+                "aftertaste",
+                attacker,
+                "aftertaste",
+                amount,
+                {
+                    "effect_label": "aftertaste",
+                    "effect_type": "aftertaste",
+                    "base_damage": self.base_pot,
+                    "random_damage_type": (
+                        random_damage_type.id
+                        if hasattr(random_damage_type, "id")
+                        else str(random_damage_type)
+                    ),
+                    "actual_damage": amount,
+                },
+            )
 
             dmg = await target.apply_damage(amount, temp_attacker, action_name="Aftertaste")
             results.append(dmg)

--- a/backend/plugins/relics/echo_bell.py
+++ b/backend/plugins/relics/echo_bell.py
@@ -92,6 +92,7 @@ class EchoBell(RelicBase):
                     "aftertaste_trigger",
                     total_hits,
                     {
+                        "effect_label": "aftertaste",
                         "original_amount": amount,
                         "total_chance": total_chance,
                         "guaranteed_hits": guaranteed_hits,

--- a/backend/plugins/relics/echoing_drum.py
+++ b/backend/plugins/relics/echoing_drum.py
@@ -89,6 +89,7 @@ class EchoingDrum(RelicBase):
                     "aftertaste_trigger",
                     total_hits,
                     {
+                        "effect_label": "aftertaste",
                         "original_amount": amount,
                         "total_chance": total_chance,
                         "guaranteed_hits": guaranteed_hits,

--- a/backend/plugins/relics/rusty_buckle.py
+++ b/backend/plugins/relics/rusty_buckle.py
@@ -95,8 +95,8 @@ class RustyBuckle(RelicBase):
         _update_charge_snapshot()
 
         async def _turn_start(entity) -> None:
-            from plugins.characters.foe_base import FoeBase
             from plugins.characters._base import PlayerBase
+            from plugins.characters.foe_base import FoeBase
 
             current_state = getattr(party, "_rusty_buckle_state", state)
             if entity is None or not isinstance(entity, (PlayerBase, FoeBase)):
@@ -166,6 +166,7 @@ class RustyBuckle(RelicBase):
                     "aftertaste_trigger",
                     dmg,
                     {
+                        "effect_label": "aftertaste",
                         "trigger_count": triggers,
                         "hp_lost_percentage": lost_pct * 100,
                         "aftertaste_hits": hits,

--- a/backend/tests/test_card_relic_snapshot_events.py
+++ b/backend/tests/test_card_relic_snapshot_events.py
@@ -143,3 +143,29 @@ async def test_card_and_relic_events_record_snapshot_metadata(monkeypatch):
     assert relic_metadata["details"] == {"source": "shop"}
 
     assert calls == [expected_multiplier, expected_multiplier]
+
+    await BUS.emit_async(
+        "relic_effect",
+        "aftertaste",
+        member,
+        "aftertaste",
+        21,
+        {
+            "effect_label": "aftertaste",
+            "effect_type": "aftertaste",
+            "base_damage": 18,
+            "actual_damage": 21,
+        },
+    )
+
+    events = list(battle_snapshots[run_id].get("recent_events", []))
+    assert len(events) == 3
+    aftertaste_event = events[-1]
+    assert aftertaste_event["type"] == "relic_effect"
+    assert aftertaste_event["amount"] == 21
+    assert aftertaste_event["target_id"] == member.id
+    aftertaste_metadata = aftertaste_event.get("metadata", {})
+    assert aftertaste_metadata["relic_id"] == "aftertaste"
+    assert aftertaste_metadata["effect"] == "aftertaste"
+    assert aftertaste_metadata["details"]["effect_label"] == "aftertaste"
+    assert aftertaste_metadata["details"]["effect_type"] == "aftertaste"

--- a/backend/tests/test_event_bus_performance.py
+++ b/backend/tests/test_event_bus_performance.py
@@ -122,12 +122,20 @@ class TestEventBusPerformance:
             # Simulate initial attack triggering multiple Aftertaste effects
             for i in range(aftertaste_count):
                 # Each Aftertaste effect emits a relic_effect event
-                await BUS.emit_async("relic_effect", "aftertaste", attacker, "damage", 25, {
-                    "effect_type": "aftertaste",
-                    "base_damage": 25,
-                    "random_damage_type": "Fire",
-                    "actual_damage": 25
-                })
+                await BUS.emit_async(
+                    "relic_effect",
+                    "aftertaste",
+                    attacker,
+                    "aftertaste",
+                    25,
+                    {
+                        "effect_label": "aftertaste",
+                        "effect_type": "aftertaste",
+                        "base_damage": 25,
+                        "random_damage_type": "Fire",
+                        "actual_damage": 25,
+                    },
+                )
 
                 # Then emits damage_dealt when damage is applied
                 await BUS.emit_async("damage_dealt", attacker, target, 25, "effect", "aftertaste", "Fire", "Aftertaste (Fire)")

--- a/frontend/tests/battle-floaters.test.js
+++ b/frontend/tests/battle-floaters.test.js
@@ -25,6 +25,15 @@ describe('Battle event floaters', () => {
     expect(floaterSource).toContain('critical = Boolean');
   });
 
+  test('includes effect_label fallback so aftertaste labels render in floaters', () => {
+    const labelBlockStart = floaterSource.indexOf('const LABEL_FALLBACK_KEYS');
+    expect(labelBlockStart).toBeGreaterThan(-1);
+    const labelBlockEnd = floaterSource.indexOf('];', labelBlockStart);
+    expect(labelBlockEnd).toBeGreaterThan(labelBlockStart);
+    const labelBlock = floaterSource.slice(labelBlockStart, labelBlockEnd);
+    expect(labelBlock).toContain("'effect_label'");
+  });
+
   test('staggered floater scheduling uses index-based offsets', () => {
     const anchor = 'list.forEach((raw, i) => {';
     const start = floaterSource.indexOf(anchor);


### PR DESCRIPTION
## Summary
- update the Aftertaste effect to emit relic_effect events labeled as "aftertaste" and include redundant metadata
- propagate the shared label into Rusty Buckle, Echoing Drum, and Echo Bell aftertaste trigger events
- extend battle snapshot and floater unit coverage to assert the new label is surfaced in backend data and front-end parsing

## Testing
- uv run ruff check backend/plugins/effects/aftertaste.py backend/plugins/relics/rusty_buckle.py backend/plugins/relics/echoing_drum.py backend/plugins/relics/echo_bell.py backend/tests/test_card_relic_snapshot_events.py backend/tests/test_event_bus_performance.py --fix
- uv run pytest backend/tests/test_card_relic_snapshot_events.py
- bun test tests/battle-floaters.test.js


------
https://chatgpt.com/codex/tasks/task_b_68dedbc7c280832cb983129d911d7276