### PR TITLE
Add battle FX toggle and persistence

### DIFF
--- a/frontend/.codex/implementation/settings-menu.md
+++ b/frontend/.codex/implementation/settings-menu.md
@@ -46,6 +46,8 @@ Replaces the single "Reduced Motion" toggle with granular accessibility controls
 - **Disable Portrait Glows**: Removes glowing effects from `BattleFighterCard` portraits
 - **Simplify Overlay Transitions**: Uses simpler transitions for overlays and menus
 - **Disable Star Storm**: Turns off the animated `StarStorm.svelte` background effect
+- **Enable RPG Maker FX**: Opt-in switch for Effekseer battle animations such as spell bursts and weapon trails. When disabled,
+  the `BattleEffects` layer stays dormant so the WebGL runtime never initializes.
 
 Each control operates independently, allowing players to disable specific animations while keeping others. Components like `StarStorm.svelte` and `BattleEventFloaters.svelte` check both legacy `reducedMotion` props and the new granular settings via `getMotionSettings()`.
 

--- a/frontend/src/lib/components/BattleView.svelte
+++ b/frontend/src/lib/components/BattleView.svelte
@@ -38,12 +38,15 @@
   export let flashEnrageCounter = true;
 
   // Use granular motion settings with fallback to legacy prop
-  $: motionSettings = $motionStore || { 
-    globalReducedMotion: false, 
-    disablePortraitGlows: false, 
-    simplifyOverlayTransitions: false 
+  $: motionSettings = $motionStore || {
+    globalReducedMotion: false,
+    disablePortraitGlows: false,
+    simplifyOverlayTransitions: false,
+    enableBattleFx: false
   };
   $: effectiveReducedMotion = reducedMotion || motionSettings.globalReducedMotion;
+  $: battleFxEnabled = Boolean(motionSettings?.enableBattleFx);
+  $: battleFxActive = battleFxEnabled && !effectiveReducedMotion;
 
   let foes = [];
   let queue = [];
@@ -422,7 +425,7 @@
   
   let effectCue = '';
   function queueEffect(name) {
-    if (!name || effectiveReducedMotion) return;
+    if (!name || effectiveReducedMotion || !battleFxEnabled) return;
     effectCue = name;
     tick().then(() => {
       effectCue = '';
@@ -2339,7 +2342,7 @@
   bind:this={rootEl}
 >
   <EnrageIndicator active={Boolean(enrage?.active)} reducedMotion={effectiveReducedMotion} enrageData={enrage} />
-  <BattleEffects cue={effectCue} />
+  <BattleEffects cue={effectCue} enabled={battleFxActive} />
   <BattleProjectileLayer
     class="overlay-layer"
     projectiles={projectileEntries}

--- a/frontend/src/lib/components/UISettings.svelte
+++ b/frontend/src/lib/components/UISettings.svelte
@@ -178,6 +178,19 @@
       />
     </div>
   </div>
+
+  <div class="control" title="Enable RPG Maker style battle effects rendered with Effekseer.">
+    <div class="control-left">
+      <span class="label"><Move /> Enable RPG Maker FX</span>
+    </div>
+    <div class="control-right">
+      <input
+        type="checkbox"
+        bind:checked={motionSettings.enableBattleFx}
+        on:change={(e) => updateMotion({ enableBattleFx: e.target.checked })}
+      />
+    </div>
+  </div>
 </div>
 
 <style>

--- a/frontend/src/lib/effects/BattleEffects.svelte
+++ b/frontend/src/lib/effects/BattleEffects.svelte
@@ -1,69 +1,150 @@
 <script>
   import { onMount, onDestroy } from 'svelte';
-  // Feature flag to disable effects for now
-  const EFFEKSEER_ENABLED = false;
-  // Dynamically import Effekseer only when enabled
-  let effekseerApi;
 
   export let cue = '';
+  export let enabled = false;
 
   let canvas;
   let context;
   let loaded = new Map();
   let frame;
+  let initializing;
+  let effekseerApi;
+  let mounted = false;
 
-  async function init() {
-    if (!EFFEKSEER_ENABLED) return;
-    if (!effekseerApi) {
-      const mod = await import('@zaniar/effekseer-webgl-wasm/effekseer.min.js');
-      // Try common shapes: default export, named, or global
-      effekseerApi = mod?.default || mod?.effekseer || globalThis.effekseer;
-    }
-    if (!effekseerApi) return; // silently skip when unavailable
-    await new Promise((resolve, reject) => {
-      effekseerApi.initRuntime('/effekseer.wasm', resolve, reject);
-    });
-    context = effekseerApi.createContext();
-    // Create a WebGL context from the canvas
-    const gl =
-      canvas.getContext('webgl2', { alpha: true, premultipliedAlpha: true }) ||
-      canvas.getContext('webgl', { alpha: true, premultipliedAlpha: true }) ||
-      canvas.getContext('experimental-webgl');
-    if (!gl) throw new Error('WebGL not supported');
-    context.init(gl);
-    loop();
+  async function ensureContext() {
+    if (!mounted || !enabled || !canvas) return null;
+    if (context) return context;
+    if (initializing) return initializing;
+
+    initializing = (async () => {
+      try {
+        if (!effekseerApi) {
+          const mod = await import('@zaniar/effekseer-webgl-wasm/effekseer.min.js');
+          effekseerApi = mod?.default || mod?.effekseer || globalThis.effekseer;
+        }
+        if (!effekseerApi) return null;
+
+        await new Promise((resolve, reject) => {
+          effekseerApi.initRuntime('/effekseer.wasm', resolve, reject);
+        });
+
+        if (!enabled || !mounted) return null;
+
+        const instance = effekseerApi.createContext();
+        const gl =
+          canvas.getContext('webgl2', { alpha: true, premultipliedAlpha: true }) ||
+          canvas.getContext('webgl', { alpha: true, premultipliedAlpha: true }) ||
+          canvas.getContext('experimental-webgl');
+
+        if (!gl) {
+          instance?.release?.();
+          return null;
+        }
+
+        if (!enabled || !mounted) {
+          instance?.release?.();
+          return null;
+        }
+
+        instance.init(gl);
+        context = instance;
+        loop();
+        return context;
+      } catch {
+        return null;
+      } finally {
+        initializing = null;
+      }
+    })();
+
+    return initializing;
   }
 
   function loop() {
-    if (context) {
-      context.update();
-      context.draw();
+    if (context && enabled) {
+      try {
+        context.update();
+        context.draw();
+      } catch {
+        // ignore draw failures so the loop can continue
+      }
+      frame = requestAnimationFrame(loop);
+    } else {
+      frame = null;
     }
-    frame = requestAnimationFrame(loop);
+  }
+
+  function stopLoop() {
+    if (frame) {
+      cancelAnimationFrame(frame);
+      frame = null;
+    }
+  }
+
+  function teardown() {
+    stopLoop();
+    try { context?.stopAll?.(); } catch {}
+    try { context?.release?.(); } catch {}
+    context = null;
+    loaded.clear();
   }
 
   async function playEffect(name) {
-    if (!EFFEKSEER_ENABLED || !context || !name) return;
+    if (!enabled || !name) return;
+    const ctx = await ensureContext();
+    if (!enabled || !ctx) return;
+
     let effect = loaded.get(name);
     if (!effect) {
-      const url = new URL(`../assets/effects/${name}.efkefc`, import.meta.url).href;
-      effect = await new Promise((resolve, reject) => {
-        const e = context.loadEffect(
-          url,
-          1.0,
-          () => resolve(e),
-          () => reject(new Error('load failed'))
-        );
-      });
-      loaded.set(name, effect);
+      try {
+        const url = new URL(`../assets/effects/${name}.efkefc`, import.meta.url).href;
+        effect = await new Promise((resolve, reject) => {
+          const e = ctx.loadEffect(
+            url,
+            1.0,
+            () => resolve(e),
+            () => reject(new Error('load failed'))
+          );
+        });
+        loaded.set(name, effect);
+      } catch {
+        return;
+      }
     }
-    context.play(effect);
+
+    try {
+      ctx.play(effect);
+    } catch {
+      // ignore playback failures
+    }
   }
 
-  $: if (cue) playEffect(cue);
+  onMount(() => {
+    mounted = true;
+    if (enabled) ensureContext();
+    return () => {
+      mounted = false;
+      teardown();
+    };
+  });
 
-  onMount(init);
-  onDestroy(() => cancelAnimationFrame(frame));
+  onDestroy(() => {
+    mounted = false;
+    teardown();
+  });
+
+  $: if (mounted && enabled) {
+    ensureContext();
+  }
+
+  $: if (!enabled) {
+    teardown();
+  }
+
+  $: if (cue) {
+    playEffect(cue);
+  }
 </script>
 
 <canvas bind:this={canvas} class="effect-layer"></canvas>

--- a/frontend/src/lib/systems/settingsStorage.js
+++ b/frontend/src/lib/systems/settingsStorage.js
@@ -49,7 +49,8 @@ function getDefaultSettings() {
       disableFloatingDamage: false,
       disablePortraitGlows: false,
       simplifyOverlayTransitions: false,
-      disableStarStorm: false
+      disableStarStorm: false,
+      enableBattleFx: false
     },
     // Legacy settings for backward compatibility
     framerate: 60,
@@ -79,11 +80,16 @@ function migrateSettings(data) {
         ...data,
         version: SETTINGS_VERSION
       };
-      
+
+      migrated.motion = {
+        ...defaults.motion,
+        ...(data.motion || {})
+      };
+
       // If we had an old reducedMotion setting, migrate it to the new structure
       if (data.reducedMotion !== undefined) {
         migrated.motion = {
-          ...defaults.motion,
+          ...migrated.motion,
           globalReducedMotion: Boolean(data.reducedMotion),
           // When old reducedMotion was enabled, enable most motion reduction options
           disableFloatingDamage: Boolean(data.reducedMotion),
@@ -143,9 +149,10 @@ export function loadSettings() {
     // Ensure motion settings exist
     const defaults = getDefaultSettings();
 
-    if (!data.motion) {
-      data.motion = defaults.motion;
-    }
+    data.motion = {
+      ...defaults.motion,
+      ...(data.motion || {})
+    };
 
     // Ensure theme settings exist
     if (!data.theme) {

--- a/frontend/tests/granular-motion-integration.test.js
+++ b/frontend/tests/granular-motion-integration.test.js
@@ -1,4 +1,4 @@
-import { describe, expect, test, beforeEach } from 'bun:test';
+import { describe, expect, test, beforeEach, afterEach } from 'bun:test';
 import { readFileSync } from 'fs';
 import { join } from 'path';
 
@@ -6,8 +6,10 @@ describe('Granular motion integration fixes', () => {
   const gameViewportFile = join(import.meta.dir, '../src/lib/components/GameViewport.svelte');
   const uiSettingsFile = join(import.meta.dir, '../src/lib/components/UISettings.svelte');
   const battleViewFile = join(import.meta.dir, '../src/lib/components/BattleView.svelte');
+  const battleEffectsFile = join(import.meta.dir, '../src/lib/effects/BattleEffects.svelte');
   const battleFighterCardFile = join(import.meta.dir, '../src/lib/battle/BattleFighterCard.svelte');
   const overlayHostFile = join(import.meta.dir, '../src/lib/components/OverlayHost.svelte');
+  const settingsStorageModuleUrl = new URL('../src/lib/systems/settingsStorage.js', import.meta.url).href;
 
   test('GameViewport uses themeStore for reactive theme changes', () => {
     const content = readFileSync(gameViewportFile, 'utf8');
@@ -24,11 +26,29 @@ describe('Granular motion integration fixes', () => {
     expect(content).toContain('themeSettings.backgroundBehavior === \'custom\'');
   });
 
+  test('UISettings exposes battle FX toggle', () => {
+    const content = readFileSync(uiSettingsFile, 'utf8');
+    expect(content).toContain('Enable RPG Maker FX');
+    expect(content).toContain('motionSettings.enableBattleFx');
+    expect(content).toContain('updateMotion({ enableBattleFx: e.target.checked })');
+  });
+
   test('BattleView uses granular motion settings', () => {
     const content = readFileSync(battleViewFile, 'utf8');
     expect(content).toContain('import { motionStore }');
     expect(content).toContain('effectiveReducedMotion');
     expect(content).toContain('motionSettings = $motionStore');
+    expect(content).toContain('battleFxEnabled');
+    expect(content).toContain('battleFxActive = battleFxEnabled && !effectiveReducedMotion');
+    expect(content).toContain('!battleFxEnabled');
+    expect(content).toContain('<BattleEffects cue={effectCue} enabled={battleFxActive} />');
+  });
+
+  test('BattleEffects component respects enabled flag', () => {
+    const content = readFileSync(battleEffectsFile, 'utf8');
+    expect(content).toContain('export let enabled = false');
+    expect(content).toContain('if (!enabled || !name) return');
+    expect(content).toContain('if (!mounted || !enabled || !canvas) return null');
   });
 
   test('BattleFighterCard respects portrait glow settings', () => {
@@ -43,5 +63,50 @@ describe('Granular motion integration fixes', () => {
     expect(content).toContain('simplifiedTransitions');
     expect(content).toContain('effectiveReducedMotion');
     expect(content).toContain('motionStore');
+  });
+
+  describe('Battle FX preference persistence', () => {
+    const SETTINGS_KEY = 'autofighter_settings';
+    let settingsModule;
+    let storageBacking;
+
+    beforeEach(async () => {
+      storageBacking = new Map();
+      globalThis.window = {
+        matchMedia: () => ({
+          matches: false,
+          addEventListener: () => {},
+          removeEventListener: () => {}
+        })
+      };
+      globalThis.localStorage = {
+        getItem: (key) => (storageBacking.has(key) ? storageBacking.get(key) : null),
+        setItem: (key, value) => storageBacking.set(key, String(value)),
+        removeItem: (key) => storageBacking.delete(key),
+        clear: () => storageBacking.clear()
+      };
+
+      settingsModule = await import(`${settingsStorageModuleUrl}?t=${Date.now()}`);
+      settingsModule.clearSettings();
+      settingsModule.motionStore.set(null);
+      settingsModule.themeStore.set(null);
+    });
+
+    afterEach(() => {
+      delete globalThis.localStorage;
+      delete globalThis.window;
+    });
+
+    test('enableBattleFx defaults off and persists when toggled', () => {
+      const initial = settingsModule.loadSettings();
+      expect(initial.motion.enableBattleFx).toBe(false);
+
+      settingsModule.updateMotionSettings({ enableBattleFx: true });
+      const stored = JSON.parse(globalThis.localStorage.getItem(SETTINGS_KEY));
+      expect(stored.motion.enableBattleFx).toBe(true);
+
+      const reloaded = settingsModule.loadSettings();
+      expect(reloaded.motion.enableBattleFx).toBe(true);
+    });
   });
 });


### PR DESCRIPTION
## Summary
- extend settings storage with an `enableBattleFx` flag and keep migration/default helpers in sync
- surface an "Enable RPG Maker FX" motion toggle and gate BattleView effects on both reduced motion and the new preference
- drive BattleEffects through an `enabled` prop, document the control, and add persistence coverage to the motion integration test suite

## Testing
- bun run lint
- bun test tests/granular-motion-integration.test.js

------
https://chatgpt.com/codex/tasks/task_b_68e2d9ddadfc832c9783a5afba368462