### PR TITLE
Fix RunChooser modifiers stage class binding

### DIFF
--- a/frontend/src/lib/components/RunChooser.svelte
+++ b/frontend/src/lib/components/RunChooser.svelte
@@ -930,8 +930,7 @@
   </div>
 {:else}
   <MenuPanel
-    class="run-wizard"
-    class:modifiers-stage={step === 'modifiers'}
+    class={`run-wizard${step === 'modifiers' ? ' modifiers-stage' : ''}`}
     data-step={step}
     padding="var(--menu-panel-padding, clamp(0.65rem, 1.8vw, 1.1rem))"
     {reducedMotion}


### PR DESCRIPTION
## Summary
- ensure the RunChooser panel retains its modifiers-stage styling without using a class directive

## Testing
- VITE_API_BASE=http://localhost bun run build *(fails: missing stringHashIndex export in assetLoader)*

------
https://chatgpt.com/codex/tasks/task_b_68e2864d66cc832caa05bf4eecd2b031