### PR TITLE
feat: respect reduced motion for popup bounce

### DIFF
--- a/frontend/src/lib/components/BackendNotReady.svelte
+++ b/frontend/src/lib/components/BackendNotReady.svelte
@@ -4,6 +4,7 @@
 
   export let apiBase = '';
   export let message = 'Backend is not ready yet.';
+  export let reducedMotion = false;
 
   const dispatch = createEventDispatcher();
 
@@ -16,7 +17,7 @@
   }
 </script>
 
-<PopupWindow title="Backend Not Ready" on:close={close}>
+<PopupWindow title="Backend Not Ready" {reducedMotion} on:close={close}>
   <div style="padding: 0.5rem 0.25rem; line-height: 1.4;">
     <p>The Web UI cannot reach the backend.</p>
     <p><strong>API:</strong> {apiBase}</p>

--- a/frontend/src/lib/components/BackendShutdownOverlay.svelte
+++ b/frontend/src/lib/components/BackendShutdownOverlay.svelte
@@ -6,6 +6,7 @@
   export let message = 'The backend encountered a critical error.';
   export let traceback = '';
   export let status = 500;
+  export let reducedMotion = false;
 
   const dispatch = createEventDispatcher();
 
@@ -39,7 +40,7 @@
   }
 </script>
 
-<PopupWindow title="Backend Shutting Down" on:close={close}>
+<PopupWindow title="Backend Shutting Down" {reducedMotion} on:close={close}>
   <div class="content">
     <p class="lead">The backend reported a critical error (status {status}) and is shutting down.</p>
     <p>

--- a/frontend/src/lib/components/ErrorOverlay.svelte
+++ b/frontend/src/lib/components/ErrorOverlay.svelte
@@ -5,6 +5,7 @@
 
   export let message = '';
   export let traceback = '';
+  export let reducedMotion = false;
 
   const dispatch = createEventDispatcher();
   let reportUrl = '';
@@ -20,7 +21,7 @@
   }
 </script>
 
-<PopupWindow title="Error" on:close={close}>
+<PopupWindow title="Error" {reducedMotion} on:close={close}>
   <div style="padding: 0.5rem 0.25rem; line-height: 1.4;">
     <pre>{message}\n{traceback}</pre>
     <div class="stained-glass-row" style="justify-content: flex-end; margin-top: 0.75rem;">

--- a/frontend/src/lib/components/OverlayHost.svelte
+++ b/frontend/src/lib/components/OverlayHost.svelte
@@ -238,7 +238,7 @@
 {/if}
 
 {#if $overlayView === 'defeat'}
-  <PopupWindow title="Defeat" on:close={() => dispatch('back')}>
+  <PopupWindow title="Defeat" reducedMotion={overlayReducedMotion} on:close={() => dispatch('back')}>
     <div style="padding: 0.5rem 0.25rem; line-height: 1.4;">
       <p>Your party was defeated.</p>
       <p>You have been returned to the main menu.</p>
@@ -253,6 +253,7 @@
   <ErrorOverlay
     message={$overlayData.message || 'An unexpected error occurred.'}
     traceback={$overlayData.traceback || ''}
+    reducedMotion={overlayReducedMotion}
     on:close={() => dispatch('back')}
   />
 {/if}
@@ -262,14 +263,15 @@
     message={$overlayData.message || 'A critical backend error occurred.'}
     traceback={$overlayData.traceback || ''}
     status={$overlayData.status || 500}
+    reducedMotion={overlayReducedMotion}
     on:close={() => dispatch('back')}
   />
 {/if}
 
 {#if $overlayView === 'run-choose'}
-  <PopupWindow title="Resume or Start Run" maxWidth="720px" zIndex={1300} on:close={() => dispatch('back')}>
+  <PopupWindow title="Resume or Start Run" maxWidth="720px" zIndex={1300} reducedMotion={overlayReducedMotion} on:close={() => dispatch('back')}>
     <RunChooser runs={$overlayData.runs || []}
-      reducedMotion={simplifiedTransitions ? true : effectiveReducedMotion}
+      reducedMotion={overlayReducedMotion}
       on:choose={(e) => dispatch('loadRun', e.detail.run)}
       on:load={(e) => dispatch('loadRun', e.detail.run)}
       on:startNew={() => dispatch('startNewRun')}
@@ -281,6 +283,7 @@
   <BackendNotReady
     apiBase={$overlayData.apiBase || ''}
     message={$overlayData.message || 'Backend is not ready yet.'}
+    reducedMotion={overlayReducedMotion}
     on:close={() => dispatch('back')}
   />
 {/if}
@@ -308,6 +311,7 @@
     title="Warp Mechanics"
     maxWidth="640px"
     zIndex={1350}
+    reducedMotion={overlayReducedMotion}
     on:close={() => dispatch('back')}
   >
     <div class="warp-info-body">
@@ -351,7 +355,7 @@
 {/if}
 
 {#if $overlayView === 'inventory'}
-  <PopupWindow title="Inventory" padding="0" maxWidth="1200px" zIndex={1300} on:close={() => dispatch('back')}>
+  <PopupWindow title="Inventory" padding="0" maxWidth="1200px" zIndex={1300} reducedMotion={overlayReducedMotion} on:close={() => dispatch('back')}>
     <Inventory cards={roomData?.cards ?? []} relics={roomData?.relics ?? []} />
   </PopupWindow>
 {/if}
@@ -381,7 +385,7 @@
 {/if}
 
 {#if $overlayView === 'settings'}
-  <PopupWindow title="Settings" maxWidth="960px" maxHeight="90vh" zIndex={1300} on:close={() => dispatch('back')}>
+  <PopupWindow title="Settings" maxWidth="960px" maxHeight="90vh" zIndex={1300} reducedMotion={overlayReducedMotion} on:close={() => dispatch('back')}>
     <SettingsMenu
       {sfxVolume}
       {musicVolume}
@@ -403,7 +407,7 @@
 {/if}
 
 {#if $overlayView === 'guidebook'}
-  <PopupWindow title="Guidebook" maxWidth="1200px" maxHeight="90vh" zIndex={1300} on:close={() => dispatch('back')}>
+  <PopupWindow title="Guidebook" maxWidth="1200px" maxHeight="90vh" zIndex={1300} reducedMotion={overlayReducedMotion} on:close={() => dispatch('back')}>
     <Guidebook />
   </PopupWindow>
 {/if}
@@ -415,6 +419,7 @@
     maxHeight="100%"
     zIndex={1100}
     surfaceNoScroll={true}
+    reducedMotion={overlayReducedMotion}
     on:close={() => { /* block closing while choices remain */ }}
   >
     <RewardOverlay

--- a/frontend/src/lib/components/PopupWindow.svelte
+++ b/frontend/src/lib/components/PopupWindow.svelte
@@ -21,7 +21,11 @@
 </script>
 
 {#if bareSurface}
-  <div class="box" style={`--max-w: ${maxWidth}; --max-h: ${maxHeight}` }>
+  <div
+    class="box"
+    class:motion-enabled={!reducedMotion}
+    style={`--max-w: ${maxWidth}; --max-h: ${maxHeight}` }
+  >
     <div class="inner">
       <div class="content-wrap">
         <MenuPanel class="panel-body" {padding} {reducedMotion}>
@@ -41,7 +45,11 @@
   </div>
 {:else}
   <OverlaySurface {zIndex} noScroll={surfaceNoScroll}>
-    <div class="box" style={`--max-w: ${maxWidth}; --max-h: ${maxHeight}` }>
+    <div
+      class="box"
+      class:motion-enabled={!reducedMotion}
+      style={`--max-w: ${maxWidth}; --max-h: ${maxHeight}` }
+    >
       <div class="inner">
         <div class="content-wrap">
           <MenuPanel class="panel-body" {padding} {reducedMotion}>
@@ -99,6 +107,32 @@
     flex-direction: column;
     /* allow children to shrink and scroll within */
     min-height: 0;
+    transform-origin: center;
+  }
+
+  .box.motion-enabled {
+    animation: popup-bounce-in 210ms ease-out both;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .box.motion-enabled {
+      animation: none;
+    }
+  }
+
+  @keyframes popup-bounce-in {
+    0% {
+      transform: scale(0.92);
+      opacity: 0;
+    }
+    65% {
+      transform: scale(1.02);
+      opacity: 1;
+    }
+    100% {
+      transform: scale(1);
+      opacity: 1;
+    }
   }
 
   .inner { display: flex; flex-direction: column; min-height: 0; }


### PR DESCRIPTION
## Summary
- add a scale-based bounce-in animation to popup windows with reduced-motion fallbacks
- thread the reducedMotion flag through overlay host call sites and wrapper overlays
- ensure overlay child components forward the reducedMotion prop to PopupWindow

## Testing
- bun run lint

------
https://chatgpt.com/codex/tasks/task_b_68dee323f870832cb0332e6ee15922b6