### PR TITLE
[fix] Remove reward metadata label from login rewards chips

### DIFF
--- a/frontend/src/lib/components/LoginRewardsPanel.svelte
+++ b/frontend/src/lib/components/LoginRewardsPanel.svelte
@@ -318,7 +318,6 @@
                   ({item.quantity}x)
                 {/if}
               </span>
-              <span class="reward-type">{(item?.damage_type || '').toUpperCase()} • ID {item?.item_id}</span>
             </div>
           </div>
         {/each}


### PR DESCRIPTION
## Summary
- remove the reward metadata line from the daily login reward chips so each chip renders on a single row

## Testing
- [ ] Backend tests
- [ ] Frontend tests
- [x] Linting

## Checklist
- [ ] Linked or updated relevant `.codex/tasks` entries
- [ ] Updated player roster and foe docs if adding or modifying fighters or enemies
- [ ] Referenced `.codex/implementation/ui-animation-guidelines.md` when adding UI animations

------
https://chatgpt.com/codex/tasks/task_b_68e29459a168832cbf9be3f4b20ca7f7