### PR TITLE
Fix modifier input max binding in RunChooser

### DIFF
--- a/frontend/src/lib/components/RunChooser.svelte
+++ b/frontend/src/lib/components/RunChooser.svelte
@@ -611,9 +611,7 @@
                       type="number"
                       min={mod.stacking?.minimum ?? 0}
                       step={mod.stacking?.step ?? 1}
-                      {#if Number.isFinite(mod.stacking?.maximum)}
-                        max={mod.stacking.maximum}
-                      {/if}
+                      max={Number.isFinite(mod.stacking?.maximum) ? mod.stacking.maximum : undefined}
                       value={sanitizeStack(mod.id, modifierValues[mod.id])}
                       on:change={(event) => handleModifierChange(mod.id, event.target.value)}
                     />


### PR DESCRIPTION
## Summary
- replace the conditional block around the modifier max attribute with a single guarded binding in RunChooser

## Testing
- VITE_API_BASE=http://localhost bun run build *(fails: frontend/src/routes/+page.svelte mixes logical and nullish coalescing operators without parentheses)*

ready for review

------
https://chatgpt.com/codex/tasks/task_b_68e2444b5ddc832c8c3d03cad07425d2