### PR TITLE
Fix MenuPanel transition directives

### DIFF
--- a/frontend/src/lib/components/MenuPanel.svelte
+++ b/frontend/src/lib/components/MenuPanel.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { fade, fly } from 'svelte/transition';
+  import { fly } from 'svelte/transition';
   import { cubicOut } from 'svelte/easing';
   import { onDestroy } from 'svelte';
   import { browser } from '$app/environment';
@@ -42,9 +42,6 @@
     ? { duration: 0 }
     : { y: 12, duration: TRANSITION_DURATION, easing: cubicOut };
 
-  $: fadeOptions = shouldReduceMotion
-    ? { duration: 0 }
-    : { duration: TRANSITION_DURATION, easing: cubicOut };
 </script>
 
 <style>
@@ -95,9 +92,7 @@
   class={`panel ${$$props.class || ''}`}
   style={`--padding: ${padding}; ${style}`}
   in:fly={flyInOptions}
-  in:fade={fadeOptions}
   out:fly={flyOutOptions}
-  out:fade={fadeOptions}
 >
   <StarStorm color={starColor} reducedMotion={shouldReduceMotion} />
   <slot />


### PR DESCRIPTION
## Summary
- remove the extra fade transition usage from MenuPanel so only the fly directive remains

## Testing
- [ ] Backend tests
- [x] Frontend tests (`VITE_API_BASE=http://localhost bun run build`)
- [ ] Linting
- [ ] Doc sync updates (README and `.codex/implementation` docs; link tasks below)

## Checklist
- [ ] Linked or updated relevant `.codex/tasks` entries
- [ ] Updated player roster and foe docs if adding or modifying fighters or enemies
- [ ] Referenced `.codex/implementation/ui-animation-guidelines.md` when adding UI animations

------
https://chatgpt.com/codex/tasks/task_b_68defacc7090832cb3acdbc977688d16