### PR TITLE
Fix battle floaters labels for nested metadata

### DIFF
--- a/frontend/src/lib/components/BattleEventFloaters.svelte
+++ b/frontend/src/lib/components/BattleEventFloaters.svelte
@@ -54,6 +54,8 @@
     'name',
     'display_name',
     'displayName',
+    'effect_label',
+    'effectLabel',
     'effect_name',
     'effect',
     'effect_type',
@@ -146,6 +148,8 @@
       if (meta.details && typeof meta.details === 'object') {
         const details = meta.details;
         fallbackValues.push(
+          details.effect_label,
+          details.effectLabel,
           details.effect,
           details.effect_type,
           details.effectType,

--- a/frontend/tests/battle-floaters.test.js
+++ b/frontend/tests/battle-floaters.test.js
@@ -34,6 +34,28 @@ describe('Battle event floaters', () => {
     expect(labelBlock).toContain("'effect_label'");
   });
 
+  test('DETAIL_LABEL_KEYS include nested effect_label variants for aftertaste metadata', () => {
+    const detailBlockStart = floaterSource.indexOf('const DETAIL_LABEL_KEYS');
+    expect(detailBlockStart).toBeGreaterThan(-1);
+    const detailBlockEnd = floaterSource.indexOf('];', detailBlockStart);
+    expect(detailBlockEnd).toBeGreaterThan(detailBlockStart);
+    const detailBlock = floaterSource.slice(detailBlockStart, detailBlockEnd);
+    expect(detailBlock).toContain("'effect_label'");
+    expect(detailBlock).toContain("'effectLabel'");
+  });
+
+  test('card and relic floater fallback inspects metadata.details effect_label', () => {
+    const detailsBlockStart = floaterSource.indexOf('const details = meta.details;');
+    expect(detailsBlockStart).toBeGreaterThan(-1);
+    const fallbackPushStart = floaterSource.indexOf('fallbackValues.push(', detailsBlockStart);
+    expect(fallbackPushStart).toBeGreaterThan(detailsBlockStart);
+    const fallbackPushEnd = floaterSource.indexOf(');', fallbackPushStart);
+    expect(fallbackPushEnd).toBeGreaterThan(fallbackPushStart);
+    const fallbackBlock = floaterSource.slice(fallbackPushStart, fallbackPushEnd);
+    expect(fallbackBlock).toContain('details.effect_label');
+    expect(fallbackBlock).toContain('details.effectLabel');
+  });
+
   test('staggered floater scheduling uses index-based offsets', () => {
     const anchor = 'list.forEach((raw, i) => {';
     const start = floaterSource.indexOf(anchor);


### PR DESCRIPTION
## Summary
- update BattleEventFloaters to read nested effect_label/effectLabel values
- extend card/relic floater fallback search with nested effect label metadata
- add tests covering nested aftertaste label detection

## Testing
- [ ] Backend tests
- [x] Frontend tests
- [ ] Linting
- [ ] Doc sync updates (README and `.codex/implementation` docs; link tasks below)


------
https://chatgpt.com/codex/tasks/task_b_68e0417e15a8832cb52d4cf550e86d88