### PR TITLE
Adjust battle placeholder gating for fresh runs

### DIFF
--- a/backend/routes/ui.py
+++ b/backend/routes/ui.py
@@ -210,9 +210,18 @@ async def get_ui_state() -> tuple[str, int, dict[str, Any]]:
                 isinstance(progression, dict) and progression.get("current_step")
             )
 
+            has_active_battle_task = (
+                run_id in battle_tasks and not battle_tasks[run_id].done()
+            )
+            state_reports_battle = bool(state.get("battle"))
+
             if snap is not None and is_battle_room:
                 current_room_data = snap
-            elif is_battle_room and not awaiting_progression:
+            elif (
+                is_battle_room
+                and not awaiting_progression
+                and (has_active_battle_task or state_reports_battle)
+            ):
                 # Battle is active but no snapshot is available yet.
                 current_room_data = {
                     "result": "battle",

--- a/backend/tests/test_ui_battle_placeholder.py
+++ b/backend/tests/test_ui_battle_placeholder.py
@@ -34,6 +34,7 @@ async def test_ui_reports_battle_mode_when_snapshot_missing(app_with_db):
     state["awaiting_card"] = False
     state["awaiting_relic"] = False
     state["awaiting_loot"] = False
+    state["battle"] = True
     state.pop("reward_progression", None)
     await asyncio.to_thread(save_map, run_id, state)
 


### PR DESCRIPTION
## Summary
- require an active battle task or persisted battle flag before returning the placeholder response
- set the regression test's map state battle flag to emulate a mid-battle restore without a snapshot

## Testing
- uv run pytest tests/test_ui_battle_placeholder.py

------
https://chatgpt.com/codex/tasks/task_b_68dff7b946b8832c856c748f04cae234