### PR TITLE
feat: preserve defeat runs until shutdown

### DIFF
--- a/backend/runs/lifecycle.py
+++ b/backend/runs/lifecycle.py
@@ -116,6 +116,7 @@ async def cleanup_battle_state() -> None:
     locks_removed = 0
 
     for run_id in completed:
+        state: dict[str, Any] = {}
         if battle_tasks.pop(run_id, None) is not None:
             tasks_removed += 1
 
@@ -144,10 +145,13 @@ async def cleanup_battle_state() -> None:
             ended = state.get("ended", False)
 
         has_rewards = any([awaiting_card, awaiting_relic, awaiting_loot])
+        run_result = str(state.get("run_result", "")).strip().lower() if state else ""
+        preserve_snapshot = ended and run_result == "defeat"
 
         if ended or (not awaiting_next and not has_rewards):
-            if battle_snapshots.pop(run_id, None) is not None:
-                snapshots_removed += 1
+            if not preserve_snapshot:
+                if battle_snapshots.pop(run_id, None) is not None:
+                    snapshots_removed += 1
             if battle_locks.pop(run_id, None) is not None:
                 locks_removed += 1
 
@@ -316,41 +320,65 @@ async def _run_battle(
                     for foe_id, cooldown in updated.items()
                 ]
             if result.get("result") == "defeat":
-                state["awaiting_card"] = False
-                state["awaiting_relic"] = False
-                state["awaiting_loot"] = False
-                state["awaiting_next"] = False
+                state.update(
+                    {
+                        "awaiting_card": False,
+                        "awaiting_relic": False,
+                        "awaiting_loot": False,
+                        "awaiting_next": False,
+                        "ended": True,
+                        "run_result": "defeat",
+                        "run_result_logged": state.get("run_result_logged", False),
+                    }
+                )
                 try:
                     await asyncio.to_thread(save_map, run_id, state)
+                except Exception:
+                    pass
+                try:
                     await asyncio.to_thread(save_party, run_id, party)
-                    result.update(
-                        {
-                            "run_id": run_id,
-                            "current_room": rooms[state["current"]].room_type,
-                            "current_index": state["current"],
-                            "awaiting_card": False,
-                            "awaiting_relic": False,
-                            "awaiting_loot": False,
-                            "awaiting_next": False,
-                            "next_room": None,
-                            "ended": True,
-                        }
-                    )
-                    await progress(result)
-                    try:
-                        await log_run_end(run_id, "defeat")
-                        await log_play_session_end(run_id)
-                    except Exception:
-                        pass
+                except Exception:
+                    pass
+
+                result.update(
+                    {
+                        "run_id": run_id,
+                        "current_room": rooms[state["current"]].room_type,
+                        "current_index": state["current"],
+                        "awaiting_card": False,
+                        "awaiting_relic": False,
+                        "awaiting_loot": False,
+                        "awaiting_next": False,
+                        "next_room": None,
+                        "ended": True,
+                        "run_result": "defeat",
+                    }
+                )
+                await progress(result)
+
+                telemetry_logged = False
+                try:
+                    await log_run_end(run_id, "defeat")
+                    await log_play_session_end(run_id)
+                except Exception:
+                    pass
+                else:
+                    telemetry_logged = True
                 finally:
-                    try:
-                        # End run logging when run is deleted due to defeat
-                        end_run_logging()
-                        with get_save_manager().connection() as conn:
-                            conn.execute("DELETE FROM runs WHERE id = ?", (run_id,))
-                    except Exception:
-                        pass
-                purge_run_state(run_id, cancel_task=False)
+                    if telemetry_logged:
+                        state["run_result_logged"] = True
+                        try:
+                            await asyncio.to_thread(save_map, run_id, state)
+                        except Exception:
+                            pass
+
+                try:
+                    end_run_logging()
+                except Exception:
+                    pass
+
+                battle_tasks.pop(run_id, None)
+                battle_locks.pop(run_id, None)
                 return
             has_card_choices = bool(result.get("card_choices"))
             has_relic_choices = bool(result.get("relic_choices"))

--- a/frontend/src/lib/components/OverlayHost.svelte
+++ b/frontend/src/lib/components/OverlayHost.svelte
@@ -238,12 +238,13 @@
 {/if}
 
 {#if $overlayView === 'defeat'}
-  <PopupWindow title="Defeat" reducedMotion={overlayReducedMotion} on:close={() => dispatch('back')}>
-    <div style="padding: 0.5rem 0.25rem; line-height: 1.4;">
-      <p>Your party was defeated.</p>
-      <p>You have been returned to the main menu.</p>
-      <div class="stained-glass-row" style="justify-content: flex-end; margin-top: 0.75rem;">
-        <button class="icon-btn" on:click={() => dispatch('back')}>OK</button>
+  <PopupWindow title="Run Lost" reducedMotion={overlayReducedMotion} on:close={() => dispatch('back')}>
+    <div class="defeat-content">
+      <h2 class="defeat-heading">Run Lost</h2>
+      <p class="defeat-message">Your party was overwhelmed and the run has come to an end.</p>
+      <p class="defeat-note">All rewards and progress have been preserved so you can regroup from the main menu.</p>
+      <div class="defeat-actions stained-glass-row">
+        <button class="icon-btn" on:click={() => dispatch('back')}>Return</button>
       </div>
     </div>
   </PopupWindow>
@@ -525,6 +526,39 @@
   .warp-info-note {
     font-size: 0.9rem;
     color: rgba(255,255,255,0.75);
+  }
+
+  .defeat-content {
+    padding: 0.75rem 0.75rem 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    text-align: center;
+    line-height: 1.5;
+  }
+
+  .defeat-heading {
+    margin: 0;
+    font-size: 1.75rem;
+    font-weight: 700;
+    color: var(--warning-text, #ff6b6b);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+
+  .defeat-message,
+  .defeat-note {
+    margin: 0;
+  }
+
+  .defeat-note {
+    font-size: 0.95rem;
+    color: rgba(255, 255, 255, 0.8);
+  }
+
+  .defeat-actions {
+    justify-content: center;
+    margin-top: 0.75rem;
   }
 
   .overlay-inset {

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -753,14 +753,22 @@
     onBattleSettled: () => {
       scheduleMapRefresh();
     },
-    onRunEnd: () => {
-      handleRunEnd();
+    onRunEnd: ({ defeat } = {}) => {
+      if (defeat) {
+        handleDefeat();
+      } else {
+        handleRunEnd();
+      }
     }
   });
 
   configureMapPollingHandlers({
-    onRunEnd: () => {
-      handleRunEnd();
+    onRunEnd: ({ defeat } = {}) => {
+      if (defeat) {
+        handleDefeat();
+      } else {
+        handleRunEnd();
+      }
     },
     onError: (error) => {
       console.warn('State polling failed:', error?.message || error);

--- a/frontend/tests/defeat-overlay.vitest.js
+++ b/frontend/tests/defeat-overlay.vitest.js
@@ -1,0 +1,44 @@
+import { beforeEach, describe, expect, test } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/svelte';
+import OverlayHost from '../src/lib/components/OverlayHost.svelte';
+import { overlayView, overlayData, homeOverlay } from '../src/lib/systems/OverlayController.js';
+
+const baseProps = {
+  selected: [],
+  runId: 'run-123',
+  roomData: { result: 'defeat', ended: true },
+  shopProcessing: false,
+  battleSnapshot: null,
+  editorState: {},
+  sfxVolume: 5,
+  musicVolume: 5,
+  voiceVolume: 5,
+  framerate: 60,
+  reducedMotion: false,
+  showActionValues: false,
+  showTurnCounter: true,
+  flashEnrageCounter: true,
+  fullIdleMode: false,
+  skipBattleReview: false,
+  animationSpeed: 1,
+  selectedParty: [],
+  battleActive: false,
+  backendFlavor: ''
+};
+
+describe('defeat overlay', () => {
+  beforeEach(() => {
+    cleanup();
+    homeOverlay();
+    overlayData.set({});
+  });
+
+  test('renders Run Lost messaging', () => {
+    overlayView.set('defeat');
+    render(OverlayHost, { props: baseProps });
+
+    expect(screen.getByText('Run Lost')).toBeTruthy();
+    expect(screen.getByText(/the run has come to an end/i)).toBeTruthy();
+    expect(screen.getByRole('button', { name: /return/i })).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary
- mark defeat runs as ended without deleting records so snapshots remain available until shutdown
- update shutdown and bulk run cleanup to respect defeat telemetry and purge state only after frontend acknowledgement
- surface defeat status through polling handlers and refresh the Run Lost overlay with new copy and tests

## Testing
- uv run pytest tests/test_battle_defeat.py
- bun test tests/polling-orchestrator.test.js
- bun x vitest run --config vitest.config.js *(fails: TypeError from @sveltejs/vite-plugin-svelte load-custom config)*

------
https://chatgpt.com/codex/tasks/task_b_68e17dce6ecc832c87e9a8606ee64c1a