### PR TITLE
Fix upgrade overlay styling to match panel background

### DIFF
--- a/frontend/src/lib/components/StatTabs.svelte
+++ b/frontend/src/lib/components/StatTabs.svelte
@@ -418,8 +418,7 @@
     align-items: stretch;
     justify-content: flex-end;
     padding: 0.75rem 0.6rem;
-    background: linear-gradient(90deg, rgba(10, 15, 28, 0.45) 0%, rgba(10, 15, 28, 0.82) 65%);
-    backdrop-filter: blur(2px);
+    background: none;
   }
   .upgrade-panel {
     flex: 0 1 360px;


### PR DESCRIPTION
## Summary
- remove the gradient-and-blur treatment from the upgrade overlay layer so it inherits the surrounding panel styling

## Testing
- bun run lint

ready for review

------
https://chatgpt.com/codex/tasks/task_b_68e1b879ce38832cac3e5d572b31a2f7