### PR TITLE
Cap room override quotas to optional slot capacity

### DIFF
--- a/backend/autofighter/mapgen.py
+++ b/backend/autofighter/mapgen.py
@@ -187,14 +187,20 @@ class MapGenerator:
                 suppressed.update({"shop", "rest"})
 
         quotas: dict[str, int] = {}
+        remaining_optional_slots = middle
 
         def _apply_quota(room_type: str, default: int | None = None) -> None:
+            nonlocal remaining_optional_slots
             if room_type in suppressed:
                 return
             quota_value = self._room_quota(room_type, default)
             if quota_value is None or quota_value <= 0:
                 return
-            quotas[room_type] = int(quota_value)
+            allowed = min(int(quota_value), remaining_optional_slots)
+            if allowed <= 0:
+                return
+            quotas[room_type] = allowed
+            remaining_optional_slots -= allowed
 
         _apply_quota("shop", default=1)
         _apply_quota("rest")


### PR DESCRIPTION
## Summary
- cap room override quotas to the available optional slots so generated floors do not exceed ten rooms

## Testing
- `uv run pytest tests/test_mapgen.py tests/test_run_configuration_context.py` *(fails: file or directory not found)*

------
https://chatgpt.com/codex/tasks/task_b_68e2e4872b6c832cae28b3d80dff2060