### PR TITLE
fix: export stringHashIndex from asset loader

### DIFF
--- a/frontend/src/lib/systems/assetLoader.js
+++ b/frontend/src/lib/systems/assetLoader.js
@@ -53,7 +53,8 @@ export {
   resetAssetRegistryOverrides,
   getDefaultFallback,
   getSummonGallery,
-  getAvailableSummonIds
+  getAvailableSummonIds,
+  stringHashIndex
 };
 
 const ELEMENT_ICONS = {


### PR DESCRIPTION
## Summary
- export `stringHashIndex` from the asset loader module so dependent code can import it directly

## Testing
- bun run lint
- bun run dev -- --host 0.0.0.0 --port 5173

------
https://chatgpt.com/codex/tasks/task_b_68e28aac16ec832cb86ae99a2c53e9d5