### PR TITLE
Prevent duplicate battle FX enqueues

### DIFF
--- a/frontend/src/lib/components/BattleView.svelte
+++ b/frontend/src/lib/components/BattleView.svelte
@@ -424,11 +424,19 @@
   }
   
   let effectCue = '';
+  let pendingEffect = null;
   function queueEffect(name) {
     if (!name || effectiveReducedMotion || !battleFxEnabled) return;
+    if (name === effectCue || name === pendingEffect) return;
+
+    pendingEffect = name;
     effectCue = name;
+
     tick().then(() => {
-      effectCue = '';
+      if (pendingEffect === name) {
+        pendingEffect = null;
+        effectCue = '';
+      }
     });
   }
 

--- a/frontend/tests/battle-effect-queue-guard.vitest.js
+++ b/frontend/tests/battle-effect-queue-guard.vitest.js
@@ -1,0 +1,119 @@
+import { render, screen, cleanup } from '@testing-library/svelte';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { tick } from 'svelte';
+
+import OverlayStub from './__fixtures__/BattleTargetingOverlay.stub.svelte';
+import QueueStub from './__fixtures__/ActionQueue.stub.svelte';
+import FloatersStub from './__fixtures__/BattleEventFloaters.stub.svelte';
+import ProjectileStub from './__fixtures__/BattleProjectileLayer.stub.svelte';
+import EffectsStub from './__fixtures__/BattleEffects.stub.svelte';
+import FighterCardStub from './__fixtures__/BattleFighterCard.stub.svelte';
+import EnrageIndicatorStub from './__fixtures__/EnrageIndicator.stub.svelte';
+import BattleLogStub from './__fixtures__/BattleLog.stub.svelte';
+import StatusIconsStub from './__fixtures__/StatusIcons.stub.svelte';
+
+vi.mock('$lib', () => ({
+  roomAction: vi.fn(),
+}));
+
+vi.mock('../src/lib/components/BattleTargetingOverlay.svelte', () => ({
+  default: OverlayStub,
+}));
+vi.mock('../src/lib/battle/ActionQueue.svelte', () => ({
+  default: QueueStub,
+}));
+vi.mock('../src/lib/components/BattleEventFloaters.svelte', () => ({
+  default: FloatersStub,
+}));
+vi.mock('../src/lib/components/BattleProjectileLayer.svelte', () => ({
+  default: ProjectileStub,
+}));
+vi.mock('../src/lib/effects/BattleEffects.svelte', () => ({
+  default: EffectsStub,
+}));
+vi.mock('../src/lib/battle/BattleFighterCard.svelte', () => ({
+  default: FighterCardStub,
+}));
+vi.mock('../src/lib/battle/BattleLog.svelte', () => ({
+  default: BattleLogStub,
+}));
+vi.mock('../src/lib/battle/StatusIcons.svelte', () => ({
+  default: StatusIconsStub,
+}));
+vi.mock('../src/lib/battle/EnrageIndicator.svelte', () => ({
+  default: EnrageIndicatorStub,
+}));
+
+import BattleView from '../src/lib/components/BattleView.svelte';
+import { roomAction } from '$lib';
+import { motionStore } from '../src/lib/systems/settingsStorage.js';
+
+async function settle() {
+  await Promise.resolve();
+  await tick();
+  await Promise.resolve();
+}
+
+describe('BattleView effect queue guard', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    motionStore.set({
+      globalReducedMotion: false,
+      disablePortraitGlows: false,
+      simplifyOverlayTransitions: false,
+      enableBattleFx: true,
+    });
+    roomAction.mockReset();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllTimers();
+    vi.clearAllMocks();
+    vi.useRealTimers();
+  });
+
+  it('suppresses duplicate SummonEffect enqueues without silencing playback', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const { component } = render(BattleView, {
+      props: {
+        runId: '',
+        active: false,
+        framerate: 60,
+        showHud: false,
+        showFoes: false,
+      },
+    });
+
+    const state = component.$capture_state?.();
+    expect(state?.queueEffect).toBeTypeOf('function');
+
+    const queueEffect = state.queueEffect;
+    const effectsProbe = screen.getByTestId('effects-probe');
+
+    queueEffect('SummonEffect');
+    queueEffect('SummonEffect');
+    queueEffect('SummonEffect');
+
+    expect(effectsProbe.dataset.cue).toBe('SummonEffect');
+
+    await settle();
+
+    expect(effectsProbe.dataset.cue).toBe('');
+    expect(effectsProbe.dataset.lastCue).toBe('SummonEffect');
+
+    queueEffect('SummonEffect');
+    expect(effectsProbe.dataset.cue).toBe('SummonEffect');
+
+    await settle();
+
+    expect(
+      warnSpy.mock.calls.some(([message]) =>
+        typeof message === 'string' && message.includes('effect_update_depth_exceeded'),
+      ),
+    ).toBe(false);
+
+    warnSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- add a guard in BattleView.svelte so battle FX cues are not re-enqueued while a previous tick is pending
- add a Vitest that calls queueEffect('SummonEffect') several times to assert the guard suppresses duplicate warnings while still toggling playback

## Testing
- [ ] Backend tests
- [ ] Frontend tests (`bunx vitest run battle-effect-queue-guard` fails with @sveltejs/vite-plugin-svelte startup error: "Cannot read properties of undefined (reading 'consumer')")
- [ ] Linting
- [ ] Doc sync updates (README and `.codex/implementation` docs; link tasks below)

## Checklist
- [ ] Linked or updated relevant `.codex/tasks` entries
- [ ] Updated player roster and foe docs if adding or modifying fighters or enemies
- [ ] Referenced `.codex/implementation/ui-animation-guidelines.md` when adding UI animations

------
https://chatgpt.com/codex/tasks/task_b_68e2ef610308832cb56f0800342f0e2b