### PR TITLE
Thread run modifier context through shops and foes

### DIFF
--- a/backend/routes/ui.py
+++ b/backend/routes/ui.py
@@ -249,11 +249,18 @@ async def get_ui_state() -> tuple[str, int, dict[str, Any]]:
                     items_bought = 0
 
                 party_snapshot = await asyncio.to_thread(load_party, run_id)
+                context = getattr(current_node, "run_modifier_context", None)
+                if context is None:
+                    context = getattr(party_snapshot, "run_modifier_context", None)
+                    if context is not None:
+                        setattr(current_node, "run_modifier_context", context)
+
                 shop_view = serialize_shop_payload(
                     party_snapshot,
                     stored_stock,
                     getattr(current_node, "pressure", 0),
                     items_bought,
+                    context=context,
                 )
                 shop_view.update(
                     {


### PR DESCRIPTION
## Summary
- propagate `RunModifierContext` through the foe factory so rank rolls and stat scaling respect run modifiers
- rework shop pricing, taxation, and serialization to consume the modifier context and expose metadata in responses
- update UI routing and backend tests to call the new helpers and cover the adjusted shop flows

## Testing
- `uv run ruff check autofighter/rooms/shop.py routes/ui.py autofighter/rooms/foe_factory.py tests/test_shop_room.py --fix`
- `uv run pytest tests/test_shop_room.py tests/test_foe_selector.py`
- `uv run pytest` *(fails: missing `battle_logging` modules and syntax error in `tests/test_event_bus_performance.py`)*

------
https://chatgpt.com/codex/tasks/task_b_68e2b03ecc04832ca0b0c950957fdf64