### PR TITLE
[FIX] Track attack metadata in damage events

### DIFF
--- a/backend/tests/test_luna_damage_metadata.py
+++ b/backend/tests/test_luna_damage_metadata.py
@@ -1,0 +1,60 @@
+import pytest
+
+from autofighter.rooms.battle.turn_loop.player_turn import (
+    prepare_action_attack_metadata,
+)
+from autofighter.stats import BUS
+from autofighter.stats import Stats
+from autofighter.stats import set_battle_active
+from plugins.characters.luna import Luna
+
+
+@pytest.mark.asyncio
+async def test_luna_consecutive_hits_emit_unique_attack_metadata(monkeypatch):
+    set_battle_active(True)
+    events: list[tuple] = []
+
+    def _capture(event: str, *args):
+        if event == "damage_taken":
+            events.append(args)
+
+    monkeypatch.setattr(BUS, "emit_batched", _capture)
+
+    attacker = Luna()
+    attacker.id = "luna_test_attacker"
+    attacker.set_base_stat("atk", 600)
+    attacker.set_base_stat("crit_rate", 0)
+    attacker.set_base_stat("crit_damage", 2)
+    attacker.actions_per_turn = 2
+    attacker.action_points = attacker.actions_per_turn
+
+    target = Stats()
+    target.id = "luna_test_target"
+    target.set_base_stat("max_hp", 5000)
+    target.set_base_stat("defense", 10)
+    target.set_base_stat("dodge_odds", 0)
+    target.hp = target.max_hp
+
+    try:
+        prepare_action_attack_metadata(attacker)
+        await target.apply_damage(attacker.atk, attacker=attacker, action_name="Normal Attack")
+        attacker.action_points = max(attacker.action_points - 1, 0)
+
+        prepare_action_attack_metadata(attacker)
+        await target.apply_damage(attacker.atk, attacker=attacker, action_name="Normal Attack")
+    finally:
+        set_battle_active(False)
+
+    damage_events = [args for args in events if len(args) >= 8]
+    assert len(damage_events) >= 2, "Expected at least two damage events from consecutive hits"
+
+    first_details = damage_events[0][-1]
+    second_details = damage_events[1][-1]
+
+    assert first_details.get("attack_index") == 1
+    assert first_details.get("attack_total") == 2
+    assert second_details.get("attack_index") == 2
+    assert second_details.get("attack_total") == 2
+    assert first_details.get("attack_sequence") != second_details.get("attack_sequence")
+    assert isinstance(first_details.get("attack_sequence"), int)
+    assert isinstance(second_details.get("attack_sequence"), int)


### PR DESCRIPTION
## Summary
- add helpers in the player turn loop to stage attack index/total metadata and set it before normal and spread hits resolve
- extend Stats.apply_damage to merge staged metadata into emitted damage details and ensure every hit gets a unique attack_sequence
- add a focused Luna battle test that asserts consecutive hits surface the new metadata on damage_taken events

## Testing
- uv run ruff check autofighter/rooms/battle/turn_loop/player_turn.py autofighter/stats.py tests/test_luna_damage_metadata.py --fix
- uv run pytest tests/test_luna_damage_metadata.py


------
https://chatgpt.com/codex/tasks/task_b_68e280b720e8832ca0b2cd42cf093541