### PR TITLE
Align Ice ultimate signature and add regression test

### DIFF
--- a/backend/plugins/damage_types/ice.py
+++ b/backend/plugins/damage_types/ice.py
@@ -16,19 +16,32 @@ class Ice(DamageTypeBase):
     def create_dot(self, damage: float, source) -> DamageOverTime | None:
         return damage_effects.create_dot(self.id, damage, source)
 
-    async def ultimate(self, user: Stats, foes: list[Stats]) -> bool:
+    async def ultimate(
+        self,
+        actor: Stats,
+        allies: list[Stats],
+        enemies: list[Stats],
+    ) -> bool:
         """Strike all foes six times, ramping damage by 30% per target."""
         from autofighter.rooms.battle.pacing import YIELD_MULTIPLIER
         from autofighter.rooms.battle.pacing import pace_sleep
 
-        if not await self.consume_ultimate(user):
+        if not await self.consume_ultimate(actor):
             return False
-        base = user.atk
+
+        if not enemies:
+            return True
+
+        base = actor.atk
         for _ in range(6):
             bonus = 1.0
-            for foe in foes:
+            for enemy in enemies:
                 dmg = int(base * bonus)
-                await foe.apply_damage(dmg, attacker=user, action_name="Ice Ultimate")
+                await enemy.apply_damage(
+                    dmg,
+                    attacker=actor,
+                    action_name="Ice Ultimate",
+                )
                 await pace_sleep(YIELD_MULTIPLIER)
                 bonus += 0.3
             await pace_sleep(YIELD_MULTIPLIER)

--- a/backend/tests/test_ice_ultimate.py
+++ b/backend/tests/test_ice_ultimate.py
@@ -1,0 +1,45 @@
+import pytest
+
+from autofighter.stats import BUS
+from autofighter.stats import Stats
+from autofighter.stats import set_battle_active
+from plugins.damage_types.ice import Ice
+
+
+class Actor(Stats):
+    async def use_ultimate(self) -> bool:
+        if not self.ultimate_ready:
+            return False
+
+        self.ultimate_charge = 0
+        self.ultimate_ready = False
+        await BUS.emit_async("ultimate_used", self)
+        return True
+
+
+@pytest.mark.asyncio
+async def test_ice_ultimate_hits_multiple_enemies_without_error():
+    actor = Actor(damage_type=Ice())
+    actor.id = "ice-actor"
+    actor.atk = 300
+    actor.ultimate_charge = 15
+    actor.ultimate_ready = True
+
+    foes: list[Stats] = []
+    for idx in range(3):
+        foe = Stats()
+        foe.id = f"foe-{idx}"
+        foe.defense = 0
+        foe.dodge_odds = 0
+        foes.append(foe)
+
+    set_battle_active(True)
+    try:
+        result = await actor.damage_type.ultimate(actor, [actor], foes)
+    finally:
+        set_battle_active(False)
+
+    assert result is True
+    for foe in foes:
+        assert foe.hp < foe.max_hp
+        assert foe.last_damage_taken > 0


### PR DESCRIPTION
## Summary
- align the Ice damage type ultimate signature with the base damage type contract
- ensure the ability iterates over the provided enemies list, consuming charge and handling empty targets
- add an async test that equips Ice and executes the ultimate against multiple foes

## Testing
- pytest backend/tests/test_ice_ultimate.py

ready for review

------
https://chatgpt.com/codex/tasks/task_b_68e295c42934832c88e5c0e5c492a883