### PR TITLE
Fix staged roster toggle gating

### DIFF
--- a/frontend/src/lib/components/PartyRoster.svelte
+++ b/frontend/src/lib/components/PartyRoster.svelte
@@ -115,7 +115,7 @@
 
     previewId = id;
 
-    if (wasStaged && !char?.is_player) {
+    if (wasStaged && priorPreview === id && !char?.is_player) {
       const replaceId = stagedReplaceId ?? computeReplaceTarget(id, priorPreview);
       dispatchToggle(id, { replaceId, reason: 'second-click' });
       clearStaged(id);

--- a/frontend/tests/partypicker.test.js
+++ b/frontend/tests/partypicker.test.js
@@ -62,6 +62,13 @@ describe('PartyPicker component', () => {
     expect(content).toContain('sparkleTrail');
   });
 
+  test('roster stages on first tap and requires a second tap or long-press to toggle', () => {
+    const content = readFileSync(join(import.meta.dir, '../src/lib/components/PartyRoster.svelte'), 'utf8');
+    expect(content).toContain('if (wasStaged && priorPreview === id && !char?.is_player) {');
+    expect(content).toContain('armToggle(char, priorPreview);');
+    expect(content).toContain("dispatchToggle(char.id, { replaceId, reason: 'long-press' });");
+  });
+
   test('roster layout snapshot', () => {
     const content = readFileSync(join(import.meta.dir, '../src/lib/components/PartyRoster.svelte'), 'utf8');
     expect(content).toMatchSnapshot();


### PR DESCRIPTION
## Summary
- gate click-driven roster toggles behind both staging and matching preview ids
- verify tests assert first tap previews while long-press and second tap toggle

## Testing
- bun test --bail *(fails: tests/assets.test.js expects bg_attack_default_gray.png)*

------
https://chatgpt.com/codex/tasks/task_b_68dff3a032c4832ca20046a73da73158