### PR TITLE
Fix menu panel transitions for reduced motion

### DIFF
--- a/frontend/src/lib/components/MenuPanel.svelte
+++ b/frontend/src/lib/components/MenuPanel.svelte
@@ -1,9 +1,26 @@
 <script>
+  import { fade, fly } from 'svelte/transition';
+  import { cubicOut } from 'svelte/easing';
+
   import StarStorm from './StarStorm.svelte';
   export let padding = '0.5rem';
   export let reducedMotion = false;
   export let starColor = '';
   export let style = '';
+
+  const TRANSITION_DURATION = 220;
+
+  $: flyInOptions = reducedMotion
+    ? { duration: 0 }
+    : { y: -12, duration: TRANSITION_DURATION, easing: cubicOut };
+
+  $: flyOutOptions = reducedMotion
+    ? { duration: 0 }
+    : { y: 12, duration: TRANSITION_DURATION, easing: cubicOut };
+
+  $: fadeOptions = reducedMotion
+    ? { duration: 0 }
+    : { duration: TRANSITION_DURATION, easing: cubicOut };
 </script>
 
 <style>
@@ -24,8 +41,6 @@
     box-shadow: var(--glass-shadow);
     border: var(--glass-border);
     backdrop-filter: var(--glass-filter);
-    animation: panel-slide-fade 220ms ease-out both;
-    will-change: transform, opacity;
   }
 
   /* Themed scrollbars for dark UI */
@@ -49,34 +64,16 @@
   .panel::-webkit-scrollbar-thumb:hover {
     background: linear-gradient(180deg, rgba(215, 215, 225, 0.7), rgba(175, 175, 190, 0.7));
   }
-
-  .panel.motion-disabled {
-    animation: none;
-  }
-
-  @media (prefers-reduced-motion: reduce) {
-    .panel {
-      animation: none;
-    }
-  }
-
-  @keyframes panel-slide-fade {
-    from {
-      opacity: 0;
-      transform: translateY(-0.75rem);
-    }
-    to {
-      opacity: 1;
-      transform: translateY(0);
-    }
-  }
 </style>
 
 <div
   {...$$restProps}
   class={`panel ${$$props.class || ''}`}
-  class:motion-disabled={reducedMotion}
   style={`--padding: ${padding}; ${style}`}
+  in:fly={flyInOptions}
+  in:fade={fadeOptions}
+  out:fly={flyOutOptions}
+  out:fade={fadeOptions}
 >
   <StarStorm color={starColor} {reducedMotion} />
   <slot />


### PR DESCRIPTION
## Summary
- replace the CSS keyframe animation in `MenuPanel` with Svelte in/out fly+fade transitions
- ensure exit transitions mirror entry timing and respect the `reducedMotion` flag by disabling transitions

## Testing
- bun run lint

------
https://chatgpt.com/codex/tasks/task_b_68def0fab738832cb018982688117890