### PR TITLE
Add falsy server guard to vitest environment shim

### DIFF
--- a/frontend/vitest.config.js
+++ b/frontend/vitest.config.js
@@ -6,6 +6,9 @@ const vitestEnvironmentShim = {
   name: 'vitest-environment-shim',
   enforce: 'pre',
   configureServer(server) {
+    if (!server) {
+      return;
+    }
     if (!server.environments) {
       const assetsInclude = server.config?.assetsInclude || (() => false);
       server.environments = {


### PR DESCRIPTION
## Summary
- add a defensive return in the vitest environment shim so the hook skips configuration when no server object is provided

## Testing
- bun test *(fails: existing floor-transition.mock vi.mock undefined and start-run damage type expectation)*

------
https://chatgpt.com/codex/tasks/task_b_68e254b00e98832c9b3dcba72b7ff429