### PR TITLE
fix: preserve upgrade pending state when switching stats

### DIFF
--- a/frontend/src/lib/components/PartyPicker.svelte
+++ b/frontend/src/lib/components/PartyPicker.svelte
@@ -279,7 +279,34 @@
       id: char?.id ?? previewId ?? null,
       character: char || null
     };
-    upgradeContext = mode === 'upgrade' ? nextDetail : null;
+    const previousContext = upgradeContext;
+    if (mode === 'upgrade') {
+      const samePendingTarget = Boolean(
+        previousContext?.pendingStat && previousContext?.id && previousContext.id === nextDetail.id
+      );
+      upgradeContext = {
+        ...nextDetail,
+        stat: nextDetail.stat ?? previousContext?.stat ?? null,
+        lastRequestedStat:
+          nextDetail.lastRequestedStat ??
+          (samePendingTarget
+            ? previousContext?.lastRequestedStat ?? previousContext?.pendingStat ?? null
+            : null),
+        pendingStat: samePendingTarget
+          ? previousContext?.pendingStat ?? null
+          : nextDetail.pendingStat ?? null,
+        message:
+          nextDetail.message ??
+          (samePendingTarget ? previousContext?.message ?? '' : '') ??
+          '',
+        error:
+          nextDetail.error ??
+          (samePendingTarget ? previousContext?.error ?? '' : '') ??
+          ''
+      };
+    } else {
+      upgradeContext = null;
+    }
     if (mode === 'upgrade') {
       previewStat = detail?.stat ?? previewStat ?? null;
     } else {


### PR DESCRIPTION
## Summary
- keep the current upgrade context when re-entering upgrade mode for the same character
- retain the pendingStat flag so concurrent upgrade requests stay blocked while one is in flight

## Testing
- bun run lint

------
https://chatgpt.com/codex/tasks/task_b_68e17a8b62e8832c83eaa2e90abdbc68