### PR TITLE
feat: log telemetry during startup run pruning

### DIFF
--- a/.codex/tasks/56d43991-run-startup-pruning.task
+++ b/.codex/tasks/56d43991-run-startup-pruning.task
@@ -26,3 +26,5 @@ Implement automatic cleanup of stale runs when the backend boots so the UI alway
 - Coordinate with whoever owns run backup/restore endpoints so expectations stay aligned (`services/run_service.py` helpers like `backup_save`, `restore_save`).
 - Validate that login reward streak tracking and analytics events remain intact after pruning.
 - If adding new helper functions, keep files under ~300 lines or split appropriately per repository guidelines.
+
+Ready for Task Master

--- a/backend/.codex/implementation/run-modules.md
+++ b/backend/.codex/implementation/run-modules.md
@@ -5,6 +5,10 @@ The backend's former `game.py` helpers have been split into focused modules unde
 - `runs/encryption.py` – provides `get_save_manager` and `get_fernet` with global caching.
 - `runs/party_manager.py` – utilities for party and player customization, loading and saving parties, and passive descriptions.
 - `runs/lifecycle.py` – manages run and battle state, map persistence, and exposes the `_run_battle` coroutine used by room services.
+- `services/run_service.prune_runs_on_startup()` – invoked by `app.before_serving` to purge persisted runs and in-memory battle
+  caches so each backend boot begins from a clean slate. Historical battle logs
+  remain on disk for analytics/backups, and telemetry marks removed runs as
+  `aborted` to keep tracking timelines coherent.
 
 These modules are imported directly by services and tests, reducing coupling and clarifying responsibilities.
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -13,6 +13,15 @@ uv sync
 uv run app.py
 ```
 
+## Startup Run Pruning
+
+On startup the backend now clears any persisted run rows and in-memory battle
+state before serving traffic. This guarantees the UI always begins from a clean
+menu instead of reviving unfinished adventures that remained on disk. Battle
+logs remain on disk, and telemetry records each removed run as an "aborted"
+outcome so analytics timelines stay consistent. Operators must restore an
+exported backup after a restart if they want to pick up a suspended run.
+
 ## LLM Loader
 
 `backend/llms/loader.py` provides a LangChain-based loader for local models. Select a backend with `AF_LLM_MODEL`:

--- a/backend/app.py
+++ b/backend/app.py
@@ -37,6 +37,7 @@ from runs.party_manager import _describe_passives  # noqa: F401
 from runs.party_manager import _load_player_customization  # noqa: F401
 from runs.party_manager import load_party  # noqa: F401
 from runs.party_manager import save_party  # noqa: F401
+from services.run_service import prune_runs_on_startup
 from werkzeug.exceptions import HTTPException
 
 from autofighter.gacha import GachaManager  # noqa: F401  # re-export for tests
@@ -126,6 +127,11 @@ async def _cleanup_loop() -> None:
     while True:
         await asyncio.sleep(300)
         await cleanup_battle_state()
+
+
+@app.before_serving
+async def prune_runs_before_serving() -> None:
+    await prune_runs_on_startup()
 
 
 @app.before_serving

--- a/backend/tests/test_startup_pruning.py
+++ b/backend/tests/test_startup_pruning.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+import sys
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_prune_runs_on_startup_clears_persistent_and_cached_state(monkeypatch, tmp_path):
+    db_path = tmp_path / "save.db"
+    monkeypatch.setenv("AF_DB_PATH", str(db_path))
+    monkeypatch.setenv("AF_DB_KEY", "testkey")
+    monkeypatch.setenv("AF_TRACK_DB_PATH", str(tmp_path / "track.db"))
+    monkeypatch.syspath_prepend(str(Path(__file__).resolve().parents[1]))
+
+    sys.modules.pop("tracking", None)
+
+    # Ensure the save manager will pick up the new database path.
+    from runs import encryption
+    from runs import lifecycle
+    from tracking import manager as tracking_manager
+
+    tracking_manager.TRACKING_MANAGER = None
+
+    encryption.SAVE_MANAGER = None
+    encryption.FERNET = None
+
+    lifecycle.purge_all_run_state()
+
+    from services import run_service
+
+    start_result = await run_service.start_run(["player"])
+    run_id = start_result["run_id"]
+
+    lifecycle.battle_snapshots[run_id] = {"awaiting_next": False}
+    lifecycle.battle_locks[run_id] = asyncio.Lock()
+    lifecycle.battle_tasks[run_id] = asyncio.create_task(asyncio.sleep(10))
+
+    with encryption.get_save_manager().connection() as conn:
+        remaining = conn.execute("SELECT COUNT(*) FROM runs").fetchone()[0]
+    assert remaining == 1
+
+    await run_service.prune_runs_on_startup()
+    await asyncio.sleep(0)
+
+    with encryption.get_save_manager().connection() as conn:
+        remaining = conn.execute("SELECT COUNT(*) FROM runs").fetchone()[0]
+    assert remaining == 0
+
+    assert lifecycle.battle_tasks == {}
+    assert lifecycle.battle_snapshots == {}
+    assert lifecycle.battle_locks == {}
+
+    tracking_db = tracking_manager.get_tracking_manager()
+    with tracking_db.connection() as conn:
+        outcome_row = conn.execute(
+            "SELECT outcome FROM runs WHERE run_id = ?",
+            (run_id,),
+        ).fetchone()
+        assert outcome_row is not None
+        assert outcome_row[0] == "aborted"
+
+        session_row = conn.execute(
+            "SELECT logout_ts FROM play_sessions WHERE session_id = ?",
+            (run_id,),
+        ).fetchone()
+        assert session_row is not None
+        assert session_row[0] is not None
+
+        menu_row = conn.execute(
+            "SELECT menu_item, result, details_json FROM menu_actions WHERE result = ?",
+            ("startup_pruned",),
+        ).fetchone()
+        assert menu_row is not None
+        assert menu_row[0] == "Run"
+        assert menu_row[1] == "startup_pruned"
+        details = json.loads(menu_row[2])
+        assert details["run_id"] == run_id
+        assert details["reason"] == "startup_prune"
+
+    # A second invocation should be a no-op and should not raise errors.
+    await run_service.prune_runs_on_startup()
+    await asyncio.sleep(0)


### PR DESCRIPTION
## Summary
- ensure `prune_runs_on_startup` emits battle end events with run ids and records run/menu/session telemetry so analytics stay consistent (Goal 33e45df1-run-start-flow)
- document the telemetry side effects of startup pruning in the backend README and run module implementation notes
- extend the startup pruning regression test to verify the tracking database captures the aborted run outcome and menu action details

## Testing
- uv run ruff check services/run_service.py tests/test_startup_pruning.py
- uv run pytest tests/test_startup_pruning.py

------
https://chatgpt.com/codex/tasks/task_b_68e03514fbd4832cb88a93bbc0a7f7e6