### PR TITLE
Fix reduced motion handling for glitched fighter cards

### DIFF
--- a/frontend/src/lib/battle/BattleFighterCard.svelte
+++ b/frontend/src/lib/battle/BattleFighterCard.svelte
@@ -433,7 +433,11 @@
     animation: glitch3 0.5s infinite;
   }
 
-  .glitched-card.glitch-reduced .glitch-content,
+  .glitched-card.glitch-reduced .glitch-content {
+    animation: none;
+    opacity: 1;
+  }
+
   .glitched-card.glitch-reduced .glitch-wrapper::before,
   .glitched-card.glitch-reduced .glitch-wrapper::after {
     animation: none;


### PR DESCRIPTION
## Summary
- keep glitched fighter cards visible under reduced motion while disabling animated overlays

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e55d296fc8832c9ed1a649dc205f3c