### PR TITLE
[FEAT] Confirm manual run termination

### DIFF
--- a/frontend/.codex/implementation/settings-menu.md
+++ b/frontend/.codex/implementation/settings-menu.md
@@ -58,7 +58,7 @@ Settings are stored in `localStorage` with schema versioning for backward compat
 
 `SettingsMenu.svelte` handles tab selection, LRM configuration, and dispatches `save` and `endRun` events. `SettingsMenu.svelte` receives `backendFlavor` from the page and checks it for `"llm"` to decide whether the LLM tab should appear. When the flavor string omits `"llm"`, the component skips `getLrmConfig()` and hides the model selector and test button.
 
-The Gameplay tab's **End Run** button now attempts to end the current run by ID and falls back to clearing all runs when the ID is missing or the targeted request fails.
+The Gameplay tab's **End Run** button now attempts to end the current run by ID and falls back to clearing all runs when the ID is missing or the targeted request fails. When the cleanup completes successfully the root page opens a "Run Ended" confirmation overlay so players get positive feedback that their manual termination succeeded.
 
 The Gameplay tab also exposes an **Animation Speed** slider (0.1–2.0×). Adjusting it writes the selected multiplier to settings storage and posts the derived turn pacing (`base_turn_pacing / animationSpeed`) to `/config/turn_pacing` so backend battle pacing matches the UI setting.
 

--- a/frontend/src/lib/components/GameViewport.svelte
+++ b/frontend/src/lib/components/GameViewport.svelte
@@ -424,7 +424,7 @@
       on:loadRun={(e) => dispatch('loadRun', e.detail)}
       on:startNewRun={() => dispatch('startNewRun')}
       on:saveSettings={(e) => ({ sfxVolume, musicVolume, voiceVolume, framerate, reducedMotion, showActionValues, showTurnCounter, flashEnrageCounter, fullIdleMode, skipBattleReview, animationSpeed } = e.detail)}
-      on:endRun={() => dispatch('endRun')}
+      on:endRun={(e) => dispatch('endRun', e.detail)}
       on:shopBuy={(e) => dispatch('shopBuy', e.detail)}
       on:shopReroll={() => dispatch('shopReroll')}
         on:shopLeave={() => dispatch('shopLeave')}

--- a/frontend/src/lib/components/OverlayHost.svelte
+++ b/frontend/src/lib/components/OverlayHost.svelte
@@ -250,6 +250,19 @@
   </PopupWindow>
 {/if}
 
+{#if $overlayView === 'run-ended'}
+  <PopupWindow title="Run Ended" reducedMotion={overlayReducedMotion} on:close={() => dispatch('back')}>
+    <div class="run-ended-content">
+      <h2 class="run-ended-heading">Run Ended</h2>
+      <p class="run-ended-message">You ended this run manually. Progress has been saved to the main menu.</p>
+      <p class="run-ended-note">Feel free to start a new challenge whenever you're ready.</p>
+      <div class="run-ended-actions stained-glass-row">
+        <button class="icon-btn" on:click={() => dispatch('back')}>Return</button>
+      </div>
+    </div>
+  </PopupWindow>
+{/if}
+
 {#if $overlayView === 'error'}
   <ErrorOverlay
     message={$overlayData.message || 'An unexpected error occurred.'}
@@ -402,7 +415,7 @@
       {runId}
       {backendFlavor}
       on:save={(e) => dispatch('saveSettings', e.detail)}
-      on:endRun={() => dispatch('endRun')}
+      on:endRun={(e) => dispatch('endRun', e.detail)}
     />
   </PopupWindow>
 {/if}
@@ -557,6 +570,39 @@
   }
 
   .defeat-actions {
+    justify-content: center;
+    margin-top: 0.75rem;
+  }
+
+  .run-ended-content {
+    padding: 0.75rem 0.75rem 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    text-align: center;
+    line-height: 1.5;
+  }
+
+  .run-ended-heading {
+    margin: 0;
+    font-size: 1.75rem;
+    font-weight: 700;
+    color: var(--accent, #7bdff2);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+
+  .run-ended-message,
+  .run-ended-note {
+    margin: 0;
+  }
+
+  .run-ended-note {
+    font-size: 0.95rem;
+    color: rgba(255, 255, 255, 0.8);
+  }
+
+  .run-ended-actions {
     justify-content: center;
     margin-top: 0.75rem;
   }

--- a/frontend/src/lib/components/SettingsMenu.svelte
+++ b/frontend/src/lib/components/SettingsMenu.svelte
@@ -241,7 +241,7 @@
     }
 
     endingRun = false;
-    dispatch('endRun');
+    dispatch('endRun', { reason: 'forced' });
     // Clear status after a short delay so users see feedback
     try { setTimeout(() => (endRunStatus = ''), 1200); } catch {}
   }

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -455,7 +455,9 @@
     }
   }
 
-  async function handleRunEnd() {
+  async function handleRunEnd(eventOrDetail = {}) {
+    const detail = eventOrDetail?.detail !== undefined ? eventOrDetail.detail : eventOrDetail;
+    const reason = detail?.reason ? String(detail.reason) : '';
     // Halt any in-flight battle snapshot polling ASAP
     haltSync = true;
     // Proactively ask backend to end any active runs to avoid lingering state
@@ -468,6 +470,9 @@
     stopUIPolling();
     homeOverlay();
     clearRunState();
+    if (reason === 'forced') {
+      openOverlay('run-ended');
+    }
   }
 
   function handleDefeat() {

--- a/frontend/tests/run-ended-overlay.vitest.js
+++ b/frontend/tests/run-ended-overlay.vitest.js
@@ -1,0 +1,44 @@
+import { beforeEach, describe, expect, test } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/svelte';
+import OverlayHost from '../src/lib/components/OverlayHost.svelte';
+import { overlayView, overlayData, homeOverlay } from '../src/lib/systems/OverlayController.js';
+
+const baseProps = {
+  selected: [],
+  runId: '',
+  roomData: null,
+  shopProcessing: false,
+  battleSnapshot: null,
+  editorState: {},
+  sfxVolume: 5,
+  musicVolume: 5,
+  voiceVolume: 5,
+  framerate: 60,
+  reducedMotion: false,
+  showActionValues: false,
+  showTurnCounter: true,
+  flashEnrageCounter: true,
+  fullIdleMode: false,
+  skipBattleReview: false,
+  animationSpeed: 1,
+  selectedParty: [],
+  battleActive: false,
+  backendFlavor: ''
+};
+
+describe('run-ended overlay view', () => {
+  beforeEach(() => {
+    cleanup();
+    homeOverlay();
+    overlayData.set({});
+  });
+
+  test('renders run ended confirmation copy', () => {
+    overlayView.set('run-ended');
+    render(OverlayHost, { props: baseProps });
+
+    expect(screen.getByText('Run Ended')).toBeTruthy();
+    expect(screen.getByText(/ended this run manually/i)).toBeTruthy();
+    expect(screen.getByRole('button', { name: /return/i })).toBeTruthy();
+  });
+});

--- a/frontend/tests/settings-manual-end.vitest.js
+++ b/frontend/tests/settings-manual-end.vitest.js
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import SettingsMenu from '../src/lib/components/SettingsMenu.svelte';
+
+vi.mock('../src/lib/systems/api.js', () => ({
+  endRun: vi.fn(() => Promise.resolve()),
+  endAllRuns: vi.fn(() => Promise.resolve()),
+  wipeData: vi.fn(() => Promise.resolve()),
+  exportSave: vi.fn(() => Promise.resolve()),
+  importSave: vi.fn(() => Promise.resolve()),
+  getLrmConfig: vi.fn(() => Promise.resolve({ available_models: [], current_model: '' })),
+  setLrmModel: vi.fn(() => Promise.resolve()),
+  testLrmModel: vi.fn(() => Promise.resolve({ response: '' })),
+  getBackendHealth: vi.fn(() => Promise.resolve({ status: 'ok', ping_ms: 42 })),
+  getTurnPacing: vi.fn(() => Promise.resolve({ default: 0.5, turn_pacing: 0.5 })),
+  setTurnPacing: vi.fn(() => Promise.resolve({ default: 0.5, turn_pacing: 0.5 }))
+}));
+
+vi.mock('../src/lib/systems/settingsStorage.js', () => ({
+  saveSettings: vi.fn(),
+  clearSettings: vi.fn(),
+  clearAllClientData: vi.fn(),
+  motionStore: { subscribe: (run) => { run({ globalReducedMotion: false, simplifyOverlayTransitions: false }); return () => {}; } }
+}));
+
+vi.mock('../src/lib/systems/overlayState.js', () => ({
+  setManualSyncHalt: vi.fn()
+}));
+
+describe('SettingsMenu manual run ending', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('dispatches a forced endRun event with reason detail', async () => {
+    const { component } = render(SettingsMenu, {
+      props: {
+        sfxVolume: 5,
+        musicVolume: 5,
+        voiceVolume: 5,
+        framerate: 60,
+        reducedMotion: false,
+        showActionValues: false,
+        showTurnCounter: true,
+        flashEnrageCounter: true,
+        fullIdleMode: false,
+        skipBattleReview: false,
+        animationSpeed: 1,
+        lrmModel: '',
+        runId: 'run-123',
+        backendFlavor: 'default'
+      }
+    });
+
+    const handler = vi.fn();
+    component.$on('endRun', handler);
+
+    const endButton = await screen.findByRole('button', { name: 'End' });
+    await fireEvent.click(endButton);
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler.mock.calls[0][0]?.detail).toStrictEqual({ reason: 'forced' });
+  });
+});


### PR DESCRIPTION
## Summary
- allow the root run shutdown helper to accept a detail payload and surface a dedicated "Run Ended" overlay when players terminate runs manually
- propagate the forced end reason from settings through the overlay stack and style the new confirmation overlay
- add focused Vitest coverage for the manual end dispatch and run-ended overlay plus documentation updates for the settings menu

## Testing
- bunx vitest run --config vitest.config.js tests/settings-manual-end.vitest.js tests/run-ended-overlay.vitest.js *(fails: @sveltejs/vite-plugin-svelte load-custom plugin receives undefined config in Vitest environment)*

------
https://chatgpt.com/codex/tasks/task_b_68e1a55463f0832c9c52750f8bf3e0ac