### PR TITLE
fix: separate menu panel transitions

### DIFF
--- a/frontend/src/lib/components/MenuPanel.svelte
+++ b/frontend/src/lib/components/MenuPanel.svelte
@@ -67,6 +67,14 @@
     backdrop-filter: var(--glass-filter);
   }
 
+  .panel-content {
+    display: flex;
+    flex-direction: column;
+    flex: 1 1 auto;
+    width: 100%;
+    min-height: 100%;
+  }
+
   /* Themed scrollbars for dark UI */
   .panel {
     scrollbar-width: thin;
@@ -95,10 +103,10 @@
   class={`panel ${$$props.class || ''}`}
   style={`--padding: ${padding}; ${style}`}
   in:fly={flyInOptions}
-  in:fade={fadeOptions}
   out:fly={flyOutOptions}
-  out:fade={fadeOptions}
 >
-  <StarStorm color={starColor} reducedMotion={shouldReduceMotion} />
-  <slot />
+  <div class="panel-content" in:fade={fadeOptions} out:fade={fadeOptions}>
+    <StarStorm color={starColor} reducedMotion={shouldReduceMotion} />
+    <slot />
+  </div>
 </div>


### PR DESCRIPTION
## Summary
- wrap the MenuPanel slot content in an inner container so fade transitions apply without conflicting with the fly transition
- add a flexbox wrapper style to preserve layout and scrolling while maintaining reduced motion behavior

## Testing
- VITE_API_BASE=http://localhost bun run build

------
https://chatgpt.com/codex/tasks/task_b_68df48b41c90832c860d0dbdab12456a