### PR TITLE
Fix overflow in Stats.apply_damage mitigation loop

### DIFF
--- a/backend/tests/test_apply_damage_overflow_regression.py
+++ b/backend/tests/test_apply_damage_overflow_regression.py
@@ -1,0 +1,36 @@
+import sys
+
+import pytest
+
+from autofighter.stats import Stats
+from autofighter.stats import set_battle_active
+from autofighter.stats import set_enrage_percent
+
+
+@pytest.mark.asyncio
+async def test_apply_damage_extreme_enrage_remains_finite():
+    attacker = Stats()
+    defender = Stats()
+
+    attacker.crit_rate = 0.0
+    attacker.vitality = 1e150
+
+    defender.dodge_odds = 0.0
+    defender.defense = 1
+    defender.mitigation = 0.1
+    defender.vitality = 0.01
+    defender.hp = defender.max_hp
+
+    raw_amount = 1e150
+
+    set_enrage_percent(1e6)
+    set_battle_active(True)
+    try:
+        damage = await defender.apply_damage(raw_amount, attacker=attacker)
+    finally:
+        set_battle_active(False)
+        set_enrage_percent(0.0)
+
+    assert isinstance(damage, int)
+    assert damage >= 1
+    assert damage < sys.float_info.max


### PR DESCRIPTION
## Summary
- clamp the mitigation loop in `Stats.apply_damage` to keep damage calculations finite under extreme inputs
- guard the enrage scaling branch against non-finite results
- add a regression test covering high-enrage attacks against low-defense targets

## Testing
- uv run pytest backend/tests/test_apply_damage_overflow_regression.py

------
https://chatgpt.com/codex/tasks/task_b_68e54e167c60832cbccb76bf2419d122