### PR TITLE
Fix grouped login reward iteration to use map values

### DIFF
--- a/frontend/src/lib/components/LoginRewardsPanel.svelte
+++ b/frontend/src/lib/components/LoginRewardsPanel.svelte
@@ -209,7 +209,7 @@
             });
           }
           return map;
-        }, new Map())
+        }, new Map()).values()
       )
     : [];
   $: autoDeliveryLabel = status


### PR DESCRIPTION
## Summary
- iterate over the grouped login reward map values so the template receives reward objects

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e2827b03bc832cb7898615e0d02dfe