### PR TITLE
[FIX] Reapply player stat modifiers on run load

### DIFF
--- a/backend/.codex/implementation/run-configuration-metadata.md
+++ b/backend/.codex/implementation/run-configuration-metadata.md
@@ -56,6 +56,14 @@ stat penalties without re-validating the metadata payload. The context is
 persisted alongside the map state and stamped onto generated nodes via a
 metadata hash for analytics.
 
+The `apply_player_modifier_context` helper keeps player stats aligned with the
+stored configuration. `start_run` uses it immediately after validation so the
+new party reflects any character penalties before the first map is generated,
+and `runs.party_manager.load_party` invokes the same helper when rehydrating a
+run. This prevents stat penalties from disappearing on reloads and ensures
+telemetry derived from reloaded parties matches the preview calculations in the
+setup wizard.
+
 Run type definitions may also include `room_overrides` metadata. The
 `get_room_overrides` helper normalises these directives so `MapGenerator` can
 consistently disable or duplicate optional rooms (e.g., Boss Rush removes shops

--- a/backend/runs/party_manager.py
+++ b/backend/runs/party_manager.py
@@ -16,6 +16,7 @@ from plugins import characters as player_plugins
 from plugins.characters._base import PlayerBase
 from plugins.damage_types import load_damage_type
 from services.run_configuration import RunModifierContext
+from services.run_configuration import apply_player_modifier_context
 
 from .encryption import get_save_manager
 
@@ -313,6 +314,8 @@ def load_party(run_id: str) -> Party:
     except Exception:
         log.exception("Failed to resolve daily RDR bonus; falling back to base value")
         daily_bonus = 0.0
+
+    apply_player_modifier_context(members, hydrated_context or raw_modifier_context)
 
     party = Party(
         members=members,

--- a/backend/tests/test_party_persistence.py
+++ b/backend/tests/test_party_persistence.py
@@ -1,5 +1,10 @@
 import pytest
-from test_app import app_with_db as _app_with_db  # reuse fixture  # noqa: F401
+from plugins.characters import player as player_module
+from runs.party_manager import load_party
+from services.run_configuration import build_run_modifier_context
+from services.run_configuration import validate_run_configuration
+from services.user_level_service import get_user_level
+from test_app import app_with_db  # noqa: F401
 
 
 @pytest.mark.asyncio
@@ -20,3 +25,36 @@ async def test_party_save_and_validation(app_with_db):
     assert bad.status_code == 400
     bad_data = await bad.get_json()
     assert bad_data['error'] == 'unowned character'
+
+
+@pytest.mark.asyncio
+async def test_load_party_applies_run_modifier_context(app_with_db):
+    app, _ = app_with_db
+    client = app.test_client()
+
+    stacks = 5
+    start_resp = await client.post(
+        '/run/start',
+        json={'party': ['player'], 'modifiers': {'character_stat_down': stacks}},
+    )
+    payload = await start_resp.get_json()
+    run_id = payload['run_id']
+
+    party = load_party(run_id)
+    loaded_player = next(member for member in party.members if member.id == 'player')
+
+    baseline_player = player_module.Player()
+    selection = validate_run_configuration(
+        run_type='standard',
+        modifiers={'character_stat_down': stacks},
+    )
+    context = build_run_modifier_context(selection.snapshot)
+    multiplier = context.player_stat_multiplier
+    user_level = get_user_level()
+    user_level_multiplier = 1.0 + float(user_level) * 0.01
+
+    expected_hp = int(round(baseline_player.get_base_stat('max_hp') * user_level_multiplier * multiplier))
+    expected_atk = int(round(baseline_player.get_base_stat('atk') * user_level_multiplier * multiplier))
+
+    assert loaded_player.get_base_stat('max_hp') == expected_hp
+    assert loaded_player.get_base_stat('atk') == expected_atk


### PR DESCRIPTION
## Summary
- add an apply_player_modifier_context helper to keep player stats aligned with run configuration snapshots
- reuse the helper during run startup and party reload to persist stat penalties
- document the helper and add regression tests for modifier scaling and load-party integration

## Testing
- uv run pytest tests/test_run_configuration_context.py tests/test_party_persistence.py -k load_party_applies_run_modifier_context

------
https://chatgpt.com/codex/tasks/task_b_68e2e6f93a50832cbdd5878a81a3a519