### PR TITLE
fix: avoid double counting encounter slot bonuses

### DIFF
--- a/backend/tests/test_mapgen.py
+++ b/backend/tests/test_mapgen.py
@@ -61,7 +61,9 @@ def test_generator_marks_prime_glitched_and_bonus_rooms():
 
     assert any("prime" in room.room_type for room in battle_rooms)
     assert any("glitched" in room.room_type for room in battle_rooms)
-    assert any(room.encounter_bonus > 0 for room in battle_rooms if room.room_type != "battle-boss-floor")
+    assert any(
+        room.encounter_bonus_marker for room in battle_rooms if room.room_type != "battle-boss-floor"
+    )
 
     for room in battle_rooms:
         if room.room_type == "battle-boss-floor":


### PR DESCRIPTION
## Summary
- add an encounter_bonus_marker field to MapNode to track rooms granted modifier slot bonuses without affecting spawn calculations
- stop writing modifier encounter bonuses into MapNode.encounter_bonus so _desired_count only sees explicit per-room bonuses
- update map generator tests to validate the new marker field

## Testing
- uv run pytest tests/test_mapgen.py tests/test_foe_factory.py

------
https://chatgpt.com/codex/tasks/task_b_68e2d7fa54c0832c8ec7cc91f50aa6ee