### PR TITLE
Default MenuPanel transitions to prefers-reduced-motion

### DIFF
--- a/frontend/src/lib/components/MenuPanel.svelte
+++ b/frontend/src/lib/components/MenuPanel.svelte
@@ -1,24 +1,48 @@
 <script>
   import { fade, fly } from 'svelte/transition';
   import { cubicOut } from 'svelte/easing';
+  import { onDestroy } from 'svelte';
+  import { browser } from '$app/environment';
 
   import StarStorm from './StarStorm.svelte';
   export let padding = '0.5rem';
-  export let reducedMotion = false;
+  export let reducedMotion;
   export let starColor = '';
   export let style = '';
 
   const TRANSITION_DURATION = 220;
 
-  $: flyInOptions = reducedMotion
+  let prefersReducedMotion = false;
+
+  if (browser) {
+    const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+
+    const updatePreference = (event) => {
+      prefersReducedMotion = event.matches;
+    };
+
+    updatePreference(mediaQuery);
+
+    mediaQuery.addEventListener?.('change', updatePreference);
+    mediaQuery.addListener?.(updatePreference);
+
+    onDestroy(() => {
+      mediaQuery.removeEventListener?.('change', updatePreference);
+      mediaQuery.removeListener?.(updatePreference);
+    });
+  }
+
+  $: shouldReduceMotion = reducedMotion ?? prefersReducedMotion;
+
+  $: flyInOptions = shouldReduceMotion
     ? { duration: 0 }
     : { y: -12, duration: TRANSITION_DURATION, easing: cubicOut };
 
-  $: flyOutOptions = reducedMotion
+  $: flyOutOptions = shouldReduceMotion
     ? { duration: 0 }
     : { y: 12, duration: TRANSITION_DURATION, easing: cubicOut };
 
-  $: fadeOptions = reducedMotion
+  $: fadeOptions = shouldReduceMotion
     ? { duration: 0 }
     : { duration: TRANSITION_DURATION, easing: cubicOut };
 </script>
@@ -75,6 +99,6 @@
   out:fly={flyOutOptions}
   out:fade={fadeOptions}
 >
-  <StarStorm color={starColor} {reducedMotion} />
+  <StarStorm color={starColor} reducedMotion={shouldReduceMotion} />
   <slot />
 </div>


### PR DESCRIPTION
## Summary
- default the MenuPanel reducedMotion behavior to the OS-level `prefers-reduced-motion` media query when the prop is omitted
- reuse the derived reduced-motion flag for panel transitions and the StarStorm child component so all animations stay in sync
- keep the media-query listener updated as preferences change to avoid regressions for accessibility settings

## Testing
- bun run lint

------
https://chatgpt.com/codex/tasks/task_b_68def3c26a5c832cb5cd5d984c9f107f