### PR TITLE
Update run startup goal after backend pruning

### DIFF
--- a/.codex/tasks/33e45df1-run-start-flow.goal
+++ b/.codex/tasks/33e45df1-run-start-flow.goal
@@ -1,24 +1,20 @@
 # Goal: Streamline Run Startup Workflow
 
 ## Summary
-We need to replace the current single-click "Start Run" action with a guided setup that walks the player through building their party, choosing a run type, configuring run modifiers, and finally launching the run. On backend boot we should automatically prune any lingering runs instead of resurfacing them. This goal will stage work across backend run lifecycle management, new metadata endpoints, and frontend UI flows.
+We need to replace the current single-click "Start Run" action with a guided setup that walks the player through building their party, choosing a run type, configuring run modifiers, and finally launching the run. Backend startup pruning now clears lingering runs automatically, so the remaining work focuses on the new metadata endpoints, frontend UI flows, and analytics required to support the richer configuration experience.
 
 ## Current State Observations
-- Backend stores runs in the `runs` table and exposes `/ui` helpers that default to the most recent saved run; `get_default_active_run` simply returns the first run id without checking freshness, so old runs persist across restarts.【F:backend/routes/ui.py†L37-L105】
+- Backend now prunes lingering runs on startup via the `prune_runs_on_startup` hook, so players begin each boot from a clean slate; however, `/ui` helpers still default to the most recent run id without richer metadata, leaving the new configuration flow work outstanding.【F:backend/routes/ui.py†L37-L105】
 - `start_run` currently accepts only party members, player damage type, and pressure; map generation and boss selection happen immediately with no notion of run types or optional modifiers.【F:backend/services/run_service.py†L45-L175】
 - The frontend Run overlay (`RunChooser`) presents a basic chooser that allows resuming an old run or launching a new one, and the main viewport triggers `startRun` directly with the party picker’s selection and optional pressure slider; there’s no wizard to collect additional configuration.【F:frontend/src/lib/components/RunChooser.svelte†L1-L67】【F:frontend/src/lib/systems/uiApi.js†L38-L65】
 
 ## Desired Outcomes
-1. Backend clears all prior runs during startup so players always begin from a clean slate when the service restarts.
-2. A new metadata layer exposes available run types/game modes and configurable modifiers (pressure, room count, boss pool, foe density, etc.) so the frontend can render picker UIs.
-3. Frontend run setup becomes a multi-step flow: Build Party → Choose Run Type → Configure Modifiers → Confirm & Start.
-4. Documentation and tests reflect the new flow, including removal of run restore/reload UX.
+1. A new metadata layer exposes available run types/game modes and configurable modifiers (pressure, room count, boss pool, foe density, etc.) so the frontend can render picker UIs.
+2. Frontend run setup becomes a multi-step flow: Build Party → Choose Run Type → Configure Modifiers → Confirm & Start.
+3. Documentation and tests reflect the new flow, including removal of run restore/reload UX.
 
 ## Proposed Task Breakdown
-1. **Backend bootstrap pruning**
-   - Introduce a startup hook (e.g., `@app.before_serving`) that wipes `runs` and related battle state, logging the cleanup and ensuring tracking events mark any purged run as aborted.
-   - Validate compatibility with backup/restore endpoints and document the behavior change in backend README or implementation notes.
-2. **Run configuration metadata service**
+1. **Run configuration metadata service**
    - Define a schema for run types and modifiers (e.g., JSON config or database table) and expose it via a new API endpoint (`/run/config` or similar).
     - Capture baseline modifier definitions covering:
      - **Foe Speed** – +0.01× action point/speed per stack.
@@ -39,18 +35,18 @@ We need to replace the current single-click "Start Run" action with a guided set
    - Ensure all modifiers respect diminishing returns semantics and document how the backend enforces that curve.
    - Extend `start_run` to accept a run type identifier and modifier payload, persisting selections alongside the run entry.
    - Add validation to guard against invalid combinations and provide descriptive error responses.
-3. **Frontend data plumbing**
+2. **Frontend data plumbing**
    - Fetch the new run configuration metadata during UI bootstrap (or when opening the Run overlay) and normalize it for client-side use.
    - Remove assumptions about the only modifier being pressure; prepare stores/actions to hold selected run type and modifier values.
    - Expose tooltip/helper text from the metadata—especially the Pressure difficulty/reward summary—so the run setup wizard can render the required hover affordance.
-4. **Run setup wizard UI**
+3. **Run setup wizard UI**
    - Replace `RunChooser` with a wizard that sequences Party Picker → Run Type → Modifier configuration → Review/confirmation.
    - Ensure each step is stateful, accessible, and resilient to backend failures; include ability to backtrack before launch.
    - Update overlays and run menu buttons to launch the wizard, and retire the “load run” path since old runs are pruned.
-5. **Backend integration & analytics**
+4. **Backend integration & analytics**
    - Update `start_run` request payloads to send the selected run type/mods, persist them in the run record, and feed them into map generation or future game mode hooks.
    - Emit tracking/logging events capturing the selected configuration for analytics.
-6. **Documentation & testing**
+5. **Documentation & testing**
    - Refresh `.codex/implementation` notes for run modules, frontend docs, and any onboarding guides to describe the new flow.
    - Add backend tests covering pruning behavior and run configuration validation, plus frontend component/store tests for the wizard state machine.
 


### PR DESCRIPTION
## Summary
- remove the completed backend bootstrap pruning deliverable from the run startup goal
- focus the remaining tasks on metadata, UI, and analytics now that pruning happens automatically

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_b_68e1a6d31878832cabe24b59a097ddd5