### PR TITLE
Update Tactical Kit card trigger

### DIFF
--- a/backend/plugins/cards/tactical_kit.py
+++ b/backend/plugins/cards/tactical_kit.py
@@ -21,7 +21,7 @@ class TacticalKit(CardBase):
         # Track which members have used their tactical conversion
         conversion_used = set()
 
-        async def _on_action_about_to_start(actor):
+        async def _on_action_about_to_start(actor, *_args, **_kwargs):
             # Check if actor is one of our party members and hasn't used conversion yet
             if actor in party.members:
                 actor_id = id(actor)
@@ -68,5 +68,5 @@ class TacticalKit(CardBase):
             if target in party.members:
                 conversion_used.clear()
 
-        self.subscribe("action_start", _on_action_about_to_start)
+        self.subscribe("action_used", _on_action_about_to_start)
         self.subscribe("battle_start", _on_battle_start)

--- a/backend/tests/test_tactical_kit.py
+++ b/backend/tests/test_tactical_kit.py
@@ -1,0 +1,42 @@
+import asyncio
+
+import pytest
+
+from autofighter.cards import apply_cards
+from autofighter.cards import award_card
+from autofighter.party import Party
+from autofighter.stats import BUS
+from plugins.characters._base import PlayerBase
+
+
+@pytest.mark.asyncio
+async def test_tactical_kit_converts_hp_once_per_battle():
+    party = Party()
+    acting_ally = PlayerBase()
+    other_ally = PlayerBase()
+    party.members.extend([acting_ally, other_ally])
+
+    award_card(party, "tactical_kit")
+    await apply_cards(party)
+
+    await BUS.emit_async("battle_start", acting_ally)
+    await BUS.emit_async("battle_start", other_ally)
+    await asyncio.sleep(0)
+
+    initial_max_hp = acting_ally.max_hp
+    initial_hp = acting_ally.hp
+    initial_atk = acting_ally.atk
+
+    await BUS.emit_async("action_used", acting_ally, other_ally, 0)
+    await asyncio.sleep(0)
+
+    expected_hp_after_conversion = max(1, initial_hp - int(initial_max_hp * 0.01))
+    assert acting_ally.hp == expected_hp_after_conversion
+    after_first_atk = acting_ally.atk
+    assert after_first_atk > initial_atk
+
+    await BUS.emit_async("action_used", acting_ally, other_ally, 0)
+    await asyncio.sleep(0)
+
+    assert acting_ally.hp == expected_hp_after_conversion
+    assert acting_ally.atk == pytest.approx(after_first_atk)


### PR DESCRIPTION
## Summary
- switch the Tactical Kit card subscription to the action_used event and accept the richer callback signature
- add a regression test confirming the HP-to-ATK conversion only triggers once per battle when the ally acts

## Testing
- uv run ruff check plugins/cards/tactical_kit.py tests/test_tactical_kit.py --fix
- uv run pytest tests/test_tactical_kit.py

------
https://chatgpt.com/codex/tasks/task_b_68e28631e404832ca990640315d9c6cc