### PR TITLE
feat: expose run configuration in tracking APIs

### DIFF
--- a/backend/routes/tracking.py
+++ b/backend/routes/tracking.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 from typing import Any
 
 from quart import Blueprint
@@ -15,16 +16,65 @@ def _rows_to_dict(cursor_description: list[tuple[str, ...]], rows: list[tuple[An
     return [dict(zip(keys, row, strict=False)) for row in rows]
 
 
+def _parse_json(value: Any) -> Any:
+    if value is None:
+        return None
+    if isinstance(value, (dict, list)):
+        return value
+    if isinstance(value, (bytes, bytearray)):
+        value = value.decode()
+    if isinstance(value, str):
+        try:
+            return json.loads(value)
+        except json.JSONDecodeError:
+            return value
+    return value
+
+
+def _inject_configuration(payload: dict[str, Any]) -> dict[str, Any]:
+    run_type = payload.pop("run_type", None)
+    modifiers_raw = payload.pop("modifiers_json", None)
+    reward_raw = payload.pop("reward_json", None)
+
+    modifiers = _parse_json(modifiers_raw)
+    reward_bonuses = _parse_json(reward_raw)
+
+    configuration: dict[str, Any] = {
+        "run_type": run_type,
+        "modifiers": modifiers if isinstance(modifiers, (dict, list)) else modifiers,
+        "reward_bonuses": reward_bonuses if isinstance(reward_bonuses, (dict, list)) else reward_bonuses,
+    }
+
+    # Avoid empty configuration payloads when nothing is stored for the run.
+    if any(value is not None for value in configuration.values()):
+        payload["configuration"] = configuration
+
+    return payload
+
+
 @bp.get("/runs")
 async def list_runs():
     def fetch():
         manager = get_tracking_manager()
         with manager.connection() as conn:
             cur = conn.execute(
-                "SELECT run_id, start_ts, end_ts, outcome FROM runs ORDER BY start_ts DESC"
+                """
+                SELECT
+                    runs.run_id,
+                    runs.start_ts,
+                    runs.end_ts,
+                    runs.outcome,
+                    run_configurations.run_type,
+                    run_configurations.modifiers_json,
+                    run_configurations.reward_json
+                FROM runs
+                LEFT JOIN run_configurations ON run_configurations.run_id = runs.run_id
+                ORDER BY runs.start_ts DESC
+                """
             )
             rows = cur.fetchall()
-            return _rows_to_dict(cur.description, rows)
+            payloads = _rows_to_dict(cur.description, rows)
+            return [_inject_configuration(payload) for payload in payloads]
 
     runs = await asyncio.to_thread(fetch)
     return jsonify({"runs": runs})
@@ -36,13 +86,26 @@ async def run_detail(run_id: str):
         manager = get_tracking_manager()
         with manager.connection() as conn:
             cur = conn.execute(
-                "SELECT run_id, start_ts, end_ts, outcome FROM runs WHERE run_id = ?",
+                """
+                SELECT
+                    runs.run_id,
+                    runs.start_ts,
+                    runs.end_ts,
+                    runs.outcome,
+                    run_configurations.run_type,
+                    run_configurations.modifiers_json,
+                    run_configurations.reward_json
+                FROM runs
+                LEFT JOIN run_configurations ON run_configurations.run_id = runs.run_id
+                WHERE runs.run_id = ?
+                """,
                 (run_id,),
             )
             run_row = cur.fetchone()
             if run_row is None:
                 return None
             run_info = dict(zip([col[0] for col in cur.description], run_row, strict=False))
+            run_info = _inject_configuration(run_info)
             member_cur = conn.execute(
                 "SELECT slot, character_id, stats_json FROM party_members WHERE run_id = ? ORDER BY slot",
                 (run_id,),


### PR DESCRIPTION
## Summary
- join run configuration metadata into tracking list/detail responses and surface structured modifiers
- normalize the new configuration payload in the UI API helpers
- show recorded run type, modifiers, and rewards inside the battle review archive menu

## Testing
- [x] Backend tests
- [ ] Frontend tests
- [x] Linting
- [ ] Doc sync updates (README and `.codex/implementation` docs; link tasks below)


------
https://chatgpt.com/codex/tasks/task_b_68e2663fe188832cb180e5a061f17219