### PR TITLE
feat: convert run chooser overlay to OverlaySurface

### DIFF
--- a/frontend/src/lib/components/OverlayHost.svelte
+++ b/frontend/src/lib/components/OverlayHost.svelte
@@ -283,7 +283,7 @@
 {/if}
 
 {#if $overlayView === 'run-choose'}
-  <PopupWindow title="Resume or Start Run" maxWidth="720px" zIndex={1300} reducedMotion={overlayReducedMotion} on:close={() => dispatch('back')}>
+  <OverlaySurface zIndex={1300}>
     <RunChooser runs={$overlayData.runs || []}
       reducedMotion={overlayReducedMotion}
       on:choose={(e) => dispatch('loadRun', e.detail.run)}
@@ -291,7 +291,7 @@
       on:startRun={(e) => dispatch('startRun', e.detail)}
       on:cancel={() => dispatch('back')}
     />
-  </PopupWindow>
+  </OverlaySurface>
 {/if}
 
 {#if $overlayView === 'backend-not-ready'}


### PR DESCRIPTION
## Summary
- switch the run chooser overlay to use OverlaySurface for consistency with other overlays
- preserve existing run selection handlers and reduced-motion behavior inside RunChooser

## Testing
- [ ] Backend tests
- [x] Frontend tests
- [x] Linting
- [ ] Doc sync updates (README and `.codex/implementation` docs; link tasks below)

## Checklist
- [ ] Linked or updated relevant `.codex/tasks` entries
- [ ] Updated player roster and foe docs if adding or modifying fighters or enemies
- [ ] Referenced `.codex/implementation/ui-animation-guidelines.md` when adding UI animations

------
https://chatgpt.com/codex/tasks/task_b_68e254c4e3fc832c8942a4f22f56e3e7