### PR TITLE
Fix lightstream sword fallback pooling

### DIFF
--- a/frontend/tests/assetloader.test.js
+++ b/frontend/tests/assetloader.test.js
@@ -9,6 +9,7 @@ if (typeof import.meta.glob !== 'function') {
     getElementColor,
     getElementIcon,
     getDotImage,
+    getLightstreamSwordArt,
     registerAssetManifest
   } = await import('../src/lib/systems/assetLoader.js');
 
@@ -83,6 +84,14 @@ if (typeof import.meta.glob !== 'function') {
     test('resolves dot icon from effect object', () => {
       const icon = getDotImage({ id: 'burning' });
       expect(icon).toBeTruthy();
+    });
+
+    test('falls back to pooled lightstream sword art when element is unknown', () => {
+      const art = getLightstreamSwordArt('plasma');
+      expect(typeof art).toBe('string');
+      expect(art).toBeTruthy();
+      expect(art.includes('lightstreamswords')).toBe(true);
+      expect(art.includes('midoriai-logo')).toBe(false);
     });
   });
 }


### PR DESCRIPTION
## Summary
- pool lightstream sword assets into a generic fallback so unknown elements still pick real sword art
- treat the Midori logo fallback as no art so lightstream overlays are skipped when no sword is available
- extend the asset loader test suite to cover unknown lightstream sword elements resolving to bundled art

## Testing
- ./run-tests.sh *(fails: numerous existing backend test failures)*
- bun run lint
- bun test tests/assetloader.test.js

------
https://chatgpt.com/codex/tasks/task_b_68e2ef3ff7f4832c9b6cdb6509db3088