### PR TITLE
Adjust glitch card animation cycle

### DIFF
--- a/frontend/src/lib/battle/BattleFighterCard.svelte
+++ b/frontend/src/lib/battle/BattleFighterCard.svelte
@@ -524,15 +524,15 @@
   }
 
   .glitched-card:not(.glitch-reduced) .glitch-content {
-    animation: glitch1 0.5s infinite;
+    animation: glitch1 1s infinite;
   }
 
   .glitched-card:not(.glitch-reduced) .glitch-wrapper::before {
-    animation: glitch2 0.5s infinite;
+    animation: glitch2 1s infinite;
   }
 
   .glitched-card:not(.glitch-reduced) .glitch-wrapper::after {
-    animation: glitch3 0.5s infinite;
+    animation: glitch3 1s infinite;
   }
 
   .glitched-card.glitch-reduced .glitch-content {


### PR DESCRIPTION
## Summary
- slow the BattleFighterCard glitch animations from half-second to one-second loops to reduce the visual intensity for glitched ranks

## Testing
- bun run lint

------
https://chatgpt.com/codex/tasks/task_b_68e56602020c832c9b7efc859bf176a2