### PR TITLE
Fix run wizard modifier input updates

### DIFF
--- a/frontend/src/lib/components/RunChooser.svelte
+++ b/frontend/src/lib/components/RunChooser.svelte
@@ -329,6 +329,11 @@
 
   function handleModifierChange(modId, raw) {
     if (!modifierMap.has(modId)) return;
+    if (raw === '') {
+      modifierValues = { ...modifierValues, [modId]: '' };
+      modifierDirty = { ...modifierDirty, [modId]: true };
+      return;
+    }
     const sanitized = sanitizeStack(modId, raw);
     modifierValues = { ...modifierValues, [modId]: sanitized };
     modifierDirty = { ...modifierDirty, [modId]: true };
@@ -611,8 +616,8 @@
                         min={mod.stacking?.minimum ?? 0}
                         step={mod.stacking?.step ?? 1}
                         max={Number.isFinite(mod.stacking?.maximum) ? mod.stacking.maximum : undefined}
-                        value={sanitizeStack(mod.id, modifierValues[mod.id])}
-                        on:change={(event) => handleModifierChange(mod.id, event.target.value)}
+                        value={modifierValues[mod.id] ?? ''}
+                        on:input={(event) => handleModifierChange(mod.id, event.target.value)}
                       />
                     </label>
                   </div>

--- a/frontend/tests/run-wizard-flow.vitest.js
+++ b/frontend/tests/run-wizard-flow.vitest.js
@@ -123,14 +123,16 @@ describe('RunChooser wizard flow', () => {
     expect(pressureInput).toBeTruthy();
     expect(enemyInput).toBeTruthy();
 
-    await fireEvent.change(pressureInput, { target: { value: '7' } });
-    await fireEvent.change(enemyInput, { target: { value: '3' } });
+    await fireEvent.input(pressureInput, { target: { value: '7' } });
+    await fireEvent.input(enemyInput, { target: { value: '3' } });
 
     const modifiersNext = screen.getByRole('button', { name: 'Next' });
     await fireEvent.click(modifiersNext);
     await tick();
 
     expect(screen.getByRole('heading', { name: 'Review & Start' })).toBeTruthy();
+    expect(screen.getByText('Pressure: 7')).toBeTruthy();
+    expect(screen.getByText('Enemy Buff: 3')).toBeTruthy();
 
     const startButton = screen.getByRole('button', { name: 'Start Run' });
     await fireEvent.click(startButton);


### PR DESCRIPTION
## Summary
- update the run wizard modifier inputs to emit changes on each keystroke while tolerating temporary empty values and keeping the existing clamping logic
- extend the run wizard flow test to verify modifier edits persist when advancing directly to the review step

## Testing
- bun x vitest run tests/run-wizard-flow.vitest.js *(fails: @sveltejs/vite-plugin-svelte hot-update expects an environments consumer during Vitest startup)*

------
https://chatgpt.com/codex/tasks/task_b_68e26ebbd100832ca29bf93e8f9049ab