### PR TITLE
Group duplicate login rewards and add quantity display

### DIFF
--- a/frontend/.codex/implementation/login-reward-panel.md
+++ b/frontend/.codex/implementation/login-reward-panel.md
@@ -14,7 +14,9 @@ drives the daily login reward flow.
 - A progress card tracks the "three rooms per day" requirement and surfaces the
   current count as both a numeric label and animated progress bar.
 - Reward entries render as grid chips with star icons, item names, and the
-  damage type/ID metadata surfaced by the backend.
+  damage type/ID metadata surfaced by the backend. Identical rewards collapse
+  into a single chip that appends a `(Nx)` suffix to highlight the combined
+  quantity.
 
 ## Behaviour
 - Fetches `/rewards/login` on mount, when the tab regains focus, after manual

--- a/frontend/src/lib/components/LoginRewardsPanel.svelte
+++ b/frontend/src/lib/components/LoginRewardsPanel.svelte
@@ -22,6 +22,16 @@
   let lastFetch = 0;
   let autoRefreshTimer = null;
 
+  function getRewardKey(item) {
+    if (item && item.item_id != null) {
+      return `id:${item.item_id}`;
+    }
+    const stars = item?.stars ?? 'unknown-stars';
+    const damage = item?.damage_type ?? 'unknown-damage';
+    const name = item?.name ?? 'unknown-name';
+    return `meta:${stars}::${damage}::${name}`;
+  }
+
   function formatCountdown(totalSeconds) {
     const total = Number.isFinite(totalSeconds) ? Math.max(0, Math.floor(totalSeconds)) : 0;
     const hours = Math.floor(total / 3600);
@@ -179,6 +189,29 @@
   $: streakDays = computeVisibleDays(streak);
   $: resetLabel = formatResetLabel(status?.reset_at);
   $: countdownLabel = formatCountdown(countdownSeconds);
+  $: groupedRewardItems = status?.reward_items?.length
+    ? Array.from(
+        status.reward_items.reduce((map, item) => {
+          const key = getRewardKey(item);
+          const rawQuantity = Number(item?.quantity ?? 1);
+          const baseQuantity = Number.isFinite(rawQuantity) ? Math.max(1, Math.floor(rawQuantity)) : 1;
+          if (map.has(key)) {
+            const existing = map.get(key);
+            map.set(key, {
+              ...existing,
+              quantity: existing.quantity + baseQuantity
+            });
+          } else {
+            map.set(key, {
+              ...item,
+              groupKey: key,
+              quantity: baseQuantity
+            });
+          }
+          return map;
+        }, new Map())
+      )
+    : [];
   $: autoDeliveryLabel = status
     ? status.claimed_today
       ? 'Today\'s bundle has been delivered to your inventory.'
@@ -266,11 +299,11 @@
     </div>
 
     <div class="reward-items" aria-label="Today's reward items">
-      {#if status.reward_items && status.reward_items.length > 0}
-        {#each status.reward_items as item}
+      {#if groupedRewardItems.length > 0}
+        {#each groupedRewardItems as item (item.groupKey)}
           <div
             class="reward-chip"
-            title={`${item?.name || 'Reward'} • ${Math.max(1, Number(item?.stars) || 1)}★ ${String(item?.damage_type || 'Unknown').toUpperCase()}`}
+            title={`${item?.name || 'Reward'} • ${Math.max(1, Number(item?.stars) || 1)}★ ${String(item?.damage_type || 'Unknown').toUpperCase()}${item.quantity > 1 ? ` • ${item.quantity}x` : ''}`}
           >
             <div class="reward-stars" aria-hidden="true">
               {#each Array(Math.max(1, Number(item?.stars) || 1)) as _, idx}
@@ -278,7 +311,13 @@
               {/each}
             </div>
             <div class="reward-meta">
-              <span class="reward-name">{item?.name || `${item?.stars ?? 1}★ ${item?.damage_type || 'Unknown'}`}</span>
+              <span class="reward-name">
+                {item?.name || `${item?.stars ?? 1}★ ${item?.damage_type || 'Unknown'}`}
+                {#if item.quantity > 1}
+                  {' '}
+                  ({item.quantity}x)
+                {/if}
+              </span>
               <span class="reward-type">{(item?.damage_type || '').toUpperCase()} • ID {item?.item_id}</span>
             </div>
           </div>

--- a/frontend/tests/login-rewards-panel.vitest.js
+++ b/frontend/tests/login-rewards-panel.vitest.js
@@ -1,0 +1,63 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/svelte';
+import LoginRewardsPanel from '../src/lib/components/LoginRewardsPanel.svelte';
+
+const mockGetLoginRewardStatus = vi.fn();
+
+vi.mock('../src/lib/systems/uiApi.js', () => ({
+  getLoginRewardStatus: mockGetLoginRewardStatus
+}));
+
+describe('LoginRewardsPanel reward grouping', () => {
+  beforeEach(() => {
+    mockGetLoginRewardStatus.mockResolvedValue({
+      seconds_until_reset: 3600,
+      reset_at: new Date().toISOString(),
+      rooms_completed: 1,
+      rooms_required: 3,
+      daily_rdr_bonus: 0.05,
+      claimed_today: false,
+      streak: 4,
+      reward_items: [
+        {
+          item_id: 'ITEM-001',
+          name: 'Photon Blade',
+          stars: 3,
+          damage_type: 'fire'
+        },
+        {
+          item_id: 'ITEM-001',
+          name: 'Photon Blade',
+          stars: 3,
+          damage_type: 'fire'
+        },
+        {
+          item_id: 'ITEM-002',
+          name: 'Aqua Core',
+          stars: 2,
+          damage_type: 'water'
+        }
+      ]
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  test('renders duplicate rewards as a single entry with quantity suffix', async () => {
+    const { container } = render(LoginRewardsPanel);
+
+    const groupedReward = await screen.findByText('Photon Blade (2x)');
+    expect(groupedReward).toBeInTheDocument();
+
+    const chips = container.querySelectorAll('.reward-chip');
+    expect(chips).toHaveLength(2);
+
+    const soloReward = await screen.findByText('Aqua Core');
+    expect(soloReward.textContent?.trim()).toBe('Aqua Core');
+
+    expect(mockGetLoginRewardStatus).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- group login reward items by item id/metadata so duplicates surface as a single entry with a quantity suffix
- reflect the quantity suffix behaviour in the login reward panel implementation notes
- add a vitest that exercises duplicate login reward items and expects a single row with the aggregated quantity label

## Testing
- bunx vitest run tests/login-rewards-panel.vitest.js *(fails: TypeError: Cannot read properties of undefined (reading 'consumer') from @sveltejs/vite-plugin-svelte)*

------
https://chatgpt.com/codex/tasks/task_b_68e27ec33ba8832cb705f9aa50f8ccf9