### PR TITLE
Fix uncapped modifier stack sanitization and add regression coverage

### DIFF
--- a/frontend/src/lib/components/RunChooser.svelte
+++ b/frontend/src/lib/components/RunChooser.svelte
@@ -883,7 +883,16 @@
     }
     const stacking = definition.stacking || {};
     const minimum = Number.isFinite(Number(stacking.minimum)) ? Number(stacking.minimum) : 0;
-    const maximum = Number.isFinite(Number(stacking.maximum)) ? Number(stacking.maximum) : null;
+    let maximum = null;
+    if (typeof stacking.maximum === 'number' && Number.isFinite(stacking.maximum)) {
+      maximum = stacking.maximum;
+    } else if (
+      stacking.maximum !== null &&
+      stacking.maximum !== undefined &&
+      Number.isFinite(Number(stacking.maximum))
+    ) {
+      maximum = Number(stacking.maximum);
+    }
     const step = Number.isFinite(Number(stacking.step)) && Number(stacking.step) > 0 ? Number(stacking.step) : 1;
     let value = Number(rawValue);
     if (!Number.isFinite(value)) {

--- a/frontend/tests/run-wizard-flow.vitest.js
+++ b/frontend/tests/run-wizard-flow.vitest.js
@@ -91,7 +91,7 @@ const BASE_METADATA = {
       label: 'Enemy Buff',
       category: 'foe',
       description: 'Improve foe stats',
-      stacking: { minimum: 0, step: 1, default: 0 },
+      stacking: { minimum: 0, maximum: null, step: 1, default: 0 },
       grants_reward_bonus: true,
       reward_bonuses: {
         exp_bonus_per_stack: 0.5,
@@ -133,6 +133,23 @@ const BASE_METADATA = {
   ],
   pressure: { tooltip: 'Pressure influences encounter difficulty.' }
 };
+
+function readRewardValue(label) {
+  const headings = screen.queryAllByText('Reward Preview');
+  for (const heading of headings) {
+    const container = heading.closest('section') ?? heading.closest('.reward-preview');
+    if (!container) continue;
+    const rows = Array.from(container.querySelectorAll('.preview-grid > div'));
+    for (const row of rows) {
+      const labelNode = row.querySelector('.preview-label');
+      if (labelNode?.textContent?.trim() === label) {
+        const valueNode = row.querySelector('.preview-value');
+        return valueNode?.textContent?.trim() ?? null;
+      }
+    }
+  }
+  return null;
+}
 
 describe('RunChooser wizard flow', () => {
   beforeEach(() => {
@@ -204,6 +221,8 @@ describe('RunChooser wizard flow', () => {
     expect(screen.getByRole('heading', { name: 'Review & Start' })).toBeTruthy();
     expect(screen.getByText('Pressure: 7')).toBeTruthy();
     expect(screen.getByText('Enemy Buff: 3')).toBeTruthy();
+    expect(readRewardValue('RDR Bonus')).toBe('+150%');
+    expect(readRewardValue('EXP Bonus')).toBe('+150%');
 
     const startButton = screen.getByRole('button', { name: 'Start Run' });
     await fireEvent.click(startButton);
@@ -296,19 +315,6 @@ describe('RunChooser wizard flow', () => {
     const goToModifiers = screen.getByRole('button', { name: 'Next' });
     await fireEvent.click(goToModifiers);
     await tick();
-
-    const readRewardValue = (label) => {
-      const rewardSection = screen.getByText('Reward Preview').closest('.reward-preview');
-      if (!rewardSection) return null;
-      const rows = Array.from(rewardSection.querySelectorAll('.preview-grid > div'));
-      for (const row of rows) {
-        const labelNode = row.querySelector('.preview-label');
-        if (labelNode?.textContent?.trim() === label) {
-          return row.querySelector('.preview-value')?.textContent?.trim();
-        }
-      }
-      return null;
-    };
 
     expect(readRewardValue('RDR Bonus')).toBe('+100%');
     expect(readRewardValue('EXP Bonus')).toBe('+100%');

--- a/frontend/vitest.config.js
+++ b/frontend/vitest.config.js
@@ -24,11 +24,22 @@ const vitestEnvironmentShim = {
     resolvedEnvironments = environments;
   },
   configureServer(server) {
-    if (!server || server.environments) {
+    if (!server) {
       return;
     }
 
-    if (resolvedEnvironments) {
+    if (!resolvedEnvironments) {
+      resolvedEnvironments = {
+        client: {
+          config: {
+            consumer: 'client',
+            assetsInclude: () => false
+          }
+        }
+      };
+    }
+
+    if (!server.environments) {
       server.environments = resolvedEnvironments;
     }
   }


### PR DESCRIPTION
## Summary
- keep uncapped modifier stacking.maximum values as null when sanitizing stack values
- extend the run wizard regression test to cover uncapped modifiers and validate reward preview output
- harden the Vitest environment shim with a default client environment when none has been resolved yet

## Testing
- [ ] Backend tests
- [ ] Frontend tests
- [ ] Linting
- [ ] Doc sync updates (README and `.codex/implementation` docs; link tasks below)

### Additional Testing
- bunx vitest run tests/run-wizard-flow.vitest.js *(fails: vite import-analysis cannot parse Svelte source without plugin support in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68e410980f94832c84d8d550484edda8