### PR TITLE
Capture run metadata version for start runs

### DIFF
--- a/backend/routes/ui.py
+++ b/backend/routes/ui.py
@@ -323,6 +323,7 @@ async def handle_ui_action() -> tuple[str, int, dict[str, Any]]:
             pressure = params.get("pressure")
             run_type = params.get("run_type")
             modifiers = params.get("modifiers")
+            metadata_version = params.get("metadata_version")
 
             if not isinstance(members, list):
                 return create_error_response("Party must be a list of member IDs", 400)
@@ -337,6 +338,7 @@ async def handle_ui_action() -> tuple[str, int, dict[str, Any]]:
                     pressure,
                     run_type=run_type,
                     modifiers=modifiers,
+                    metadata_version=metadata_version,
                 )
                 return jsonify(result)
             except ValueError as exc:
@@ -349,6 +351,7 @@ async def handle_ui_action() -> tuple[str, int, dict[str, Any]]:
                         "pressure": pressure,
                         "run_type": run_type,
                         "modifiers": modifiers,
+                        "metadata_version": metadata_version,
                         "error": str(exc),
                     },
                 )
@@ -575,6 +578,7 @@ async def start_run_endpoint() -> tuple[str, int, dict[str, Any]]:
         pressure = data.get("pressure", 0)
         run_type = data.get("run_type")
         modifiers = data.get("modifiers")
+        metadata_version = data.get("metadata_version")
 
         try:
             result = await start_run(
@@ -583,6 +587,7 @@ async def start_run_endpoint() -> tuple[str, int, dict[str, Any]]:
                 pressure,
                 run_type=run_type,
                 modifiers=modifiers,
+                metadata_version=metadata_version,
             )
             return jsonify(result), 200
         except ValueError as exc:
@@ -595,6 +600,7 @@ async def start_run_endpoint() -> tuple[str, int, dict[str, Any]]:
                     "pressure": pressure,
                     "run_type": run_type,
                     "modifiers": modifiers,
+                    "metadata_version": metadata_version,
                     "error": str(exc),
                 },
             )

--- a/frontend/src/lib/systems/uiApi.js
+++ b/frontend/src/lib/systems/uiApi.js
@@ -57,7 +57,8 @@ function normalizeStartRunPayload(options) {
     return {
       party: options || ['player'],
       damage_type: '',
-      pressure: 0
+      pressure: 0,
+      metadata_version: null
     };
   }
 
@@ -67,24 +68,28 @@ function normalizeStartRunPayload(options) {
       damageType = '',
       pressure = 0,
       runType = null,
-      modifiers = null
+      modifiers = null,
+      metadataVersion = null
     } = options;
     const normalizedParty = Array.isArray(party) && party.length > 0 ? party : ['player'];
     const normalizedModifiers = normalizeModifiers(modifiers);
     const normalizedPressure = Number.isFinite(Number(pressure)) ? Number(pressure) : 0;
+    const normalizedMetadataVersion = metadataVersion ?? null;
     return {
       party: normalizedParty,
       damage_type: damageType,
       pressure: normalizedPressure,
       run_type: runType || undefined,
-      modifiers: normalizedModifiers
+      modifiers: normalizedModifiers,
+      metadata_version: normalizedMetadataVersion
     };
   }
 
   return {
     party: ['player'],
     damage_type: '',
-    pressure: 0
+    pressure: 0,
+    metadata_version: null
   };
 }
 

--- a/frontend/tests/api.test.js
+++ b/frontend/tests/api.test.js
@@ -34,6 +34,40 @@ describe('api calls', () => {
     expect(result).toEqual({ run_id: '123', map: [] });
   });
 
+  test('startRun forwards metadata version', async () => {
+    const fetchMock = mock(async (url, options) => {
+      expect(url).toBe('http://backend.test/ui/action');
+      const body = JSON.parse(options.body);
+      expect(body).toEqual({
+        action: 'start_run',
+        params: {
+          party: ['hero'],
+          damage_type: 'Fire',
+          pressure: 5,
+          run_type: 'boss_rush',
+          modifiers: { pressure: 5 },
+          metadata_version: '2025.02'
+        }
+      });
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ run_id: 'abc', map: [] })
+      };
+    });
+    global.fetch = fetchMock;
+    const result = await startRun({
+      party: ['hero'],
+      damageType: 'Fire',
+      pressure: 5,
+      runType: 'boss_rush',
+      modifiers: { pressure: 5 },
+      metadataVersion: '2025.02'
+    });
+    expect(result).toEqual({ run_id: 'abc', map: [] });
+    expect(fetchMock.mock.calls.length).toBe(1);
+  });
+
   test('updateParty sends party', async () => {
     global.fetch = createFetch({ status: 'ok' });
     const result = await updateParty(['sample_player']);


### PR DESCRIPTION
## Summary
- add metadata version support to the UI start run payload so the client always sends its configuration version marker
- accept and persist optional metadata_version fields in the start_run routes while logging client/server metadata versions together with the run snapshot
- extend frontend API tests to assert the metadata version value is forwarded through startRun requests

## Testing
- [x] Backend tests
- [x] Frontend tests
- [x] Linting
- [ ] Doc sync updates (README and `.codex/implementation` docs; link tasks below)

## Checklist
- [ ] Linked or updated relevant `.codex/tasks` entries
- [ ] Updated player roster and foe docs if adding or modifying fighters or enemies
- [ ] Referenced `.codex/implementation/ui-animation-guidelines.md` when adding UI animations

------
https://chatgpt.com/codex/tasks/task_b_68e24a741c68832caa562c511ccc1894