### PR TITLE
Integrate run modifier context helper into backend

### DIFF
--- a/backend/tests/test_run_configuration_context.py
+++ b/backend/tests/test_run_configuration_context.py
@@ -1,0 +1,39 @@
+import math
+
+import pytest
+from services.run_configuration import build_run_modifier_context
+from services.run_configuration import validate_run_configuration
+
+
+def test_build_run_modifier_context_matches_snapshot_metadata():
+    selection = validate_run_configuration(
+        run_type="standard",
+        modifiers={
+            "pressure": 7,
+            "foe_hp": 3,
+            "foe_mitigation": 2,
+            "foe_glitched_rate": 4,
+            "foe_prime_rate": 1,
+            "character_stat_down": 5,
+        },
+    )
+
+    context = build_run_modifier_context(selection.snapshot)
+
+    assert context.pressure == 7
+    assert math.isclose(context.shop_multiplier, 1.26 ** 7, rel_tol=1e-9)
+    hp_effect = selection.snapshot["modifiers"]["foe_hp"]["details"]["effective_bonus"]
+    assert context.foe_stat_multipliers["max_hp"] == pytest.approx(1.0 + hp_effect)
+    mitigation_effect = selection.snapshot["modifiers"]["foe_mitigation"]["details"]["effective_bonus"]
+    assert context.foe_stat_deltas["mitigation"] == pytest.approx(mitigation_effect)
+    glitched_bonus = selection.snapshot["modifiers"]["foe_glitched_rate"]["details"]["raw_bonus"] * 100.0
+    assert context.glitched_spawn_bonus_pct == pytest.approx(glitched_bonus)
+    prime_bonus = selection.snapshot["modifiers"]["foe_prime_rate"]["details"]["raw_bonus"] * 100.0
+    assert context.prime_spawn_bonus_pct == pytest.approx(prime_bonus)
+    player_multiplier = selection.snapshot["modifiers"]["character_stat_down"]["details"]["effective_multiplier"]
+    assert context.player_stat_multiplier == pytest.approx(player_multiplier)
+    assert len(context.metadata_hash) == 64
+
+    serialized = context.to_dict()
+    assert serialized["metadata_hash"] == context.metadata_hash
+    assert serialized["foe_stat_multipliers"]["max_hp"] == context.foe_stat_multipliers["max_hp"]


### PR DESCRIPTION
## Summary
- add a reusable `RunModifierContext` helper that condenses modifier metadata into derived values for downstream systems
- persist the modifier context on new runs and surface the derived fields in telemetry payloads
- add a regression test ensuring the context mirrors snapshot math

## Testing
- uv run --project backend ruff check backend/services/run_configuration.py backend/services/run_service.py backend/tests/test_run_configuration_context.py --fix
- uv run --project backend pytest backend/tests/test_run_configuration_context.py

ready for review

------
https://chatgpt.com/codex/tasks/task_b_68e2acb572a0832cbe6814d970b22a07