### PR TITLE
Align star material mapping with unit scale

### DIFF
--- a/backend/routes/players.py
+++ b/backend/routes/players.py
@@ -497,7 +497,9 @@ UPGRADEABLE_STATS = [
     "vitality",
     "mitigation",
 ]
-STAR_TO_MATERIALS = {1: 1, 2: 150, 3: 22500, 4: 3375000}
+# Keep the star-to-material conversion aligned with the per-item unit scale so we
+# do not reject valid upgrade requests or lose value when consuming items.
+STAR_TO_MATERIALS = {1: 1, 2: 125, 3: 125**2, 4: 125**3}
 # Number of 1★ units represented by a single item at each star level.
 ITEM_UNIT_SCALE = {
     1: 1,

--- a/backend/tests/test_new_upgrade_system.py
+++ b/backend/tests/test_new_upgrade_system.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import pytest
 import sqlcipher3
 
-STAR_TO_MATERIALS = {1: 1, 2: 150, 3: 22500, 4: 3375000}
+STAR_TO_MATERIALS = {1: 1, 2: 125, 3: 125**2, 4: 125**3}
 
 
 @pytest.fixture()


### PR DESCRIPTION
## Summary
- align `STAR_TO_MATERIALS` conversion ratios with `ITEM_UNIT_SCALE` so higher-tier materials are valued consistently

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68e2b389f23c832c980c10686e3c4c42