### PR TITLE
feat: uncap modifier stacks and boss rush floors

### DIFF
--- a/.codex/tasks/5166eba9-run-config-backend.md
+++ b/.codex/tasks/5166eba9-run-config-backend.md
@@ -43,3 +43,5 @@ Build the backend plumbing for the run setup wizard described in the `Streamline
 - Work with frontend owners so the API shape aligns with their wizard state machine.
 - Surface any open questions (e.g. initial run type list, modifier caps) back to Task Master if blockers arise.
 - Do **not** modify frontend code in this task; create follow-up tasks for UI work if necessary.
+
+ready for review

--- a/backend/.codex/implementation/run-configuration-metadata.md
+++ b/backend/.codex/implementation/run-configuration-metadata.md
@@ -1,0 +1,77 @@
+# Run Configuration Metadata Service
+
+## Overview
+
+Run setup now flows through a metadata-backed configuration layer. The
+`services/run_configuration.py` module defines canonical run types and modifier
+definitions and exposes helpers for validation and analytics snapshots. The UI
+and `/run/start` endpoint share this contract so selections are validated once
+and stored with the run record.
+
+## Metadata Endpoint
+
+- **Route:** `GET /run/config`
+- **Handler:** `routes/ui.py::run_configuration_metadata`
+- **Payload:**
+  - `version` (string) – metadata version identifier.
+  - `generated_at` (UTC ISO timestamp) – time the payload was generated.
+  - `run_types` (list) – available run type definitions with default modifier
+    presets.
+  - `modifiers` (list) – modifier definitions including category, minimum stack
+    counts, whether stacks grant reward bonuses, and tooltip data. Stacks are no
+    longer hard capped; validation only enforces the documented minimums and
+    converts numeric input.
+  - `pressure.tooltip` – canonical tooltip text summarizing encounter sizing,
+    defense floors, elite odds, and shop tax scaling for pressure stacks.
+
+Telemetry records a `Run/view_config` menu action so analytics can measure how
+often the setup flow is opened.
+
+## Validation Flow
+
+`validate_run_configuration` accepts a run type identifier, optional modifier
+payload, and the legacy `pressure` fallback. The helper:
+
+1. Loads metadata and resolves the run type (defaulting to `standard`).
+2. Merges the run type defaults with provided modifiers.
+3. Applies the legacy `pressure` integer when the caller does not provide a
+   pressure modifier so old clients continue to work.
+4. Normalises stack counts, enforcing integer minimums and raising
+   `ValueError` for unknown modifiers or invalid combinations.
+5. Computes reward bonuses:
+   - Foe-focused modifiers grant +50% experience and rare drop rate per stack
+     via the `foe_modifier_bonus` field.
+   - `character_stat_down` applies the tiered stat penalty (0.001× per stack up
+     to 500 stacks, then 0.000001×) and returns the matching 5% + 1% per extra
+     stack bonus in `player_modifier_bonus`.
+6. Builds a snapshot with modifier details, pressure math, and aggregate
+   rewards that is stored with the run.
+
+`RunConfigurationSelection.snapshot` is serialised directly into the
+`runs.party` JSON under the `config` key and returned to the frontend as
+`configuration` from `start_run`.
+
+## Reward Application
+
+`services/run_service.start_run` integrates the validation result:
+
+- Party members receive their `exp_multiplier` boost before the initial map is
+  generated.
+- The stored party snapshot records per-member experience multipliers alongside
+  the RDR baseline, ensuring reloads persist the configuration bonuses.
+- The new run state embeds the configuration snapshot so future services can
+  read modifier details without revalidating.
+- Boss Rush runs flag the party to disable shops/rests and the map generator
+  now produces an all-boss floor layout (start room plus nine boss encounters)
+  while Standard runs retain the mixed encounters defined in `MapGenerator`.
+- Telemetry (`log_run_start`, `log_menu_action`) captures the run type,
+  modifier stacks, and computed reward bonuses.
+
+## Analytics Storage
+
+Migration `003_run_configuration_metadata.sql` introduces the
+`run_configurations` table in the tracking database. `log_run_start` writes a
+row containing the run type, modifier JSON, reward bonuses, and metadata
+version whenever configuration data is provided. This allows downstream tools
+to analyse configuration popularity and reward trends.
+

--- a/backend/autofighter/mapgen.py
+++ b/backend/autofighter/mapgen.py
@@ -45,6 +45,9 @@ class MapGenerator:
         self.pressure = pressure
 
     def generate_floor(self, party: Party | None = None) -> list[MapNode]:
+        if party is not None and self._is_boss_rush(party):
+            return self._generate_boss_rush_floor()
+
         nodes: list[MapNode] = []
         index = 0
         nodes.append(
@@ -121,3 +124,31 @@ class MapGenerator:
             )
         )
         return nodes
+
+    def _generate_boss_rush_floor(self) -> list[MapNode]:
+        nodes: list[MapNode] = []
+        for index in range(self.rooms_per_floor):
+            room_type = "start" if index == 0 else "battle-boss-floor"
+            nodes.append(
+                MapNode(
+                    room_id=index,
+                    room_type=room_type,
+                    floor=self.floor,
+                    index=index,
+                    loop=self.loop,
+                    pressure=self.pressure,
+                )
+            )
+        return nodes
+
+    @staticmethod
+    def _is_boss_rush(party: Party) -> bool:
+        config = getattr(party, "run_config", None)
+        if isinstance(config, dict):
+            run_type = config.get("run_type")
+            if isinstance(run_type, dict):
+                if run_type.get("id") == "boss_rush":
+                    return True
+            elif isinstance(run_type, str) and run_type == "boss_rush":
+                return True
+        return bool(getattr(party, "boss_rush", False))

--- a/backend/routes/ui.py
+++ b/backend/routes/ui.py
@@ -5,23 +5,20 @@ import json
 import traceback
 from typing import Any
 
-from battle_logging.writers import end_run_logging
 from quart import Blueprint
 from quart import jsonify
 from quart import request
 from runs.encryption import get_save_manager
-from runs.lifecycle import battle_locks
 from runs.lifecycle import battle_snapshots
 from runs.lifecycle import battle_tasks
-from runs.lifecycle import emit_battle_end_for_runs
 from runs.lifecycle import load_map
-from runs.lifecycle import purge_run_state
 from runs.lifecycle import save_map
 from runs.party_manager import load_party
 from services.asset_service import get_asset_manifest
 from services.reward_service import select_card
 from services.reward_service import select_relic
 from services.room_service import room_action
+from services.run_configuration import get_run_configuration_metadata
 from services.run_service import advance_room
 from services.run_service import backup_save
 from services.run_service import get_battle_events
@@ -33,8 +30,6 @@ from services.run_service import update_party
 from services.run_service import wipe_save
 from tracking import log_game_action
 from tracking import log_menu_action
-from tracking import log_play_session_end
-from tracking import log_run_end
 
 from autofighter.rooms.shop import serialize_shop_payload
 
@@ -527,6 +522,16 @@ async def battle_events(index: int):
     return jsonify(data)
 
 
+@bp.get("/run/config")
+async def run_configuration_metadata() -> tuple[str, int, dict[str, Any]]:
+    metadata = get_run_configuration_metadata()
+    try:
+        await log_menu_action("Run", "view_config", {"version": metadata.get("version")})
+    except Exception:
+        pass
+    return jsonify(metadata), 200
+
+
 @bp.post("/run/start")
 async def start_run_endpoint() -> tuple[str, int, dict[str, Any]]:
     """Start a new run. Alternative endpoint that matches test expectations."""
@@ -535,15 +540,30 @@ async def start_run_endpoint() -> tuple[str, int, dict[str, Any]]:
         members = data.get("party", ["player"])
         damage_type = data.get("damage_type", "")
         pressure = data.get("pressure", 0)
+        run_type = data.get("run_type")
+        modifiers = data.get("modifiers")
 
         try:
-            result = await start_run(members, damage_type, pressure)
+            result = await start_run(
+                members,
+                damage_type,
+                pressure,
+                run_type=run_type,
+                modifiers=modifiers,
+            )
             return jsonify(result), 200
         except ValueError as exc:
             await log_menu_action(
                 "Run",
                 "error",
-                {"members": members, "damage_type": damage_type, "pressure": pressure, "error": str(exc)},
+                {
+                    "members": members,
+                    "damage_type": damage_type,
+                    "pressure": pressure,
+                    "run_type": run_type,
+                    "modifiers": modifiers,
+                    "error": str(exc),
+                },
             )
             return jsonify({"error": str(exc)}), 400
 

--- a/backend/services/run_configuration.py
+++ b/backend/services/run_configuration.py
@@ -1,0 +1,395 @@
+"""Run configuration metadata and validation helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC
+from datetime import datetime
+from typing import Any
+from typing import Mapping
+
+from autofighter.effects import DIMINISHING_RETURNS_CONFIG
+from autofighter.effects import calculate_diminishing_returns
+
+METADATA_VERSION = "2025.02"
+
+_PRESSURE_TOOLTIP = (
+    "Each stack raises encounter pressure. Base encounters gain +1 foe slot for every "
+    "five stacks (capped by the ten-slot spawn limit) before party-size bonuses. Foes roll "
+    "a minimum defense floor of pressure × 10 that then varies between 0.82× and 1.50×. "
+    "Prime and Glitched spawn odds each gain +1% per stack in addition to floor and room "
+    "bonuses. Shop prices scale multiplicatively by 1.26^pressure with ±5% variance before "
+    "repeat-visit taxes. Pressure does not add experience or rare drop bonuses; rewards "
+    "are driven by party RDR, modifier bonuses, and per-foe payouts."
+)
+
+
+@dataclass(frozen=True)
+class RunConfigurationSelection:
+    """Validated configuration details for a run."""
+
+    run_type: dict[str, Any]
+    modifiers: dict[str, int]
+    pressure: int
+    reward_bonuses: dict[str, float]
+    snapshot: dict[str, Any]
+
+    def telemetry_payload(self) -> dict[str, Any]:
+        """Return a sanitized payload for analytics logging."""
+
+        return {
+            "version": self.snapshot.get("version", METADATA_VERSION),
+            "run_type": self.run_type.get("id"),
+            "modifiers": self.modifiers,
+            "reward_bonuses": {
+                "exp_bonus": self.reward_bonuses.get("exp_bonus", 0.0),
+                "rdr_bonus": self.reward_bonuses.get("rdr_bonus", 0.0),
+                "foe_modifier_bonus": self.reward_bonuses.get("foe_modifier_bonus", 0.0),
+                "player_modifier_bonus": self.reward_bonuses.get("player_modifier_bonus", 0.0),
+            },
+        }
+
+
+def _now_iso() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _pressure_effects(stacks: int) -> dict[str, Any]:
+    extra_foes = stacks // 5
+    defense_floor = stacks * 10
+    elite_bonus = stacks
+    shop_multiplier = 1.26 ** stacks if stacks else 1.0
+    return {
+        "stacks": stacks,
+        "encounter_bonus": extra_foes,
+        "defense_floor": defense_floor,
+        "elite_spawn_bonus_pct": elite_bonus,
+        "shop_multiplier": shop_multiplier,
+        "tooltip": _PRESSURE_TOOLTIP,
+    }
+
+
+def _diminishing_factor(stat: str, stacks: int) -> float:
+    if stacks <= 0:
+        return 1.0
+    config = DIMINISHING_RETURNS_CONFIG.get(stat)
+    if not config:
+        return 1.0
+    threshold = float(config["threshold"])
+    base_offset = float(config["base_offset"])
+    current_value = base_offset + threshold * stacks
+    try:
+        return float(calculate_diminishing_returns(stat, current_value))
+    except Exception:
+        return 1.0
+
+
+def _foe_modifier_effect(stat: str, per_stack: float, stacks: int) -> dict[str, Any]:
+    raw_bonus = per_stack * stacks
+    diminishing = _diminishing_factor(stat, stacks)
+    effective_bonus = raw_bonus * diminishing
+    return {
+        "per_stack": per_stack,
+        "stacks": stacks,
+        "raw_bonus": raw_bonus,
+        "diminishing_factor": diminishing,
+        "effective_bonus": effective_bonus,
+    }
+
+
+def _percent_modifier_effect(per_stack: float, stacks: int) -> dict[str, Any]:
+    raw_bonus = per_stack * stacks
+    return {
+        "per_stack": per_stack,
+        "stacks": stacks,
+        "raw_bonus": raw_bonus,
+    }
+
+
+def _character_stat_penalty(stacks: int) -> dict[str, Any]:
+    capped = min(stacks, 500)
+    overflow = max(stacks - 500, 0)
+    penalty_primary = capped * 0.001
+    penalty_overflow = overflow * 0.000001
+    total_penalty = penalty_primary + penalty_overflow
+    effective_multiplier = max(0.0, 1.0 - total_penalty)
+    bonus_rdr = 0.0
+    bonus_exp = 0.0
+    if stacks > 0:
+        bonus_rdr = 0.05 + max(0, stacks - 1) * 0.01
+        bonus_exp = bonus_rdr
+    return {
+        "stacks": stacks,
+        "penalty_primary": penalty_primary,
+        "penalty_overflow": penalty_overflow,
+        "total_penalty": total_penalty,
+        "effective_multiplier": effective_multiplier,
+        "bonus_rdr": bonus_rdr,
+        "bonus_exp": bonus_exp,
+    }
+
+
+_MODIFIER_DEFINITIONS: dict[str, dict[str, Any]] = {
+    "pressure": {
+        "id": "pressure",
+        "label": "Pressure",
+        "category": "core",
+        "min_stacks": 0,
+        "stack_step": 1,
+        "grants_reward_bonus": False,
+        "effects": _pressure_effects,
+    },
+    "foe_speed": {
+        "id": "foe_speed",
+        "label": "Foe Speed",
+        "category": "foe",
+        "min_stacks": 0,
+        "stack_step": 1,
+        "grants_reward_bonus": True,
+        "effects": lambda stacks: _percent_modifier_effect(0.01, stacks),
+        "diminishing_stat": "atk",
+    },
+    "foe_hp": {
+        "id": "foe_hp",
+        "label": "Foe HP",
+        "category": "foe",
+        "min_stacks": 0,
+        "stack_step": 1,
+        "grants_reward_bonus": True,
+        "effects": lambda stacks: _foe_modifier_effect("max_hp", 0.5, stacks),
+        "diminishing_stat": "max_hp",
+    },
+    "foe_mitigation": {
+        "id": "foe_mitigation",
+        "label": "Foe Mitigation",
+        "category": "foe",
+        "min_stacks": 0,
+        "stack_step": 1,
+        "grants_reward_bonus": True,
+        "effects": lambda stacks: _foe_modifier_effect("mitigation", 0.00001, stacks),
+        "diminishing_stat": "mitigation",
+    },
+    "foe_vitality": {
+        "id": "foe_vitality",
+        "label": "Foe Vitality",
+        "category": "foe",
+        "min_stacks": 0,
+        "stack_step": 1,
+        "grants_reward_bonus": True,
+        "effects": lambda stacks: _foe_modifier_effect("vitality", 0.00001, stacks),
+        "diminishing_stat": "vitality",
+    },
+    "foe_glitched_rate": {
+        "id": "foe_glitched_rate",
+        "label": "Glitched Spawn Rate",
+        "category": "foe",
+        "min_stacks": 0,
+        "stack_step": 1,
+        "grants_reward_bonus": True,
+        "effects": lambda stacks: _percent_modifier_effect(0.01, stacks),
+    },
+    "foe_prime_rate": {
+        "id": "foe_prime_rate",
+        "label": "Prime Spawn Rate",
+        "category": "foe",
+        "min_stacks": 0,
+        "stack_step": 1,
+        "grants_reward_bonus": True,
+        "effects": lambda stacks: _percent_modifier_effect(0.01, stacks),
+    },
+    "character_stat_down": {
+        "id": "character_stat_down",
+        "label": "Character Stat Down",
+        "category": "player",
+        "min_stacks": 0,
+        "stack_step": 1,
+        "grants_reward_bonus": False,
+        "effects": _character_stat_penalty,
+    },
+}
+
+
+_RUN_TYPES: list[dict[str, Any]] = [
+    {
+        "id": "standard",
+        "label": "Standard Expedition",
+        "description": "Balanced adventure with classic pacing and full map variety.",
+        "default_modifiers": {"pressure": 0},
+        "allowed_modifiers": list(_MODIFIER_DEFINITIONS.keys()),
+    },
+    {
+        "id": "boss_rush",
+        "label": "Boss Rush",
+        "description": "Shortened gauntlet that escalates pressure quickly and leans on elite encounters.",
+        "default_modifiers": {"pressure": 5, "foe_hp": 2, "foe_mitigation": 2},
+        "allowed_modifiers": list(_MODIFIER_DEFINITIONS.keys()),
+    },
+]
+
+
+def get_run_configuration_metadata() -> dict[str, Any]:
+    """Return the canonical run type and modifier metadata."""
+
+    modifiers: list[dict[str, Any]] = []
+    for entry in _MODIFIER_DEFINITIONS.values():
+        base = {
+            "id": entry["id"],
+            "label": entry["label"],
+            "category": entry["category"],
+            "min_stacks": entry["min_stacks"],
+            "stack_step": entry["stack_step"],
+            "grants_reward_bonus": entry["grants_reward_bonus"],
+        }
+        if entry["id"] == "pressure":
+            base["tooltip"] = _PRESSURE_TOOLTIP
+        modifiers.append(base)
+
+    return {
+        "version": METADATA_VERSION,
+        "generated_at": _now_iso(),
+        "run_types": list(_RUN_TYPES),
+        "modifiers": modifiers,
+        "pressure": {
+            "tooltip": _PRESSURE_TOOLTIP,
+        },
+    }
+
+
+def _normalise_value(value: Any) -> int:
+    if isinstance(value, Mapping) and "stacks" in value:
+        value = value["stacks"]
+    if isinstance(value, bool):
+        raise ValueError("modifier stacks must be numeric")
+    try:
+        stacks = int(value)
+    except (TypeError, ValueError):
+        raise ValueError("modifier stacks must be numeric") from None
+    if stacks < 0:
+        raise ValueError("modifier stacks must be non-negative")
+    return stacks
+
+
+def validate_run_configuration(
+    *,
+    run_type: str | None,
+    modifiers: Mapping[str, Any] | None,
+    fallback_pressure: int | None = None,
+) -> RunConfigurationSelection:
+    """Validate requested run setup and compute reward adjustments."""
+
+    metadata = get_run_configuration_metadata()
+    run_type_id = (run_type or "standard").strip().lower() or "standard"
+    run_type_entry = next((rt for rt in _RUN_TYPES if rt["id"] == run_type_id), None)
+    if run_type_entry is None:
+        raise ValueError("unknown run type")
+
+    allowed = set(run_type_entry.get("allowed_modifiers", []))
+    combined: dict[str, Any] = dict(run_type_entry.get("default_modifiers", {}))
+
+    provided_pressure = False
+    if modifiers is not None:
+        if not isinstance(modifiers, Mapping):
+            raise ValueError("modifiers must be an object")
+        for key, value in modifiers.items():
+            mod_id = str(key).strip().lower()
+            combined[mod_id] = value
+            if mod_id == "pressure":
+                provided_pressure = True
+
+    if fallback_pressure is not None and not provided_pressure:
+        try:
+            combined["pressure"] = int(fallback_pressure)
+        except (TypeError, ValueError):
+            raise ValueError("pressure must be numeric") from None
+
+    normalized: dict[str, int] = {}
+    modifier_snapshots: dict[str, Any] = {}
+    foe_reward_stacks = 0
+    player_bonus = 0.0
+    char_penalty_snapshot: dict[str, Any] | None = None
+
+    for key, value in combined.items():
+        mod_id = str(key).strip().lower()
+        definition = _MODIFIER_DEFINITIONS.get(mod_id)
+        if definition is None:
+            raise ValueError(f"unknown modifier: {mod_id}")
+        if allowed and mod_id not in allowed:
+            raise ValueError(f"modifier '{mod_id}' is not allowed for run type '{run_type_entry['id']}'")
+
+        stacks = _normalise_value(value)
+        if stacks < definition["min_stacks"]:
+            raise ValueError(
+                f"modifier '{mod_id}' requires at least {definition['min_stacks']} stack(s)"
+            )
+
+        normalized[mod_id] = stacks
+        effects_fn = definition.get("effects")
+        if callable(effects_fn):
+            details = effects_fn(stacks)
+        else:
+            details = {"stacks": stacks}
+        modifier_snapshots[mod_id] = {
+            "id": mod_id,
+            "label": definition.get("label", mod_id),
+            "category": definition.get("category"),
+            "details": details,
+        }
+
+        if definition.get("grants_reward_bonus"):
+            foe_reward_stacks += stacks
+
+        if mod_id == "character_stat_down":
+            char_penalty_snapshot = details
+            player_bonus = details.get("bonus_rdr", 0.0)
+
+    pressure_value = int(normalized.get("pressure", 0))
+    if char_penalty_snapshot is None:
+        char_penalty_snapshot = _character_stat_penalty(0)
+        modifier_snapshots.setdefault(
+            "character_stat_down",
+            {
+                "id": "character_stat_down",
+                "label": _MODIFIER_DEFINITIONS["character_stat_down"]["label"],
+                "category": "player",
+                "details": char_penalty_snapshot,
+            },
+        )
+
+    reward_bonuses = {
+        "foe_modifier_bonus": foe_reward_stacks * 0.5,
+        "player_modifier_bonus": player_bonus,
+    }
+    reward_bonuses["exp_bonus"] = reward_bonuses["foe_modifier_bonus"] + reward_bonuses["player_modifier_bonus"]
+    reward_bonuses["rdr_bonus"] = reward_bonuses["exp_bonus"]
+    reward_bonuses["exp_multiplier"] = 1.0 + reward_bonuses["exp_bonus"]
+    reward_bonuses["rdr_multiplier"] = 1.0 + reward_bonuses["rdr_bonus"]
+
+    snapshot = {
+        "version": METADATA_VERSION,
+        "generated_at": metadata["generated_at"],
+        "run_type": {
+            "id": run_type_entry["id"],
+            "label": run_type_entry.get("label"),
+            "description": run_type_entry.get("description"),
+        },
+        "modifiers": modifier_snapshots,
+        "pressure": _pressure_effects(pressure_value),
+        "reward_bonuses": reward_bonuses,
+    }
+
+    return RunConfigurationSelection(
+        run_type={"id": run_type_entry["id"], "label": run_type_entry.get("label")},
+        modifiers=normalized,
+        pressure=pressure_value,
+        reward_bonuses=reward_bonuses,
+        snapshot=snapshot,
+    )
+
+
+__all__ = [
+    "METADATA_VERSION",
+    "RunConfigurationSelection",
+    "get_run_configuration_metadata",
+    "validate_run_configuration",
+]
+

--- a/backend/services/run_service.py
+++ b/backend/services/run_service.py
@@ -36,6 +36,8 @@ from autofighter.rooms import _choose_foe
 from autofighter.rooms import _serialize
 from plugins import characters as player_plugins
 from services.login_reward_service import record_room_completion
+from services.run_configuration import RunConfigurationSelection
+from services.run_configuration import validate_run_configuration
 from services.user_level_service import get_user_level
 
 log = logging.getLogger(__name__)
@@ -117,6 +119,8 @@ async def start_run(
     members: list[str],
     damage_type: str = "",
     pressure: int = 0,
+    run_type: str | None = None,
+    modifiers: dict[str, object] | None = None,
 ) -> dict[str, object]:
     """Create a new run and return its initial state."""
     damage_type = (damage_type or "").capitalize()
@@ -163,15 +167,42 @@ async def start_run(
                 )
                 break
 
+    try:
+        configuration: RunConfigurationSelection = validate_run_configuration(
+            run_type=run_type,
+            modifiers=modifiers or {},
+            fallback_pressure=pressure,
+        )
+    except ValueError as exc:
+        raise ValueError(str(exc)) from exc
+
+    pressure_value = configuration.pressure
+
+    reward_bonuses = configuration.reward_bonuses
+    exp_multiplier = float(reward_bonuses.get("exp_multiplier", 1.0))
+    rdr_multiplier = float(reward_bonuses.get("rdr_multiplier", 1.0))
+
+    exp_multiplier_map: dict[str, float] = {}
+    for member, info in zip(party_members, party_info):
+        member.exp_multiplier *= exp_multiplier
+        info["exp_multiplier"] = member.exp_multiplier
+        exp_multiplier_map[member.id] = float(member.exp_multiplier)
+
     initial_party = Party(
         members=party_members,
         gold=0,
         relics=[],
         cards=[],
-        rdr=1.0,
+        rdr=rdr_multiplier,
     )
+    setattr(initial_party, "run_config", configuration.snapshot)
+    run_type_id = configuration.run_type.get("id")
+    if run_type_id == "boss_rush":
+        setattr(initial_party, "no_shops", True)
+        setattr(initial_party, "no_rests", True)
+        setattr(initial_party, "boss_rush", True)
 
-    generator = MapGenerator(run_id, pressure=pressure)
+    generator = MapGenerator(run_id, pressure=pressure_value)
     nodes = generator.generate_floor(party=initial_party)
 
     boss_choice = None
@@ -188,7 +219,7 @@ async def start_run(
         "awaiting_next": False,
         "total_rooms_cleared": 0,
         "floors_cleared": 0,
-        "current_pressure": int(pressure or 0),
+        "current_pressure": int(pressure_value or 0),
     }
     if boss_choice is not None and nodes:
         state["floor_boss"] = {
@@ -228,10 +259,15 @@ async def start_run(
                             "cards": [],
                             "exp": dict.fromkeys(members, 0),
                             "level": dict.fromkeys(members, 1),
-                            "rdr": 1.0,
+                            "exp_multiplier": {
+                                mid: exp_multiplier_map.get(mid, exp_multiplier)
+                                for mid in members
+                            },
+                            "rdr": rdr_multiplier,
                             # Freeze the user level for the duration of this run
                             "user_level": int(get_user_level()),
                             "player": snapshot,
+                            "config": configuration.snapshot,
                         }
                     ),
                     json.dumps(state),
@@ -254,7 +290,12 @@ async def start_run(
             }
         )
 
-    await log_run_start(run_id, start_ts, member_snapshots)
+    await log_run_start(
+        run_id,
+        start_ts,
+        member_snapshots,
+        configuration=configuration.snapshot,
+    )
     await log_play_session_start(run_id, "local", start_ts)
     await log_menu_action(
         "Run",
@@ -262,11 +303,22 @@ async def start_run(
         {
             "members": members,
             "damage_type": damage_type,
-            "pressure": pressure,
+            "pressure": pressure_value,
             "run_id": run_id,
+            "run_type": configuration.run_type.get("id"),
+            "modifiers": configuration.modifiers,
+            "reward_bonuses": {
+                "exp_bonus": reward_bonuses.get("exp_bonus", 0.0),
+                "rdr_bonus": reward_bonuses.get("rdr_bonus", 0.0),
+            },
         },
     )
-    return {"run_id": run_id, "map": state, "party": party_info}
+    return {
+        "run_id": run_id,
+        "map": state,
+        "party": party_info,
+        "configuration": configuration.snapshot,
+    }
 
 
 async def update_party(run_id: str, members: list[str]) -> dict[str, object]:

--- a/backend/tests/test_mapgen.py
+++ b/backend/tests/test_mapgen.py
@@ -6,6 +6,12 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from autofighter.mapgen import MapGenerator
 
 
+class _BossRushParty:
+    def __init__(self) -> None:
+        self.run_config = {"run_type": {"id": "boss_rush"}}
+        self.boss_rush = True
+
+
 def test_generator_deterministic():
     gen1 = MapGenerator("seed")
     gen2 = MapGenerator("seed")
@@ -18,3 +24,12 @@ def test_generator_deterministic():
     types = [n.room_type for n in rooms1[1:-1]]
     assert set(types) <= {"shop", "battle-weak", "battle-normal"}
     assert "shop" in types
+
+
+def test_generator_boss_rush_floor_all_bosses():
+    party = _BossRushParty()
+    gen = MapGenerator("seed")
+    rooms = gen.generate_floor(party)
+    assert len(rooms) == MapGenerator.rooms_per_floor
+    assert rooms[0].room_type == "start"
+    assert all(room.room_type == "battle-boss-floor" for room in rooms[1:])

--- a/backend/tests/test_run_configuration_service.py
+++ b/backend/tests/test_run_configuration_service.py
@@ -1,0 +1,36 @@
+import pytest
+from services.run_configuration import get_run_configuration_metadata
+from services.run_configuration import validate_run_configuration
+
+
+def test_run_configuration_metadata_shape():
+    metadata = get_run_configuration_metadata()
+    assert metadata["run_types"], "run types should be present"
+    assert metadata["modifiers"], "modifiers should be present"
+    pressure = metadata.get("pressure", {})
+    assert "tooltip" in pressure and "encounter" in pressure["tooltip"].lower()
+
+
+def test_validate_run_configuration_defaults():
+    selection = validate_run_configuration(run_type=None, modifiers=None, fallback_pressure=4)
+    assert selection.run_type["id"] == "standard"
+    assert selection.pressure == 4
+    assert selection.reward_bonuses["exp_multiplier"] >= 1.0
+    assert selection.snapshot["pressure"]["tooltip"]
+
+
+def test_validate_run_configuration_with_modifiers():
+    selection = validate_run_configuration(
+        run_type="boss_rush",
+        modifiers={"foe_hp": 4, "character_stat_down": 3},
+    )
+    assert selection.modifiers["pressure"] >= 5
+    bonus = selection.snapshot["modifiers"]["character_stat_down"]["details"]["bonus_rdr"]
+    assert pytest.approx(bonus, rel=1e-3) == 0.07
+    assert selection.reward_bonuses["exp_bonus"] >= bonus
+
+
+def test_validate_run_configuration_rejects_unknown_modifier():
+    with pytest.raises(ValueError):
+        validate_run_configuration(run_type="standard", modifiers={"invalid": 1})
+

--- a/backend/tracking/migrations/003_run_configuration_metadata.sql
+++ b/backend/tracking/migrations/003_run_configuration_metadata.sql
@@ -1,0 +1,11 @@
+-- Track run configuration metadata selections
+CREATE TABLE IF NOT EXISTS run_configurations (
+    run_id TEXT PRIMARY KEY,
+    run_type TEXT,
+    modifiers_json TEXT,
+    reward_json TEXT,
+    version TEXT,
+    recorded_ts INTEGER,
+    FOREIGN KEY (run_id) REFERENCES runs(run_id) ON DELETE CASCADE
+);
+

--- a/backend/tracking/service.py
+++ b/backend/tracking/service.py
@@ -67,6 +67,8 @@ async def log_run_start(
     start_ts: int,
     members: list[dict[str, Any]],
     outcome: str | None = None,
+    *,
+    configuration: dict[str, Any] | None = None,
 ) -> None:
     def write(conn: Any) -> None:
         cur = conn.execute(
@@ -89,6 +91,23 @@ async def log_run_start(
                     slot,
                     member.get("character_id", "unknown"),
                     _dump(stats),
+                ),
+            )
+        if configuration:
+            run_type_value = configuration.get("run_type")
+            if isinstance(run_type_value, dict):
+                run_type_value = run_type_value.get("id", "")
+            reward_payload = configuration.get("reward_bonuses")
+            conn.execute(
+                "INSERT OR REPLACE INTO run_configurations (run_id, run_type, modifiers_json, reward_json, version, recorded_ts) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                (
+                    run_id,
+                    run_type_value,
+                    _dump(configuration.get("modifiers")),
+                    _dump(reward_payload),
+                    str(configuration.get("version", "")),
+                    start_ts,
                 ),
             )
 


### PR DESCRIPTION
## Summary
- remove hard maximum stack values from run configuration metadata and validation while keeping minimum checks
- make boss rush runs flag the party and map generator to create all-boss floors and disable shops/rests
- document the updated behaviour and cover the boss rush layout with tests

## Testing
- uv run pytest tests/test_run_configuration_service.py tests/test_mapgen.py
- uv run ruff check services/run_configuration.py services/run_service.py autofighter/mapgen.py tests/test_run_configuration_service.py tests/test_mapgen.py

------
https://chatgpt.com/codex/tasks/task_b_68e1adfbab58832c8d6be9d585579a8f