### PR TITLE
feat: surface tick indicators on fighter cards

### DIFF
--- a/frontend/src/lib/components/BattleView.svelte
+++ b/frontend/src/lib/components/BattleView.svelte
@@ -179,6 +179,12 @@
     'card_effect',
     'relic_effect',
   ]);
+  const tickIndicatorQueues = new Map();
+  const tickIndicatorTimers = new Map();
+  const tickIndicatorTokenRefs = new Map();
+  let tickIndicators = new Map();
+  let tickIndicatorCounter = 0;
+  let tickIndicatorDuration = 800;
   let lastRunId = runId;
 
   function normalizeChargeIdentifier(entry, index) {
@@ -262,6 +268,7 @@
     lastRunId = runId;
     currentTurn = null;
     battleSnapshot = null;
+    clearTickIndicators();
   }
   $: if (!active) {
     floaterFeed = [];
@@ -284,6 +291,7 @@
     hpHistory = new Map();
     currentTurn = null;
     battleSnapshot = null;
+    clearTickIndicators();
   }
 
   // Compute and update anchor for a given id/node
@@ -736,6 +744,7 @@
   // Example: 30fps -> 3/s, 60fps -> 6/s, 120fps -> 12/s
   let pollDelay = 10000 / framerate;
   $: pollDelay = 10000 / framerate;
+  $: tickIndicatorDuration = Math.max(750, pollDelay * 1.35);
   $: statusChipLifetime = effectiveReducedMotion ? Math.max(900, pollDelay * 6) : Math.max(1600, pollDelay * 10);
   let bg = getRandomBackground();
 
@@ -918,6 +927,125 @@
     ].join('::');
   }
 
+  function refreshTickIndicators() {
+    if (!tickIndicatorQueues.size) {
+      tickIndicators = new Map();
+      return;
+    }
+    tickIndicators = new Map(
+      Array.from(tickIndicatorQueues.entries(), ([key, list]) => [
+        key,
+        list.slice().sort((a, b) => a.timestamp - b.timestamp),
+      ]),
+    );
+  }
+
+  function clearTickIndicators() {
+    for (const handle of tickIndicatorTimers.values()) {
+      try { clearTimeout(handle); } catch {}
+    }
+    tickIndicatorQueues.clear();
+    tickIndicatorTimers.clear();
+    tickIndicatorTokenRefs.clear();
+    tickIndicators = new Map();
+    tickIndicatorCounter = 0;
+  }
+
+  function queueTickIndicators(events) {
+    if (!Array.isArray(events) || !events.length) return;
+    let mutated = false;
+    for (const raw of events) {
+      if (!raw || typeof raw !== 'object') continue;
+      const normalized = raw && typeof raw === 'object' && 'damageTypeId' in raw
+        ? raw
+        : normalizeRecentEvent(raw);
+      if (!normalized) continue;
+      const kind = String(normalized.type || '').toLowerCase();
+      if (kind !== 'dot_tick' && kind !== 'hot_tick') continue;
+      const targetKey = normalizeId(normalized.target_id ?? normalized.targetId);
+      if (!targetKey) continue;
+      const token = eventToken(normalized);
+      if (token && tickIndicatorTokenRefs.has(token)) continue;
+      const timestamp = Date.now();
+      const entry = {
+        id: `${timestamp}:${tickIndicatorCounter += 1}`,
+        targetId: targetKey,
+        amount: Number(normalized.amount ?? 0) || 0,
+        damageTypeId: normalizeDamageTypeId(
+          normalized.damageTypeId ||
+            normalized.metadata?.damage_type_id ||
+            normalized.metadata?.damage_type ||
+            normalized.metadata?.element ||
+            '',
+        ),
+        type: kind,
+        timestamp,
+        token,
+      };
+      const existing = tickIndicatorQueues.get(targetKey) || [];
+      tickIndicatorQueues.set(targetKey, [...existing, entry]);
+      if (token) tickIndicatorTokenRefs.set(token, entry.id);
+      const delay = Math.max(0, Number(tickIndicatorDuration) || 0);
+      const handle = setTimeout(() => {
+        tickIndicatorTimers.delete(entry.id);
+        const queue = tickIndicatorQueues.get(targetKey) || [];
+        const next = queue.filter(item => item.id !== entry.id);
+        if (next.length) {
+          tickIndicatorQueues.set(targetKey, next);
+        } else {
+          tickIndicatorQueues.delete(targetKey);
+        }
+        if (entry.token && tickIndicatorTokenRefs.get(entry.token) === entry.id) {
+          tickIndicatorTokenRefs.delete(entry.token);
+        }
+        refreshTickIndicators();
+      }, delay || 0);
+      tickIndicatorTimers.set(entry.id, handle);
+      mutated = true;
+    }
+    if (mutated) refreshTickIndicators();
+  }
+
+  function collectTickIndicatorIds(entity) {
+    const ids = new Set();
+    if (entity === undefined || entity === null) return ids;
+    if (typeof entity !== 'object') {
+      const key = normalizeId(entity);
+      if (key) ids.add(key);
+      return ids;
+    }
+    const directKeys = [
+      entity.id,
+      entity.instance_id,
+      entity.renderKey,
+      entity.render_key,
+      entity.hpKey,
+      entity.anchorId,
+    ];
+    for (const value of directKeys) {
+      const key = normalizeId(value);
+      if (key) ids.add(key);
+    }
+    if (Array.isArray(entity.anchorIds)) {
+      for (const candidate of entity.anchorIds) {
+        const key = normalizeId(candidate);
+        if (key) ids.add(key);
+      }
+    }
+    return ids;
+  }
+
+  function getTickIndicatorsForEntity(entity) {
+    const ids = collectTickIndicatorIds(entity);
+    for (const key of ids) {
+      if (tickIndicators.has(key)) {
+        const queue = tickIndicators.get(key) || [];
+        if (queue.length) return queue;
+      }
+    }
+    return [];
+  }
+
   // Group/dedupe recent events: show only newly increased instances per unique token
   function processRecentEvents(events) {
     if (!Array.isArray(events)) {
@@ -953,6 +1081,9 @@
     }
     recentEventCounts = nextCounts;
     lastRecentEventTokens = tokens;
+    if (newOnes.length) {
+      queueTickIndicators(newOnes);
+    }
     return newOnes;
   }
 
@@ -1842,7 +1973,9 @@
       const phaseOutcome = handlePhaseTransition(phaseInfo, normalizedEvents, snap.recent_events || []);
 
       if (phaseOutcome && 'overlayEvents' in phaseOutcome) {
-        recentEvents = phaseOutcome.overlayEvents || [];
+        const overlayList = phaseOutcome.overlayEvents || [];
+        recentEvents = overlayList;
+        queueTickIndicators(overlayList);
       } else if (!Array.isArray(snap.recent_events)) {
         recentEvents = [];
       }
@@ -1915,6 +2048,7 @@
   onDestroy(() => {
     clearPollTimer();
     clearStatusTimeline();
+    clearTickIndicators();
   });
 
   // Watch active state changes
@@ -2052,7 +2186,14 @@
           
           <!-- Character photo/portrait -->
           <div class="fighter-anchor" use:registerAnchor={foe.id}>
-            <BattleFighterCard fighter={foe} position="top" {effectiveReducedMotion} sizePx={getFoeSizePx(foeCount)} highlight={hoveredId === foe.id} />
+            <BattleFighterCard
+              fighter={foe}
+              position="top"
+              {effectiveReducedMotion}
+              sizePx={getFoeSizePx(foeCount)}
+              highlight={hoveredId === foe.id}
+              tickIndicators={getTickIndicatorsForEntity(foe)}
+            />
           </div>
           
           <!-- Summons -->
@@ -2118,6 +2259,7 @@
                           (Array.isArray(summon.anchorIds) && summon.anchorIds.includes(hoveredId)) ||
                           (hoveredId && summon?.summoner_id && summon?.summon_type && hoveredId === `${summon.summoner_id}_${summon.summon_type}_summon`)
                         }
+                        tickIndicators={getTickIndicatorsForEntity(summon)}
                       />
                     </div>
                   </div>
@@ -2160,6 +2302,7 @@
                         (Array.isArray(summon.anchorIds) && summon.anchorIds.includes(hoveredId)) ||
                         (hoveredId && summon?.summoner_id && summon?.summon_type && hoveredId === `${summon.summoner_id}_${summon.summon_type}_summon`)
                       }
+                      tickIndicators={getTickIndicatorsForEntity(summon)}
                     />
                   </div>
 
@@ -2219,7 +2362,13 @@
 
         <div class="party-main fighter-anchor" use:registerAnchor={member.id}>
           <!-- Character photo as base (ult & pips overlay handled inside) -->
-          <BattleFighterCard fighter={member} position="bottom" {effectiveReducedMotion} highlight={hoveredId === member.id} />
+          <BattleFighterCard
+            fighter={member}
+            position="bottom"
+            {effectiveReducedMotion}
+            highlight={hoveredId === member.id}
+            tickIndicators={getTickIndicatorsForEntity(member)}
+          />
         </div>
         
         <!-- HP bar under the photo -->

--- a/frontend/tests/__fixtures__/BattleFighterCard.stub.svelte
+++ b/frontend/tests/__fixtures__/BattleFighterCard.stub.svelte
@@ -4,6 +4,7 @@
   export let effectiveReducedMotion = false;
   export let sizePx = 0;
   export let highlight = false;
+  export let tickIndicators = [];
 </script>
 
 <div
@@ -11,4 +12,6 @@
   data-id={fighter?.id ?? ''}
   data-position={position}
   data-highlight={highlight ? 'yes' : 'no'}
+  data-ticks={Array.isArray(tickIndicators) ? tickIndicators.length : 0}
+  data-tick-types={Array.isArray(tickIndicators) ? tickIndicators.map(item => item?.type || '').join(',') : ''}
 ></div>

--- a/frontend/tests/battle-fighter-card.vitest.js
+++ b/frontend/tests/battle-fighter-card.vitest.js
@@ -1,0 +1,50 @@
+import { render, cleanup } from '@testing-library/svelte';
+import { afterEach, describe, expect, it } from 'vitest';
+import BattleFighterCard from '../src/lib/battle/BattleFighterCard.svelte';
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('BattleFighterCard tick indicators', () => {
+  it('renders tick indicator arrows with damage-type palette', () => {
+    const tickIndicators = [
+      { id: 'dot-1', type: 'dot_tick', amount: 12, damageTypeId: 'poison', timestamp: Date.now() },
+      { id: 'hot-1', type: 'hot_tick', amount: 8, damageTypeId: 'light', timestamp: Date.now() + 1 },
+    ];
+
+    const { container } = render(BattleFighterCard, {
+      props: {
+        fighter: { id: 'hero', name: 'Hero', element: 'fire' },
+        position: 'bottom',
+        tickIndicators,
+      },
+    });
+
+    const layer = container.querySelector('.tick-indicator-layer');
+    expect(layer).not.toBeNull();
+    const arrows = Array.from(layer.querySelectorAll('.tick-arrow'));
+    expect(arrows).toHaveLength(2);
+    expect(arrows[0].classList.contains('dot')).toBe(true);
+    expect(arrows[1].classList.contains('hot')).toBe(true);
+    expect(arrows[0].getAttribute('style')).toContain('--arrow-color');
+    expect(arrows[1].getAttribute('style')).toContain('--arrow-color');
+  });
+
+  it('disables tick indicator animations when reduced motion is active', () => {
+    const { container } = render(BattleFighterCard, {
+      props: {
+        fighter: { id: 'hero', name: 'Hero', element: 'water' },
+        position: 'top',
+        reducedMotion: true,
+        tickIndicators: [
+          { id: 'dot-1', type: 'dot_tick', amount: 4, damageTypeId: 'ice', timestamp: Date.now() },
+        ],
+      },
+    });
+
+    const layer = container.querySelector('.tick-indicator-layer');
+    expect(layer).not.toBeNull();
+    expect(layer.classList.contains('reduced')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- track dot/hot tick overlay events in BattleView and expose per-target queues to fighter cards
- render tinted tick indicator arrows on BattleFighterCard with reduced-motion support
- cover the new plumbing with vitest cases for BattleView and BattleFighterCard

## Testing
- bun test *(fails: existing suite reports multiple unrelated integration failures and snapshot mismatches)*
- bun x vitest run tests/battle-turn-phase.vitest.js tests/battle-fighter-card.vitest.js *(fails: vite plugin initialization error in current environment)*

------
https://chatgpt.com/codex/tasks/task_b_68e15c7e98d4832c877a653c17f6246f