### PR TITLE
Fix Phantom Ally summon damage type inheritance

### DIFF
--- a/backend/plugins/cards/phantom_ally.py
+++ b/backend/plugins/cards/phantom_ally.py
@@ -63,12 +63,14 @@ class PhantomAlly(CardBase):
 
         # Create phantom using the new summons system
         # Phantoms are full-strength copies (multiplier=1.0) that last the entire battle
+        original_damage_type = getattr(original, "damage_type", None)
         summon = SummonManager.create_summon(
             summoner=original,
             summon_type="phantom",
             source=self.id,
             stat_multiplier=1.0,  # Full strength copy
             turns_remaining=-1,  # Lasts the entire battle
+            override_damage_type=original_damage_type,
         )
 
         if not summon:


### PR DESCRIPTION
## Summary
- ensure Phantom Ally passes the original ally damage type through to SummonManager so phantoms inherit the correct element
- update the Phantom Ally test to control the selected ally and assert the phantom shares the original damage type

## Testing
- [x] Backend tests
- [ ] Frontend tests
- [x] Linting
- [ ] Doc sync updates (README and `.codex/implementation` docs; link tasks below)

## Checklist
- [ ] Linked or updated relevant `.codex/tasks` entries
- [ ] Updated player roster and foe docs if adding or modifying fighters or enemies
- [ ] Referenced `.codex/implementation/ui-animation-guidelines.md` when adding UI animations

------
https://chatgpt.com/codex/tasks/task_b_68e2b1c20a34832cb7cdb763bc48d83b