### PR TITLE
fix(frontend): initialize battle review stores before reset

### DIFF
--- a/frontend/src/lib/systems/battleReview/state.js
+++ b/frontend/src/lib/systems/battleReview/state.js
@@ -679,6 +679,9 @@ export function createBattleReviewState(initialProps = {}) {
   const timeWindow = writable(null);
   const timelineCursor = writable({ time: 0, eventId: null });
 
+  const reducedMotion = derived(props, ($props) => Boolean($props.reducedMotion));
+  const activeTab = writable('overview');
+
   let lastKey = '';
   let currentToken = 0;
 
@@ -775,7 +778,6 @@ export function createBattleReviewState(initialProps = {}) {
     }
   }
 
-  const reducedMotion = derived(props, ($props) => Boolean($props.reducedMotion));
   const displayParty = derived([props, summary], ([$props, $summary]) => deriveDisplayParty($props, $summary));
   const displayFoes = derived([props, summary], ([$props, $summary]) => deriveDisplayFoes($props, $summary));
   const outgoingBySource = derived([displayParty, displayFoes], ([$party, $foes]) =>
@@ -783,8 +785,6 @@ export function createBattleReviewState(initialProps = {}) {
   );
 
   const availableTabs = derived([displayParty, displayFoes], ([$party, $foes]) => buildAvailableTabs($party, $foes));
-
-  const activeTab = writable('overview');
 
   const currentTab = derived([availableTabs, activeTab], ([$tabs, $active]) =>
     $tabs.find((tab) => tab.id === $active) || $tabs[0]


### PR DESCRIPTION
## Summary
- declare the battle review reduced motion derived store before it is read inside resetViewState
- initialize the activeTab writable store earlier so resetViewState can safely reset it

## Testing
- bun run lint
- bun test *(fails: PartyPicker expectation missing in source file, pre-existing)*

------
https://chatgpt.com/codex/tasks/task_b_68e15f2fd3f4832c8ec0ccaa2ab86244