### PR TITLE
fix: preserve defeat runs until shutdown

### DIFF
--- a/backend/runs/lifecycle.py
+++ b/backend/runs/lifecycle.py
@@ -145,7 +145,9 @@ async def cleanup_battle_state() -> None:
             ended = state.get("ended", False)
 
         has_rewards = any([awaiting_card, awaiting_relic, awaiting_loot])
-        run_result = str(state.get("run_result", "")).strip().lower() if state else ""
+        run_result = str(snap.get("run_result", "")).strip().lower()
+        if not run_result and state:
+            run_result = str(state.get("run_result", "")).strip().lower()
         preserve_snapshot = ended and run_result == "defeat"
 
         if ended or (not awaiting_next and not has_rewards):


### PR DESCRIPTION
## Summary
- mark defeat runs as ended without deleting records so snapshots remain available until shutdown
- update shutdown and bulk run cleanup to respect defeat telemetry and purge state only after frontend acknowledgement
- surface defeat status through polling handlers and refresh the Run Lost overlay with new copy and tests
- ensure cleanup_battle_state retains defeat snapshots by deriving the run result from the snapshot when available

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68e19f806d2c832c94b1a1d5e3ca5db3