### PR TITLE
Integrate run modifiers across backend systems

### DIFF
--- a/.codex/implementation/game-workflow.md
+++ b/.codex/implementation/game-workflow.md
@@ -34,6 +34,10 @@ Source code lives under the backend:
   - Every foe-focused stack contributes +0.5 EXP/RDR (50%).
   - `character_stat_down` tracks the two-phase stat penalty (0.001× per stack until 500, then 0.000001×) while granting +5% EXP/RDR on the first stack and +6% for each additional stack (two stacks = 11%).
   - The final multipliers are included in the run snapshot and telemetry payload so downstream services and analytics can reason about the selected configuration.
+- `start_run` serialises both the configuration snapshot and a condensed `RunModifierContext` into the persisted run state. Map nodes inherit the same context metadata hash so the shop, foe factory, and analytics pipelines can reconstruct the active modifiers without re-validating wizard input.
+- The modifier context applies the player stat penalty multiplier immediately to every party member, ensuring combat stats match the previewed difficulty adjustments. Derived foe stat multipliers, encounter slot bonuses, elite odds, shop multipliers, and pressure defense floors are cached for the map generator and foe factory.
+- `MapGenerator` hydrates nodes with the modifier context and honours configuration-driven flags (e.g., `boss_rush` disabling shops/rests) instead of relying on ad-hoc party attributes. Foe factories request the context directly from nodes or the party snapshot to compute spawn counts and stat scaling.
+- Shop rooms read the stored context to surface metadata hashes, price/tax multipliers, and encounter bonuses back to the client, keeping the UI and telemetry aligned with the selected run modifiers.
 - Telemetry events (`log_run_start`, `log_menu_action`) embed the metadata snapshot, ensuring analytics retain the chosen run type, modifier stacks, and reward boosts.
 
 ## Player onboarding & menus

--- a/backend/.codex/implementation/run-configuration-metadata.md
+++ b/backend/.codex/implementation/run-configuration-metadata.md
@@ -49,7 +49,12 @@ payload, and the legacy `pressure` fallback. The helper:
 
 `RunConfigurationSelection.snapshot` is serialised directly into the
 `runs.party` JSON under the `config` key and returned to the frontend as
-`configuration` from `start_run`.
+`configuration` from `start_run`. The helper also builds a
+`RunModifierContext` derived from the snapshot so downstream systems can read
+foe stat multipliers, encounter slot bonuses, shop/tax multipliers, and player
+stat penalties without re-validating the metadata payload. The context is
+persisted alongside the map state and stamped onto generated nodes via a
+metadata hash for analytics.
 
 ## Reward Application
 

--- a/backend/autofighter/rooms/shop.py
+++ b/backend/autofighter/rooms/shop.py
@@ -144,6 +144,8 @@ def serialize_shop_payload(
             "metadata_hash": context.metadata_hash,
             "shop_multiplier": context.shop_multiplier,
             "shop_tax_multiplier": context.shop_tax_multiplier,
+            "shop_variance": list(context.shop_variance),
+            "encounter_slot_bonus": context.encounter_slot_bonus,
         }
     config_snapshot = getattr(party, "run_config", None)
     if isinstance(config_snapshot, dict):
@@ -267,6 +269,12 @@ class ShopRoom(Room):
         self.node.items_bought = items_bought
 
         context = getattr(self.node, "run_modifier_context", None)
+        if isinstance(context, dict):
+            try:
+                context = RunModifierContext.from_dict(context)
+                setattr(self.node, "run_modifier_context", context)
+            except Exception:
+                context = None
         if context is None:
             context = getattr(party, "run_modifier_context", None)
             if context is not None:

--- a/backend/tests/test_foe_factory.py
+++ b/backend/tests/test_foe_factory.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+import random
 import sys
 import types
 
@@ -25,11 +26,15 @@ import pytest  # noqa: E402
 from autofighter.mapgen import MapNode  # noqa: E402
 from autofighter.party import Party  # noqa: E402
 from autofighter.rooms import _build_foes  # noqa: E402
+from autofighter.rooms.foe_factory import ROOM_BALANCE_CONFIG  # noqa: E402
 from autofighter.rooms.foe_factory import SpawnTemplate  # noqa: E402
 from autofighter.rooms.foe_factory import get_foe_factory  # noqa: E402
+from autofighter.rooms.foes.selector import _desired_count  # noqa: E402
 from plugins.characters import CHARACTER_FOES  # noqa: E402
 from plugins.characters import Player  # noqa: E402
 from plugins.characters.slime import Slime  # noqa: E402
+from services.run_configuration import build_run_modifier_context  # noqa: E402
+from services.run_configuration import validate_run_configuration  # noqa: E402
 
 
 @pytest.fixture(autouse=True)
@@ -98,3 +103,15 @@ def test_build_foes_respects_recent_weights_and_exclusions(monkeypatch):
     party = Party(members=[Player()])
     foes = _build_foes(node, party, exclude_ids={template_id})
     assert all(foe.id != template_id for foe in foes)
+
+
+def test_desired_count_respects_modifier_context():
+    selection = validate_run_configuration(run_type="standard", modifiers={"pressure": 10})
+    context = build_run_modifier_context(selection.snapshot)
+    node = MapNode(room_id=1, room_type="battle-normal", floor=1, index=1, loop=1, pressure=context.pressure)
+    party = Party(members=[Player()])
+    base_config = dict(ROOM_BALANCE_CONFIG)
+    baseline = _desired_count(node, party, config=base_config, context=None, rng=random.Random(0))
+    boosted = _desired_count(node, party, config=base_config, context=context, rng=random.Random(0))
+    assert boosted >= baseline
+    assert boosted - baseline >= context.encounter_slot_bonus

--- a/backend/tests/test_mapgen.py
+++ b/backend/tests/test_mapgen.py
@@ -4,6 +4,8 @@ import sys
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from autofighter.mapgen import MapGenerator
+from services.run_configuration import build_run_modifier_context
+from services.run_configuration import validate_run_configuration
 
 
 class _BossRushParty:
@@ -28,8 +30,19 @@ def test_generator_deterministic():
 
 def test_generator_boss_rush_floor_all_bosses():
     party = _BossRushParty()
-    gen = MapGenerator("seed")
+    selection = validate_run_configuration(run_type="boss_rush", modifiers={"pressure": 5})
+    context = build_run_modifier_context(selection.snapshot)
+    gen = MapGenerator("seed", modifier_context=context, configuration=selection.snapshot)
     rooms = gen.generate_floor(party)
     assert len(rooms) == MapGenerator.rooms_per_floor
     assert rooms[0].room_type == "start"
     assert all(room.room_type == "battle-boss-floor" for room in rooms[1:])
+
+
+def test_generator_attaches_modifier_context_metadata():
+    selection = validate_run_configuration(run_type="standard", modifiers={"pressure": 3})
+    context = build_run_modifier_context(selection.snapshot)
+    gen = MapGenerator("seed", modifier_context=context, configuration=selection.snapshot)
+    rooms = gen.generate_floor()
+    assert rooms[0].modifier_context["metadata_hash"] == context.metadata_hash
+    assert rooms[0].metadata_hash == context.metadata_hash

--- a/backend/tests/test_run_configuration_context.py
+++ b/backend/tests/test_run_configuration_context.py
@@ -1,6 +1,7 @@
 import math
 
 import pytest
+from services.run_configuration import RunModifierContext
 from services.run_configuration import build_run_modifier_context
 from services.run_configuration import validate_run_configuration
 
@@ -22,6 +23,8 @@ def test_build_run_modifier_context_matches_snapshot_metadata():
 
     assert context.pressure == 7
     assert math.isclose(context.shop_multiplier, 1.26 ** 7, rel_tol=1e-9)
+    assert context.shop_tax_multiplier == pytest.approx(1.0)
+    assert context.shop_variance == (0.95, 1.05)
     hp_effect = selection.snapshot["modifiers"]["foe_hp"]["details"]["effective_bonus"]
     assert context.foe_stat_multipliers["max_hp"] == pytest.approx(1.0 + hp_effect)
     mitigation_effect = selection.snapshot["modifiers"]["foe_mitigation"]["details"]["effective_bonus"]
@@ -32,8 +35,16 @@ def test_build_run_modifier_context_matches_snapshot_metadata():
     assert context.prime_spawn_bonus_pct == pytest.approx(prime_bonus)
     player_multiplier = selection.snapshot["modifiers"]["character_stat_down"]["details"]["effective_multiplier"]
     assert context.player_stat_multiplier == pytest.approx(player_multiplier)
+    assert context.encounter_slot_bonus == 1
+    assert context.pressure_defense_floor == pytest.approx(70.0)
+    assert context.pressure_defense_min_roll == pytest.approx(0.82)
+    assert context.pressure_defense_max_roll == pytest.approx(1.50)
+    assert context.modifier_stacks["foe_hp"] == 3
     assert len(context.metadata_hash) == 64
 
     serialized = context.to_dict()
     assert serialized["metadata_hash"] == context.metadata_hash
     assert serialized["foe_stat_multipliers"]["max_hp"] == context.foe_stat_multipliers["max_hp"]
+    hydrated = RunModifierContext.from_dict(serialized)
+    assert hydrated.shop_multiplier == pytest.approx(context.shop_multiplier)
+    assert hydrated.encounter_slot_bonus == context.encounter_slot_bonus


### PR DESCRIPTION
## Summary
- persist the normalized run modifier context on parties, maps, and telemetry so downstream services share consistent metadata
- extend the map generator, foe factory, selector helpers, and shop room to consume derived modifier effects (pressure bonuses, stat multipliers, shop pricing, etc.)
- add targeted tests covering context hydration, map metadata, modifier-aware foe counts, and shop payload reporting

## Testing
- `uv run pytest tests/test_run_configuration_context.py tests/test_mapgen.py tests/test_foe_factory.py tests/test_shop_room.py`
- `uv run ruff check .` *(fails: existing import-order issues outside the touched areas)*

------
https://chatgpt.com/codex/tasks/task_b_68e2ba4021b8832c891eef455e26418c