### PR TITLE
feat(frontend): clarify modifier metadata previews

### DIFF
--- a/frontend/.codex/implementation/run-helpers.md
+++ b/frontend/.codex/implementation/run-helpers.md
@@ -22,7 +22,7 @@ Root run state now lives in dedicated stores under `frontend/src/lib/systems/`. 
   - Replaced the legacy single-step chooser with a four-stage wizard (Resume → Party → Run Type → Modifiers → Confirm) that consumes live metadata, persists defaults in `localStorage`, and emits `startRun` with the consolidated configuration snapshot.
   - Integrates telemetry via `logMenuAction` for step impressions, modifier adjustments, resumptions, cancellations, and start submissions so analytics receives a consistent event stream.
   - Computes reward previews client-side to mirror backend multiplier math (foe-stack bonuses plus `character_stat_down` incentives) and surfaces the canonical pressure tooltip alongside modifier descriptions.
-  - Hydrates modifier tooltips with metadata-driven stacking, reward, and effect summaries (including preview chips) so the copy stays in sync with the backend schema.
+  - Hydrates modifier tooltips with metadata-driven stacking, reward, and effect summaries (including preview chips) so the copy stays in sync with the backend schema. Preview chips are normalised and sorted by stack count, explicitly call out `Step` size for every modifier, and append an uncapped scaling reminder when metadata omits a maximum.
 
 - `frontend/src/lib/systems/pollingOrchestrator.js`
   - Owns the UI state, battle snapshot, and map fallback cadences. The controller subscribes to `haltSync`, `overlayBlocking`, and the overlay view store so all loops pause while overlays are active or manual halts are engaged.

--- a/frontend/tests/run-wizard-flow.vitest.js
+++ b/frontend/tests/run-wizard-flow.vitest.js
@@ -265,6 +265,8 @@ describe('RunChooser wizard flow', () => {
     const pressureTooltip = screen.getByRole('button', { name: /Pressure modifier details/i });
     const pressureTooltipText = pressureTooltip.getAttribute('data-tooltip') || '';
     expect(pressureTooltipText).toContain('Stacks are uncapped');
+    expect(pressureTooltipText).toContain('Stacks increase by 1 each time.');
+    expect(pressureTooltipText).toContain('Stacks continue scaling beyond this preview because the modifier is uncapped.');
     expect(pressureTooltipText).toContain('Adds +1 base foe slot for every five stacks');
 
     const foeTooltip = screen.getByRole('button', { name: /Enemy Buff modifier details/i });


### PR DESCRIPTION
## Summary
- surface modifier stack steps and uncapped reminders directly in RunChooser tooltips
- normalise and sort metadata preview chips, adding infinite-stack messaging where applicable
- document the new behaviour and extend the wizard flow test expectations

## Testing
- bun x vitest run run-wizard-flow *(fails: @sveltejs/vite-plugin-svelte hot-update consumer undefined)*
- ruff check . --fix *(fails: repository contains pre-existing E402 import ordering violations in backend tests)*

ready for review

------
https://chatgpt.com/codex/tasks/task_b_68e284ae2fe8832c88963c28011778a1