### PR TITLE
Guard optional pressure defense modifiers in foe factory

### DIFF
--- a/backend/autofighter/rooms/foe_factory.py
+++ b/backend/autofighter/rooms/foe_factory.py
@@ -116,8 +116,12 @@ class FoeFactory:
                 config["pressure_defense_floor"] = per_stack_floor
             except Exception:
                 pass
-            config["pressure_defense_min_roll"] = context.pressure_defense_min_roll
-            config["pressure_defense_max_roll"] = context.pressure_defense_max_roll
+            pressure_defense_min_roll = getattr(context, "pressure_defense_min_roll", None)
+            if pressure_defense_min_roll is not None:
+                config["pressure_defense_min_roll"] = pressure_defense_min_roll
+            pressure_defense_max_roll = getattr(context, "pressure_defense_max_roll", None)
+            if pressure_defense_max_roll is not None:
+                config["pressure_defense_max_roll"] = pressure_defense_max_roll
         elif pressure_override is None:
             pressure_override = getattr(node, "pressure", 0)
         prime_chance, glitched_chance = self.calculate_rank_probabilities(
@@ -266,8 +270,12 @@ class FoeFactory:
                 config["pressure_defense_floor"] = per_stack_floor
             except Exception:
                 pass
-            config["pressure_defense_min_roll"] = context.pressure_defense_min_roll
-            config["pressure_defense_max_roll"] = context.pressure_defense_max_roll
+            pressure_defense_min_roll = getattr(context, "pressure_defense_min_roll", None)
+            if pressure_defense_min_roll is not None:
+                config["pressure_defense_min_roll"] = pressure_defense_min_roll
+            pressure_defense_max_roll = getattr(context, "pressure_defense_max_roll", None)
+            if pressure_defense_max_roll is not None:
+                config["pressure_defense_max_roll"] = pressure_defense_max_roll
         base_mult = compute_base_multiplier(
             strength,
             node,


### PR DESCRIPTION
## Summary
- guard access to optional pressure defense roll modifiers when building encounters with run modifiers
- apply the same guards during stat scaling so missing attributes do not raise errors

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68e2b80ebd10832c9dca1e6234460863