### PR TITLE
Surface run modifier metadata in wizard tooltips

### DIFF
--- a/frontend/.codex/implementation/run-helpers.md
+++ b/frontend/.codex/implementation/run-helpers.md
@@ -22,6 +22,7 @@ Root run state now lives in dedicated stores under `frontend/src/lib/systems/`. 
   - Replaced the legacy single-step chooser with a four-stage wizard (Resume → Party → Run Type → Modifiers → Confirm) that consumes live metadata, persists defaults in `localStorage`, and emits `startRun` with the consolidated configuration snapshot.
   - Integrates telemetry via `logMenuAction` for step impressions, modifier adjustments, resumptions, cancellations, and start submissions so analytics receives a consistent event stream.
   - Computes reward previews client-side to mirror backend multiplier math (foe-stack bonuses plus `character_stat_down` incentives) and surfaces the canonical pressure tooltip alongside modifier descriptions.
+  - Hydrates modifier tooltips with metadata-driven stacking, reward, and effect summaries (including preview chips) so the copy stays in sync with the backend schema.
 
 - `frontend/src/lib/systems/pollingOrchestrator.js`
   - Owns the UI state, battle snapshot, and map fallback cadences. The controller subscribes to `haltSync`, `overlayBlocking`, and the overlay view store so all loops pause while overlays are active or manual halts are engaged.


### PR DESCRIPTION
## Summary
- hydrate modifier tooltips with backend effect metadata, preview chips, and layout tweaks so the modifiers step fills the panel cleanly
- extend the run wizard Vitest coverage to assert metadata-driven tooltips and preview copy across economy, foe, and player penalty modifiers
- document the RunChooser metadata hydration workflow in the frontend run helpers notes

## Testing
- bun run lint
- bun x vitest run tests/run-wizard-flow.vitest.js *(fails: @sveltejs/vite-plugin-svelte startup error about hot-update consumer)*

------
https://chatgpt.com/codex/tasks/task_b_68e280908c3c832caaa21a11179d34cb