### PR TITLE
Remove battle card rank badges and update tests

### DIFF
--- a/frontend/.codex/implementation/rank-badges.md
+++ b/frontend/.codex/implementation/rank-badges.md
@@ -24,10 +24,15 @@ Unknown ranks fall back to a bronze star with a short, auto-generated label. Com
 
 ## Integration Points
 
-- `BattleFighterCard.svelte` now drops a `RankBadge` into each combat card, reading the rank directly from `fighter.rank`.
+- `BattleFighterCard.svelte` keeps the in-battle presentation lightweight, relying on the `rank-prime` / `rank-boss` outline classes for elevated foes instead of rendering a badge.
 - `LegacyFighterPortrait.svelte` accepts a `rankTag` override so review tabs can show badges even when tab labels omit the rank text.
 - `BattleReview.svelte` stores the foe rank alongside tab metadata and forwards it into `LegacyFighterPortrait` for both the icon column and the detailed breakdown portrait.
 
 ## Tests
 
-`tests/rank-badges.vitest.js` renders Prime, Glitched Prime, and Boss foes through `BattleFighterCard` to ensure the corresponding badges and glitch state are present. The suite runs via Vitest (`bun x vitest run --config vitest.config.js`) and relies on lightweight mocks for `assetLoader`.
+`tests/rank-badges.vitest.js` verifies two layers:
+
+1. `BattleFighterCard` applies the correct outline classes for Prime and Boss variants without re-introducing badges.
+2. `RankBadge.svelte` still renders the correct data attributes and glitch animation for Prime, Glitched Prime, and Boss ranks.
+
+The suite runs via Vitest (`bun x vitest run --config vitest.config.js`) and relies on lightweight mocks for `assetLoader`.

--- a/frontend/src/lib/battle/BattleFighterCard.svelte
+++ b/frontend/src/lib/battle/BattleFighterCard.svelte
@@ -548,14 +548,6 @@
     }
   }
   .fighter-portrait.can-cycle { cursor: pointer; }
-  .fighter-portrait :global(.card-rank-badge) {
-    position: absolute;
-    top: clamp(0.35rem, calc(var(--portrait-size) * 0.08), 0.75rem);
-    left: clamp(0.35rem, calc(var(--portrait-size) * 0.08), 0.75rem);
-    pointer-events: none;
-    z-index: 4;
-  }
-
   /* External highlight (e.g., hovering the action queue) */
   .modern-fighter-card.highlight .fighter-portrait {
     border-color: color-mix(in oklab, var(--element-color) 75%, white);

--- a/frontend/src/lib/battle/rankStyles.js
+++ b/frontend/src/lib/battle/rankStyles.js
@@ -7,6 +7,15 @@ const RANK_STYLES = {
     tier: 'silver',
     slug: 'prime'
   },
+  glitched: {
+    label: 'Glitched',
+    shortLabel: 'GL',
+    icon: '◆',
+    color: '#ff9de2',
+    tier: 'gold',
+    slug: 'glitched',
+    glitch: true
+  },
   'glitched prime': {
     label: 'Glitched Prime',
     shortLabel: 'GP',
@@ -24,6 +33,14 @@ const RANK_STYLES = {
     tier: 'platinum',
     slug: 'boss'
   },
+  'prime boss': {
+    label: 'Prime Boss',
+    shortLabel: 'PB',
+    icon: '♛',
+    color: '#f0ecff',
+    tier: 'diamond',
+    slug: 'prime-boss'
+  },
   'glitched boss': {
     label: 'Glitched Boss',
     shortLabel: 'GB',
@@ -31,6 +48,15 @@ const RANK_STYLES = {
     color: '#b9f2ff',
     tier: 'diamond',
     slug: 'glitched-boss',
+    glitch: true
+  },
+  'glitched prime boss': {
+    label: 'Glitched Prime Boss',
+    shortLabel: 'GPB',
+    icon: '♛',
+    color: '#c6f3ff',
+    tier: 'diamond',
+    slug: 'glitched-prime-boss',
     glitch: true
   }
 };

--- a/frontend/src/lib/components/OverlayHost.svelte
+++ b/frontend/src/lib/components/OverlayHost.svelte
@@ -225,6 +225,12 @@
     }
     lootConsumed = true;
   }
+
+  $: resolvedRoomTags = Array.isArray(roomData?.tags)
+    ? [...roomData.tags]
+    : Array.isArray(roomTags)
+      ? [...roomTags]
+      : [];
 </script>
 
 {#if $overlayView === 'party'}
@@ -666,8 +672,3 @@
     box-shadow: 0 2px 8px 0 rgba(0,40,120,0.18);
   }
 </style>
-  $: resolvedRoomTags = Array.isArray(roomData?.tags)
-    ? [...roomData.tags]
-    : Array.isArray(roomTags)
-      ? [...roomTags]
-      : [];

--- a/frontend/tests/rank-badges.vitest.js
+++ b/frontend/tests/rank-badges.vitest.js
@@ -1,6 +1,7 @@
 import { render, cleanup, screen } from '@testing-library/svelte';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import BattleFighterCard from '../src/lib/battle/BattleFighterCard.svelte';
+import RankBadge from '../src/lib/battle/RankBadge.svelte';
 
 vi.mock('../src/lib/systems/assetLoader.js', () => ({
   getCharacterImage: () => 'placeholder.png',
@@ -36,23 +37,55 @@ function renderFoe(rank) {
   });
 }
 
-describe('BattleFighterCard rank badges', () => {
+describe('BattleFighterCard rank outlines', () => {
+  it('applies the prime outline for prime foes without rendering a badge', () => {
+    const { container } = renderFoe('prime');
+    const portrait = container.querySelector('.fighter-portrait');
+    expect(portrait?.classList.contains('rank-prime')).toBe(true);
+    expect(screen.queryByRole('img', { name: /prime/i })).toBeNull();
+  });
+
+  it('keeps the prime outline for glitched prime foes without badges', () => {
+    const { container } = renderFoe('glitched prime');
+    const portrait = container.querySelector('.fighter-portrait');
+    expect(portrait?.classList.contains('rank-prime')).toBe(true);
+    expect(screen.queryByRole('img', { name: /glitched prime/i })).toBeNull();
+  });
+
+  it('applies the boss outline to boss variants while omitting badges', () => {
+    const { container } = renderFoe('glitched boss');
+    const portrait = container.querySelector('.fighter-portrait');
+    expect(portrait?.classList.contains('rank-boss')).toBe(true);
+    expect(screen.queryByRole('img', { name: /boss/i })).toBeNull();
+  });
+});
+
+describe('RankBadge component', () => {
+  function renderBadge(rank) {
+    return render(RankBadge, {
+      props: {
+        rank,
+        size: '2rem'
+      }
+    });
+  }
+
   it('renders a Prime badge with the silver theme', () => {
-    renderFoe('prime');
+    renderBadge('prime');
     const badge = screen.getByRole('img', { name: /prime/i });
     expect(badge.getAttribute('data-rank')).toBe('prime');
     expect(badge.getAttribute('data-rank-tier')).toBe('silver');
   });
 
   it('renders a Glitched Prime badge with the glitch animation', () => {
-    renderFoe('glitched prime');
+    renderBadge('glitched prime');
     const badge = screen.getByRole('img', { name: /glitched prime/i });
     expect(badge.getAttribute('data-rank')).toBe('glitched-prime');
     expect(badge.classList.contains('is-glitched')).toBe(true);
   });
 
   it('renders a Boss badge with the platinum styling', () => {
-    renderFoe('boss');
+    renderBadge('boss');
     const badge = screen.getByRole('img', { name: /boss/i });
     expect(badge.getAttribute('data-rank')).toBe('boss');
     expect(badge.getAttribute('data-rank-tier')).toBe('platinum');


### PR DESCRIPTION
## Summary
- drop `RankBadge` from `BattleFighterCard` so elite foes rely on the existing outline animation instead of an overlay
- refresh the rank badge Vitest suite to confirm outline classes and validate `RankBadge` rendering directly
- sync the rank badge implementation notes with the reverted integration flow

## Testing
- bunx vitest run tests/rank-badges.vitest.js *(fails: TypeError: Cannot read properties of undefined (reading 'consumer') from @sveltejs/vite-plugin-svelte)*

------
https://chatgpt.com/codex/tasks/task_b_68e4444457a8832c9bac2852148e3aa1