### PR TITLE
fix: limit stat fallback to the same upgrade target

### DIFF
--- a/frontend/src/lib/components/PartyPicker.svelte
+++ b/frontend/src/lib/components/PartyPicker.svelte
@@ -281,12 +281,13 @@
     };
     const previousContext = upgradeContext;
     if (mode === 'upgrade') {
+      const sameCharacter = Boolean(previousContext?.id && previousContext.id === nextDetail.id);
       const samePendingTarget = Boolean(
         previousContext?.pendingStat && previousContext?.id && previousContext.id === nextDetail.id
       );
       upgradeContext = {
         ...nextDetail,
-        stat: nextDetail.stat ?? previousContext?.stat ?? null,
+        stat: nextDetail.stat ?? (sameCharacter ? previousContext?.stat ?? null : null),
         lastRequestedStat:
           nextDetail.lastRequestedStat ??
           (samePendingTarget


### PR DESCRIPTION
## Summary
- ensure PartyPicker only reuses the previous stat selection when the upgrade context targets the same character

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e17ea0e93c832c871e819cf27f6ea9