### PR TITLE
feat: align stat upgrade interactions

### DIFF
--- a/frontend/.codex/implementation/party-ui.md
+++ b/frontend/.codex/implementation/party-ui.md
@@ -38,11 +38,17 @@ Implementation details:
   can be disabled via Settings.
 - `StatTabs.svelte` uses flexible sizing so the panel fills its side and now
   surfaces a read-only stat summary alongside upgrade controls rather than
-  embedding the inline Character Editor.
+  embedding the inline Character Editor. In upgrade mode the stats list now
+  slides away and a right-aligned upgrade sheet animates in with "impact now",
+  "after upgrade", expected material cost, and the available inventory count
+  for the currently selected damage type.
 - The stat upgrade section pulls `/players/<id>/upgrade` to show remaining
-  points, per-stat totals, and next costs, dispatches `open-upgrade-mode` /
-  `close-upgrade-mode` events for `PartyPicker.svelte`, and issues upgrade
+  points, per-stat totals, and next costs, dispatches `open-upgrade` /
+  `close-upgrade` events for `PartyPicker.svelte`, and issues upgrade
   requests through the API helper that lets the server determine point costs.
+  Stat buttons in the portrait preview emit a `select-upgrade` event so the
+  Party picker can sync the highlighted stat with the new side-panel controls
+  before forwarding the upgrade request to the backend.
 - `PartyPicker.svelte` tracks the preview pane mode in a local store. Upgrade
   interactions toggle an inline upgrade sheet, which bubbles events back to the
   overlay so stat spend requests can be handled alongside the existing upgrade

--- a/frontend/src/lib/components/PartyPicker.svelte
+++ b/frontend/src/lib/components/PartyPicker.svelte
@@ -34,6 +34,7 @@
   let upgradeTokens = {};
   const EMPTY_UPGRADE_STATE = { data: null, loading: false, error: null };
   let previewUpgradeState = EMPTY_UPGRADE_STATE;
+  let previewStat = null;
   const STAT_LABELS = {
     max_hp: 'HP',
     atk: 'ATK',
@@ -56,6 +57,7 @@
   $: if ((previewId ?? null) !== lastPreviewedId) {
     lastPreviewedId = previewId ?? null;
     upgradeContext = null;
+    previewStat = null;
     previewMode.set('portrait');
     if (previewId) refreshUpgradeData(previewId, { force: true });
     try { dispatch('previewMode', { mode: 'portrait', id: previewId ?? null }); } catch {}
@@ -278,12 +280,23 @@
       character: char || null
     };
     upgradeContext = mode === 'upgrade' ? nextDetail : null;
+    if (mode === 'upgrade') {
+      previewStat = detail?.stat ?? previewStat ?? null;
+    } else {
+      previewStat = null;
+    }
     previewMode.set(mode);
     // When entering upgrade mode, force-refresh upgrade data so convert availability is accurate
     if (mode === 'upgrade' && nextDetail.id) {
       try { refreshUpgradeData(nextDetail.id, { force: true }); } catch {}
     }
     try { dispatch('previewMode', { mode, ...nextDetail }); } catch {}
+  }
+
+  function handleUpgradeSelection(detail) {
+    if (!detail) return;
+    previewStat = detail.stat ?? previewStat ?? null;
+    handlePreviewMode(detail, 'upgrade');
   }
 
   async function forwardUpgradeRequest(detail) {
@@ -445,10 +458,12 @@
         upgradeData={previewUpgradeState.data}
         upgradeLoading={previewUpgradeState.loading}
         upgradeError={previewUpgradeState.error}
+        selectedStat={previewStat}
         {reducedMotion}
         on:open-upgrade={(e) => handlePreviewMode(e.detail, 'upgrade')}
         on:close-upgrade={(e) => handlePreviewMode(e.detail, 'portrait')}
         on:request-upgrade={(e) => forwardUpgradeRequest(e.detail)}
+        on:select-upgrade={(e) => handleUpgradeSelection(e.detail)}
         on:element-change={(e) => {
           const el = e.detail?.element || '';
           previewElementOverride = el || previewElementOverride;
@@ -461,11 +476,22 @@
         }}
       />
       <div class="right-col">
-        <StatTabs {roster} {previewId} {selected} {userBuffPercent}
+        <StatTabs
+          {roster}
+          {previewId}
+          {selected}
+          {userBuffPercent}
           upgradeMode={$previewMode === 'upgrade'}
+          upgradeData={previewUpgradeState.data}
+          upgradeLoading={previewUpgradeState.loading}
+          upgradeError={previewUpgradeState.error}
+          upgradeContext={upgradeContext}
+          selectedStat={previewStat}
           on:toggle={(e) => toggleMember(e.detail)}
           on:open-upgrade={(e) => handlePreviewMode(e.detail, 'upgrade')}
           on:close-upgrade={(e) => handlePreviewMode(e.detail, 'portrait')}
+          on:request-upgrade={(e) => forwardUpgradeRequest(e.detail)}
+          on:select-upgrade={(e) => handleUpgradeSelection(e.detail)}
         />
         <div class="party-actions-inline">
           {#if actionLabel === 'Start Run'}

--- a/frontend/src/lib/components/PlayerPreview.svelte
+++ b/frontend/src/lib/components/PlayerPreview.svelte
@@ -20,6 +20,7 @@
   export let upgradeLoading = false;
   export let upgradeError = null;
   export let reducedMotion = false;
+  export let selectedStat = null;
 
   const dispatch = createEventDispatcher();
   const REPEAT_OPTIONS = [1, 5, 10];
@@ -62,7 +63,7 @@
   $: ElementIcon = getElementIcon(elementName || 'Generic');
   $: pendingStat = upgradeContext?.pendingStat || null;
   $: highlightedStat =
-    pendingStat || upgradeContext?.stat || upgradeContext?.lastRequestedStat || null;
+    pendingStat || upgradeContext?.stat || upgradeContext?.lastRequestedStat || selectedStat || null;
   $: upgradeItems = upgradeData?.items || {};
   $: upgradeTotals = upgradeData?.stat_totals || {};
   $: upgradeCosts = upgradeData?.next_costs || {};
@@ -278,6 +279,12 @@
     });
   }
 
+  function selectUpgrade(stat) {
+    if (!selected || !stat || pendingAction) return;
+    dispatch('select-upgrade', { id: selected.id, stat });
+    dispatch('open-upgrade', { id: selected.id, stat });
+  }
+
   function handleBackgroundClick(event) {
     if (event.target !== event.currentTarget) return;
     closeUpgrade('background');
@@ -403,31 +410,31 @@
 
               <!-- Buttons; icons inherit accent via color -->
               <button type="button" class="stat-icon-btn" style={`left:${currentLayout.hp.x}%; top:${currentLayout.hp.y}%; transform:translate(-50%,-50%); color:${accent}`}
-                class:active={highlightedStat==='max_hp'} disabled={pendingAction} on:click={() => requestUpgrade('max_hp')} aria-label={`HP — Bolster survivability. Level ${statLevel('max_hp')}`} title={`HP — Bolster survivability. Level ${statLevel('max_hp')}`}>
+                class:active={highlightedStat==='max_hp'} disabled={pendingAction} on:click={() => selectUpgrade('max_hp')} aria-label={`HP — Bolster survivability. Level ${statLevel('max_hp')}`} title={`HP — Bolster survivability. Level ${statLevel('max_hp')}`}>
                 <Heart aria-hidden="true" />
               </button>
               <button type="button" class="stat-icon-btn" style={`left:${currentLayout.atk.x}%; top:${currentLayout.atk.y}%; transform:translate(-50%,-50%); color:${accent}`}
-                class:active={highlightedStat==='atk'} disabled={pendingAction} on:click={() => requestUpgrade('atk')} aria-label={`ATK — Improve offensive power. Level ${statLevel('atk')}`} title={`ATK — Improve offensive power. Level ${statLevel('atk')}`}>
+                class:active={highlightedStat==='atk'} disabled={pendingAction} on:click={() => selectUpgrade('atk')} aria-label={`ATK — Improve offensive power. Level ${statLevel('atk')}`} title={`ATK — Improve offensive power. Level ${statLevel('atk')}`}>
                 <Sword aria-hidden="true" />
               </button>
               <button type="button" class="stat-icon-btn" style={`left:${currentLayout.def.x}%; top:${currentLayout.def.y}%; transform:translate(-50%,-50%); color:${accent}`}
-                class:active={highlightedStat==='defense'} disabled={pendingAction} on:click={() => requestUpgrade('defense')} aria-label={`DEF — Stiffen defenses. Level ${statLevel('defense')}`} title={`DEF — Stiffen defenses. Level ${statLevel('defense')}`}>
+                class:active={highlightedStat==='defense'} disabled={pendingAction} on:click={() => selectUpgrade('defense')} aria-label={`DEF — Stiffen defenses. Level ${statLevel('defense')}`} title={`DEF — Stiffen defenses. Level ${statLevel('defense')}`}>
                 <Shield aria-hidden="true" />
               </button>
               <button type="button" class="stat-icon-btn" style={`left:${currentLayout.crit_rate.x}%; top:${currentLayout.crit_rate.y}%; transform:translate(-50%,-50%); color:${accent}`}
-                class:active={highlightedStat==='crit_rate'} disabled={pendingAction} on:click={() => requestUpgrade('crit_rate')} aria-label={`Crit Rate — Raise critical odds. Level ${statLevel('crit_rate')}`} title={`Crit Rate — Raise critical odds. Level ${statLevel('crit_rate')}`}>
+                class:active={highlightedStat==='crit_rate'} disabled={pendingAction} on:click={() => selectUpgrade('crit_rate')} aria-label={`Crit Rate — Raise critical odds. Level ${statLevel('crit_rate')}`} title={`Crit Rate — Raise critical odds. Level ${statLevel('crit_rate')}`}>
                 <Crosshair aria-hidden="true" />
               </button>
               <button type="button" class="stat-icon-btn" style={`left:${currentLayout.crit_damage.x}%; top:${currentLayout.crit_damage.y}%; transform:translate(-50%,-50%); color:${accent}`}
-                class:active={highlightedStat==='crit_damage'} disabled={pendingAction} on:click={() => requestUpgrade('crit_damage')} aria-label={`Crit DMG — Amplify crit damage. Level ${statLevel('crit_damage')}`} title={`Crit DMG — Amplify crit damage. Level ${statLevel('crit_damage')}`}>
+                class:active={highlightedStat==='crit_damage'} disabled={pendingAction} on:click={() => selectUpgrade('crit_damage')} aria-label={`Crit DMG — Amplify crit damage. Level ${statLevel('crit_damage')}`} title={`Crit DMG — Amplify crit damage. Level ${statLevel('crit_damage')}`}>
                 <Zap aria-hidden="true" />
               </button>
               <button type="button" class="stat-icon-btn" style={`left:${currentLayout.vitality.x}%; top:${currentLayout.vitality.y}%; transform:translate(-50%,-50%); color:${accent}`}
-                class:active={highlightedStat==='vitality'} disabled={!!pendingStat} on:click={() => requestUpgrade('vitality')} aria-label={`Vitality — Extend buff durations & recovery. Level ${statLevel('vitality')}`} title={`Vitality — Extend buff durations & recovery. Level ${statLevel('vitality')}`}>
+                class:active={highlightedStat==='vitality'} disabled={!!pendingStat} on:click={() => selectUpgrade('vitality')} aria-label={`Vitality — Extend buff durations & recovery. Level ${statLevel('vitality')}`} title={`Vitality — Extend buff durations & recovery. Level ${statLevel('vitality')}`}>
                 <HeartPulse aria-hidden="true" />
               </button>
               <button type="button" class="stat-icon-btn" style={`left:${currentLayout.mitigation.x}%; top:${currentLayout.mitigation.y}%; transform:translate(-50%,-50%); color:${accent}`}
-                class:active={highlightedStat==='mitigation'} disabled={!!pendingStat} on:click={() => requestUpgrade('mitigation')} aria-label={`Mitigation — Soften incoming damage. Level ${statLevel('mitigation')}`} title={`Mitigation — Soften incoming damage. Level ${statLevel('mitigation')}`}>
+                class:active={highlightedStat==='mitigation'} disabled={!!pendingStat} on:click={() => selectUpgrade('mitigation')} aria-label={`Mitigation — Soften incoming damage. Level ${statLevel('mitigation')}`} title={`Mitigation — Soften incoming damage. Level ${statLevel('mitigation')}`}>
                 <ShieldPlus aria-hidden="true" />
               </button>
           </div>


### PR DESCRIPTION
## Summary
- track the stat highlighted in PartyPicker so both preview and StatTabs share the same upgrade context and requests
- emit stat selection events from PlayerPreview instead of immediate upgrades
- replace the StatTabs list with a sliding upgrade sheet that exposes impact metrics, cost data, and an Upgrade action, plus sync docs

## Testing
- bun run lint

------
https://chatgpt.com/codex/tasks/task_b_68e1771c0468832caab1442022496d10