### PR TITLE
[FIX] Refresh run chooser reward preview on metadata changes

### DIFF
--- a/frontend/src/lib/components/RunChooser.svelte
+++ b/frontend/src/lib/components/RunChooser.svelte
@@ -90,7 +90,7 @@
     };
   });
   $: pressureValue = sanitizeStack('pressure', modifierValues.pressure);
-  $: rewardPreview = computeRewardPreview(modifierValues);
+  $: rewardPreview = computeRewardPreview(modifierValues, modifiers);
   $: stepTitle = deriveStepTitle(step);
   $: resumeDisabled = resumeIndex < 0 || resumeIndex >= normalizedRuns.length;
   $: partySummary = partySelection.slice(0, 5);
@@ -359,7 +359,7 @@
       }
       seen.add(fingerprint);
       const stacks = buildPresetStackSummary(normalized);
-      const reward = computeRewardPreview(normalized);
+      const reward = computeRewardPreview(normalized, modifiers);
       const metadataSignature = normalizeMetadataHash(
         entry?.metadataSignature ?? entry?.metadataVersion
       );
@@ -1067,15 +1067,17 @@
     dispatch('cancel');
   }
 
-  function computeRewardPreview(values) {
+  function computeRewardPreview(values, availableModifiers = modifiers) {
     const result = {
       foe_bonus: 0,
       player_bonus: 0,
       exp_bonus: 0,
       rdr_bonus: 0
     };
-    if (!modifiers.length) return result;
-    for (const entry of modifiers) {
+    if (!Array.isArray(availableModifiers) || availableModifiers.length === 0) {
+      return result;
+    }
+    for (const entry of availableModifiers) {
       const stacks = sanitizeStack(entry.id, values[entry.id]);
       const contribution = computeModifierRewardContribution(entry, stacks);
       result.foe_bonus += contribution.foe_bonus;


### PR DESCRIPTION
## Summary
- ensure RunChooser recomputes reward previews when modifier metadata refreshes by threading the active list into computeRewardPreview
- refresh quick start preset previews to use the provided modifiers for consistency with live metadata
- add a regression test that simulates a metadata refresh with updated reward bonuses and verifies the preview updates without modifier input changes

## Testing
- [ ] Backend tests
- [ ] Frontend tests
- [ ] Linting
- [ ] Doc sync updates (README and `.codex/implementation` docs; link tasks below)

Attempted `bun x vitest run tests/run-wizard-flow.vitest.js` (fails with Svelte vite-plugin consumer error in this environment).


------
https://chatgpt.com/codex/tasks/task_b_68e2f7bb0384832ca83f85af156fe19f