### PR TITLE
[UI] Add motion-aware MenuPanel animation

### DIFF
--- a/frontend/src/lib/components/CombatViewer.svelte
+++ b/frontend/src/lib/components/CombatViewer.svelte
@@ -19,6 +19,7 @@
   export let foes = [];
   export let runId = '';
   export let battleSnapshot = null;
+  export let reducedMotion = false;
 
   const dispatch = createEventDispatcher();
 
@@ -329,7 +330,7 @@
   }
 </script>
 
-<MenuPanel>
+<MenuPanel {reducedMotion}>
   <div class="combat-viewer">
     <div class="viewer-header">
       <h2>Combat Viewer</h2>

--- a/frontend/src/lib/components/MenuPanel.svelte
+++ b/frontend/src/lib/components/MenuPanel.svelte
@@ -24,6 +24,8 @@
     box-shadow: var(--glass-shadow);
     border: var(--glass-border);
     backdrop-filter: var(--glass-filter);
+    animation: panel-slide-fade 220ms ease-out both;
+    will-change: transform, opacity;
   }
 
   /* Themed scrollbars for dark UI */
@@ -47,11 +49,33 @@
   .panel::-webkit-scrollbar-thumb:hover {
     background: linear-gradient(180deg, rgba(215, 215, 225, 0.7), rgba(175, 175, 190, 0.7));
   }
+
+  .panel.motion-disabled {
+    animation: none;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .panel {
+      animation: none;
+    }
+  }
+
+  @keyframes panel-slide-fade {
+    from {
+      opacity: 0;
+      transform: translateY(-0.75rem);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
 </style>
 
 <div
   {...$$restProps}
   class={`panel ${$$props.class || ''}`}
+  class:motion-disabled={reducedMotion}
   style={`--padding: ${padding}; ${style}`}
 >
   <StarStorm color={starColor} {reducedMotion} />

--- a/frontend/src/lib/components/OverlayHost.svelte
+++ b/frontend/src/lib/components/OverlayHost.svelte
@@ -269,6 +269,7 @@
 {#if $overlayView === 'run-choose'}
   <PopupWindow title="Resume or Start Run" maxWidth="720px" zIndex={1300} on:close={() => dispatch('back')}>
     <RunChooser runs={$overlayData.runs || []}
+      reducedMotion={simplifiedTransitions ? true : effectiveReducedMotion}
       on:choose={(e) => dispatch('loadRun', e.detail.run)}
       on:load={(e) => dispatch('loadRun', e.detail.run)}
       on:startNew={() => dispatch('startNewRun')}
@@ -366,11 +367,12 @@
 
 {#if $overlayView === 'combat-viewer'}
   <OverlaySurface zIndex={1300}>
-    <CombatViewer 
+    <CombatViewer
       party={battleSnapshot?.party ?? []}
       foes={battleSnapshot?.foes ?? []}
       {runId}
       {battleSnapshot}
+      reducedMotion={simplifiedTransitions ? true : effectiveReducedMotion}
       on:close={() => dispatch('back')}
       on:pauseCombat={() => dispatch('pauseCombat')}
       on:resumeCombat={() => dispatch('resumeCombat')}


### PR DESCRIPTION
## Summary
- add a slide/fade entrance animation to `MenuPanel` with a reduced-motion class override and media query safeguard
- ensure `OverlayHost` forwards the reduced-motion flag to `RunChooser` and `CombatViewer` so the animation can be disabled consistently

## Testing
- [ ] Backend tests
- [ ] Frontend tests
- [x] Linting
- [ ] Doc sync updates (README and `.codex/implementation` docs; link tasks below)

## Checklist
- [ ] Linked or updated relevant `.codex/tasks` entries
- [ ] Updated player roster and foe docs if adding or modifying fighters or enemies
- [x] Referenced `.codex/implementation/ui-animation-guidelines.md` when adding UI animations

------
https://chatgpt.com/codex/tasks/task_b_68dede75f0ac832cbfc19bd0e3a9a512