### PR TITLE
feat: support character-specific ultimate charge requirements

### DIFF
--- a/backend/autofighter/stats.py
+++ b/backend/autofighter/stats.py
@@ -179,6 +179,7 @@ class Stats:
     # Ultimate system
     ultimate_charge: int = 0
     ultimate_ready: bool = False
+    ultimate_charge_capacity: int = 15
 
     # Overheal system (for shields from relics/cards)
     overheal_enabled: bool = field(default=False, init=False)
@@ -671,12 +672,28 @@ class Stats:
                 # If no event loop is running, skip passive triggers
                 pass
 
+    @property
+    def ultimate_charge_max(self) -> int:
+        """Return the amount of charge required to ready the ultimate."""
+
+        try:
+            raw = getattr(self, "ultimate_charge_capacity", 15)
+            value = int(raw)
+        except Exception:
+            value = 15
+        return max(1, value)
+
     def add_ultimate_charge(self, amount: int = 1) -> None:
-        """Increase ultimate charge, capping at 15."""
+        """Increase ultimate charge until the configured maximum."""
         if self.ultimate_ready:
             return
-        self.ultimate_charge = min(15, self.ultimate_charge + amount)
-        if self.ultimate_charge >= 15:
+        try:
+            increment = int(amount)
+        except Exception:
+            increment = 0
+        maximum = self.ultimate_charge_max
+        self.ultimate_charge = min(maximum, self.ultimate_charge + max(0, increment))
+        if self.ultimate_charge >= maximum:
             self.ultimate_ready = True
 
     def handle_ally_action(self, actor: "Stats") -> None:

--- a/backend/plugins/characters/luna.py
+++ b/backend/plugins/characters/luna.py
@@ -181,6 +181,7 @@ class Luna(PlayerBase):
     passives: list[str] = field(default_factory=lambda: ["luna_lunar_reservoir"])
     # UI hint: show numeric actions indicator
     actions_display: str = "number"
+    ultimate_charge_capacity: int = 15_000
     spawn_weight_multiplier: ClassVar[dict[str, float]] = {"non_boss": 5.0}
     music_playlist_weights: ClassVar[dict[str, float]] = {"default": 3.0, "boss": 1.0}
 

--- a/backend/routes/players.py
+++ b/backend/routes/players.py
@@ -87,6 +87,20 @@ async def get_players() -> tuple[str, int, dict[str, str]]:
             else:
                 data[name] = str(value)
 
+        try:
+            raw_cap = getattr(obj, "ultimate_charge_max")
+        except Exception:
+            raw_cap = None
+        if raw_cap is None:
+            try:
+                raw_cap = getattr(obj, "ultimate_charge_capacity")
+            except Exception:
+                raw_cap = None
+        try:
+            data["ultimate_max"] = max(1, int(raw_cap))
+        except Exception:
+            data["ultimate_max"] = 15
+
         # Append in-run (computed) stats so the Party Picker can show live values
         try:
             data["max_hp"] = int(getattr(obj, "max_hp"))

--- a/backend/tests/test_async_bus_stress_with_backend_ping.py
+++ b/backend/tests/test_async_bus_stress_with_backend_ping.py
@@ -35,7 +35,7 @@ async def test_dark_ultimate_async_performance_with_backend_ping():
         member.id = f"dark_party_{i}"
         member._base_atk = 1000
         member.damage_type = Dark()
-        member.ultimate_charge = 15  # Ready to use ultimate
+        member.ultimate_charge = member.ultimate_charge_max  # Ready to use ultimate
         member.ultimate_ready = True
         party_members.append(member)
 

--- a/backend/tests/test_battle_progress_helpers.py
+++ b/backend/tests/test_battle_progress_helpers.py
@@ -139,6 +139,8 @@ async def test_build_battle_progress_payload_includes_snapshots_and_events():
     assert payload["turn"] == 7
     assert payload["party"][0]["id"] == "hero"
     assert payload["foes"][0]["id"] == "foe"
+    assert payload["party"][0]["ultimate_max"] == party_member.ultimate_charge_max
+    assert payload["foes"][0]["ultimate_max"] == foe.ultimate_charge_max
     assert payload["party_summons"]["hero"][0]["instance_id"] == hero_summon.instance_id
     assert payload["foe_summons"]["foe"][0]["instance_id"] == foe_summon.instance_id
     assert payload["recent_events"] == [{"id": "evt"}]

--- a/backend/tests/test_card_rewards.py
+++ b/backend/tests/test_card_rewards.py
@@ -175,7 +175,7 @@ async def test_critical_transfer_moves_stacks():
     await cb_b.apply(b)
     setattr(b, "_critical_boost", cb_b)
     base_atk = a.atk
-    a.add_ultimate_charge(15)
+    a.add_ultimate_charge(a.ultimate_charge_max)
     await a.use_ultimate()
     await asyncio.sleep(0)
     assert getattr(a, "_critical_boost").stacks == 3

--- a/backend/tests/test_fire_ultimate.py
+++ b/backend/tests/test_fire_ultimate.py
@@ -23,7 +23,7 @@ async def test_fire_ultimate_stack_accumulation_and_drain():
     actor._base_defense = 0
     actor.id = "actor"
     actor.hp = actor.max_hp
-    actor.ultimate_charge = 15
+    actor.ultimate_charge = actor.ultimate_charge_max
     actor.ultimate_ready = True
     await actor.use_ultimate()
     assert actor.damage_type._drain_stacks == 1
@@ -33,7 +33,7 @@ async def test_fire_ultimate_stack_accumulation_and_drain():
     expected = actor.max_hp - int(actor.max_hp * 0.05)
     assert actor.hp == expected
 
-    actor.ultimate_charge = 15
+    actor.ultimate_charge = actor.ultimate_charge_max
     actor.ultimate_ready = True
     await actor.use_ultimate()
     assert actor.damage_type._drain_stacks == 2
@@ -51,7 +51,7 @@ async def test_fire_ultimate_resets_on_battle_end():
     actor = Actor(damage_type=Fire())
     actor._base_defense = 0
     actor.id = "actor"
-    actor.ultimate_charge = 15
+    actor.ultimate_charge = actor.ultimate_charge_max
     actor.ultimate_ready = True
     await actor.use_ultimate()
     assert actor.damage_type._drain_stacks == 1
@@ -75,7 +75,7 @@ async def test_fire_ultimate_damage_multiplier():
     target.id = "target"
     base = await target.apply_damage(100, attacker)
 
-    attacker.ultimate_charge = 15
+    attacker.ultimate_charge = attacker.ultimate_charge_max
     attacker.ultimate_ready = True
     await attacker.use_ultimate()
 

--- a/backend/tests/test_foe_ultimate_charge.py
+++ b/backend/tests/test_foe_ultimate_charge.py
@@ -30,7 +30,7 @@ async def test_foe_ultimate_charge_consumption():
 
     # Add more charge to reach maximum
     foe.add_ultimate_charge(5)
-    assert foe.ultimate_charge == 15
+    assert foe.ultimate_charge == foe.ultimate_charge_max
     assert foe.ultimate_ready is True
 
     # Use ultimate and verify charge is consumed
@@ -57,11 +57,13 @@ async def test_foe_ultimate_ready_behavior():
     assert foe.ultimate_ready == player.ultimate_ready is False
 
     # Add charge to both
-    foe.add_ultimate_charge(15)
-    player.add_ultimate_charge(15)
+    foe.add_ultimate_charge(foe.ultimate_charge_max)
+    player.add_ultimate_charge(player.ultimate_charge_max)
 
     assert foe.ultimate_ready == player.ultimate_ready is True
-    assert foe.ultimate_charge == player.ultimate_charge == 15
+    assert foe.ultimate_charge == foe.ultimate_charge_max
+    assert player.ultimate_charge == player.ultimate_charge_max
+    assert foe.ultimate_charge == player.ultimate_charge
 
     # Use ultimates for both
     foe_result = await foe.use_ultimate()
@@ -78,7 +80,7 @@ async def test_foe_ultimate_events():
     foe = Stats(damage_type=Generic())
     foe.plugin_type = "foe"
     foe.use_ultimate = FoeBase.use_ultimate.__get__(foe, Stats)
-    foe.add_ultimate_charge(15)
+    foe.add_ultimate_charge(foe.ultimate_charge_max)
 
     # Track events
     events = []

--- a/backend/tests/test_generic_ultimate.py
+++ b/backend/tests/test_generic_ultimate.py
@@ -35,7 +35,7 @@ async def test_generic_ultimate_hits_and_passive_triggers():
     target._base_defense = 0
     target.set_base_stat('dodge_odds', 0)
 
-    actor.ultimate_charge = 15
+    actor.ultimate_charge = actor.ultimate_charge_max
     actor.ultimate_ready = True
 
     hits = {"count": 0}
@@ -72,7 +72,7 @@ async def test_generic_ultimate_foe_targets_opponents():
     player_target.defense = 0
     player_target.set_base_stat("dodge_odds", 0.0)
 
-    foe.ultimate_charge = 15
+    foe.ultimate_charge = foe.ultimate_charge_max
     foe.ultimate_ready = True
 
     allies = [foe, foe_buddy]

--- a/backend/tests/test_ice_ultimate.py
+++ b/backend/tests/test_ice_ultimate.py
@@ -22,7 +22,7 @@ async def test_ice_ultimate_hits_multiple_enemies_without_error():
     actor = Actor(damage_type=Ice())
     actor.id = "ice-actor"
     actor.atk = 300
-    actor.ultimate_charge = 15
+    actor.ultimate_charge = actor.ultimate_charge_max
     actor.ultimate_ready = True
 
     foes: list[Stats] = []

--- a/backend/tests/test_lady_light_radiant_aegis.py
+++ b/backend/tests/test_lady_light_radiant_aegis.py
@@ -65,7 +65,7 @@ async def test_radiant_aegis_dot_cleanse_triggers_on_light_ultimate():
 
     await passive.apply(healer)
 
-    healer.add_ultimate_charge(15)
+    healer.add_ultimate_charge(healer.ultimate_charge_max)
     await healer.damage_type.ultimate(healer, [healer, ally], [])
     await asyncio.sleep(0.05)
 

--- a/backend/tests/test_light_ultimate.py
+++ b/backend/tests/test_light_ultimate.py
@@ -30,7 +30,7 @@ async def test_light_ultimate_heals_and_cleanses():
     ally.effect_manager = EffectManager(ally)
     enemy.effect_manager = EffectManager(enemy)
     ally.effect_manager.add_dot(Bleed(10, 3))
-    actor.add_ultimate_charge(15)
+    actor.add_ultimate_charge(actor.ultimate_charge_max)
     await light.ultimate(actor, [actor, ally], [enemy])
     assert ally.hp == ally.max_hp
     assert not ally.effect_manager.dots
@@ -45,7 +45,7 @@ async def test_light_ultimate_applies_defense_debuff():
     enemy._base_defense = 100
     actor.effect_manager = EffectManager(actor)
     enemy.effect_manager = EffectManager(enemy)
-    actor.add_ultimate_charge(15)
+    actor.add_ultimate_charge(actor.ultimate_charge_max)
     await light.ultimate(actor, [actor], [enemy])
     mods = [m for m in enemy.effect_manager.mods if m.id == "light_ultimate_def_down"]
     assert len(mods) == 1

--- a/backend/tests/test_lightning_ultimate.py
+++ b/backend/tests/test_lightning_ultimate.py
@@ -32,7 +32,7 @@ async def test_lightning_ultimate_applies_random_dots(monkeypatch):
     attacker = Actor()
     attacker._base_atk = 100
     attacker.damage_type = lightning
-    attacker.ultimate_charge = 15
+    attacker.ultimate_charge = attacker.ultimate_charge_max
     attacker.ultimate_ready = True
     target = Stats()
     target.effect_manager = EffectManager(target)
@@ -61,7 +61,7 @@ async def test_lightning_ultimate_aftertaste_stacks(monkeypatch):
     attacker = Actor()
     attacker._base_atk = 100
     attacker.damage_type = lightning
-    attacker.ultimate_charge = 15
+    attacker.ultimate_charge = attacker.ultimate_charge_max
     attacker.ultimate_ready = True
     target = Stats()
     target.effect_manager = EffectManager(target)

--- a/backend/tests/test_party_endpoint.py
+++ b/backend/tests/test_party_endpoint.py
@@ -76,3 +76,15 @@ async def test_party_validation(app_with_db):
         },
     )
     assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_players_endpoint_reports_ultimate_cap(app_with_db):
+    app, _ = app_with_db
+    client = app.test_client()
+
+    resp = await client.get("/players")
+    assert resp.status_code == 200
+    payload = await resp.get_json()
+    luna_entry = next(p for p in payload["players"] if p["id"] == "luna")
+    assert luna_entry["stats"]["ultimate_max"] == 15_000

--- a/backend/tests/test_passive_stacks.py
+++ b/backend/tests/test_passive_stacks.py
@@ -62,7 +62,7 @@ async def test_luna_ultimate_grants_expected_charge():
     luna = LunaActor(hp=1000, damage_type=Generic())
     luna.passives = ["luna_lunar_reservoir"]
     luna._base_atk = 64
-    luna.ultimate_charge = 15
+    luna.ultimate_charge = luna.ultimate_charge_max
     luna.ultimate_ready = True
 
     target = Stats(hp=1000, damage_type=Generic())

--- a/backend/tests/test_relic_effects.py
+++ b/backend/tests/test_relic_effects.py
@@ -383,7 +383,7 @@ async def test_arcane_flask_shields():
     asyncio.set_event_loop(loop)
 
     async def fire():
-        a.add_ultimate_charge(15)
+        a.add_ultimate_charge(a.ultimate_charge_max)
         await a.use_ultimate()
         await asyncio.sleep(0)
 

--- a/backend/tests/test_relic_effects_advanced.py
+++ b/backend/tests/test_relic_effects_advanced.py
@@ -106,7 +106,7 @@ async def test_killer_instinct_grants_extra_turn():
     base_atk = a.atk
     base_spd = a.spd
 
-    a.add_ultimate_charge(15)
+    a.add_ultimate_charge(a.ultimate_charge_max)
     await a.use_ultimate()
     assert a.atk > base_atk
 

--- a/backend/tests/test_ultimate_charge.py
+++ b/backend/tests/test_ultimate_charge.py
@@ -1,33 +1,41 @@
 import pytest
 
+import pytest
+
+from autofighter.rooms.utils import _serialize
 from autofighter.stats import BUS
 from autofighter.stats import Stats
+from autofighter.stats import set_battle_active
 from plugins.damage_types.generic import Generic
 from plugins.damage_types.ice import Ice
+from plugins.damage_types.wind import Wind
 from plugins.characters._base import PlayerBase
+from plugins.characters.luna import Luna
 
 
 def test_charge_accumulates_and_caps():
     player = PlayerBase(damage_type=Generic())
-    for _ in range(20):
+    cap = player.ultimate_charge_max
+    for _ in range(cap + 5):
         player.add_ultimate_charge()
-    assert player.ultimate_charge == 15
+    assert player.ultimate_charge == cap
     assert player.ultimate_ready is True
 
 
 def test_charge_from_multiple_ally_actions():
     actor = PlayerBase(damage_type=Generic())
-    ice = PlayerBase(damage_type=Ice())
-    ice.handle_ally_action(actor)
-    ice.handle_ally_action(actor)
-    assert ice.ultimate_charge == actor.actions_per_turn * 2
+    wind = PlayerBase(damage_type=Wind())
+    wind.handle_ally_action(actor)
+    wind.handle_ally_action(actor)
+    assert wind.ultimate_charge == actor.actions_per_turn * 2
 
 
 @pytest.mark.asyncio
 async def test_ice_ultimate_damage_scaling():
     user = PlayerBase(damage_type=Ice())
+    user.id = "ice_user"
     user._base_atk = 10
-    user.ultimate_charge = 15
+    user.ultimate_charge = user.ultimate_charge_max
     user.ultimate_ready = True
     foe_a = Stats()
     foe_b = Stats()
@@ -36,7 +44,11 @@ async def test_ice_ultimate_damage_scaling():
         foe._base_defense = 1
         foe._base_max_hp = 2000
         foe.hp = foe.max_hp
-    await user.damage_type.ultimate(user, [user], [foe_a, foe_b])
+    set_battle_active(True)
+    try:
+        await user.damage_type.ultimate(user, [user], [foe_a, foe_b])
+    finally:
+        set_battle_active(False)
     assert foe_a.hp == 2000 - 100 * 6
     assert foe_b.hp == 2000 - 169 * 6
 
@@ -44,7 +56,7 @@ async def test_ice_ultimate_damage_scaling():
 @pytest.mark.asyncio
 async def test_use_ultimate_emits_event():
     player = PlayerBase(damage_type=Generic())
-    player.ultimate_charge = 15
+    player.ultimate_charge = player.ultimate_charge_max
     player.ultimate_ready = True
     seen: list[Stats] = []
 
@@ -59,4 +71,17 @@ async def test_use_ultimate_emits_event():
         assert seen == [player]
     finally:
         BUS.unsubscribe("ultimate_used", _handler)
+
+
+def test_luna_uses_custom_ultimate_cap_and_serializes_maximum():
+    luna = Luna()
+    assert luna.ultimate_charge_max == 15_000
+
+    luna.add_ultimate_charge(luna.ultimate_charge_max - 1)
+    assert luna.ultimate_ready is False
+    luna.add_ultimate_charge(1)
+    assert luna.ultimate_ready is True
+
+    payload = _serialize(luna)
+    assert payload["ultimate_max"] == luna.ultimate_charge_max
 

--- a/backend/tests/test_wind_ultimate_dot_transfer.py
+++ b/backend/tests/test_wind_ultimate_dot_transfer.py
@@ -52,7 +52,7 @@ async def test_wind_ultimate_transfers_from_foes():
     await BUS.emit_async("battle_start", foe1)
     await BUS.emit_async("battle_start", foe2)
 
-    player.add_ultimate_charge(15)
+    player.add_ultimate_charge(player.ultimate_charge_max)
     assert await player.use_ultimate()
 
     await BUS.emit_async("hit_landed", player, foe1, 0, "attack")
@@ -101,7 +101,7 @@ async def test_wind_foe_ultimate_transfers_from_allies():
     await BUS.emit_async("battle_start", p1)
     await BUS.emit_async("battle_start", p2)
 
-    foe.add_ultimate_charge(15)
+    foe.add_ultimate_charge(foe.ultimate_charge_max)
     assert await foe.use_ultimate()
 
     await BUS.emit_async("hit_landed", foe, p1, 0, "attack")

--- a/frontend/src/lib/battle/BattleFighterCard.svelte
+++ b/frontend/src/lib/battle/BattleFighterCard.svelte
@@ -169,7 +169,17 @@
     prevElement = fighter.element;
   }
 
-  $: ultRatio = Math.max(0, Math.min(1, Number(fighter?.ultimate_charge || 0) / 15));
+  const DEFAULT_ULT_CAP = 15;
+  $: ultimateMax = Math.max(
+    1,
+    Number(
+      fighter?.ultimate_max ??
+        fighter?.ultimate_charge_capacity ??
+        DEFAULT_ULT_CAP
+    )
+  );
+  $: ultimateCharge = Math.max(0, Number(fighter?.ultimate_charge ?? 0));
+  $: ultRatio = Math.max(0, Math.min(1, ultimateCharge / ultimateMax));
   $: tiltAngle = Math.min(ultRatio, 0.98) / 0.98;
 
   // Randomized, slow pulse timing for the ult icon

--- a/frontend/src/lib/battle/LegacyFighterPortrait.svelte
+++ b/frontend/src/lib/battle/LegacyFighterPortrait.svelte
@@ -41,8 +41,18 @@
   $: hpHue = (hpPct / 100) * 120;
   $: hpColor = `hsl(${hpHue}, 100%, 45%)`;
 
+  const DEFAULT_ULT_CAP = 15;
   $: elColor = getElementColor(fighter.element);
-  $: ultProgress = Math.max(0, Math.min(1, Number(fighter?.ultimate_charge || 0) / 15));
+  $: ultimateMax = Math.max(
+    1,
+    Number(
+      fighter?.ultimate_max ??
+        fighter?.ultimate_charge_capacity ??
+        DEFAULT_ULT_CAP
+    )
+  );
+  $: ultimateCharge = Math.max(0, Number(fighter?.ultimate_charge ?? 0));
+  $: ultProgress = Math.max(0, Math.min(1, ultimateCharge / ultimateMax));
   let lowContrast = false;
   let prevUltReady = false;
   let showUltPulse = false;

--- a/frontend/tests/battle-fighter-card.vitest.js
+++ b/frontend/tests/battle-fighter-card.vitest.js
@@ -47,4 +47,41 @@ describe('BattleFighterCard tick indicators', () => {
     expect(layer).not.toBeNull();
     expect(layer.classList.contains('reduced')).toBe(true);
   });
+
+  it('computes ultimate gauge progress using the provided maximum', () => {
+    const { container } = render(BattleFighterCard, {
+      props: {
+        fighter: {
+          id: 'luna',
+          name: 'Luna',
+          element: 'light',
+          ultimate_charge: 7500,
+          ultimate_max: 15000,
+        },
+        position: 'bottom',
+      },
+    });
+
+    const gauge = container.querySelector('.ult-gauge');
+    expect(gauge).not.toBeNull();
+    expect(gauge.style.getPropertyValue('--p')).toBe('0.5');
+  });
+
+  it('falls back to the legacy cap when no ultimate maximum is provided', () => {
+    const { container } = render(BattleFighterCard, {
+      props: {
+        fighter: {
+          id: 'rookie',
+          name: 'Rookie',
+          element: 'wind',
+          ultimate_charge: 3,
+        },
+        position: 'bottom',
+      },
+    });
+
+    const gauge = container.querySelector('.ult-gauge');
+    expect(gauge).not.toBeNull();
+    expect(gauge.style.getPropertyValue('--p')).toBe('0.2');
+  });
 });

--- a/frontend/tests/legacy-fighter-portrait.vitest.js
+++ b/frontend/tests/legacy-fighter-portrait.vitest.js
@@ -1,0 +1,43 @@
+import { render, cleanup } from '@testing-library/svelte';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import LegacyFighterPortrait from '../src/lib/battle/LegacyFighterPortrait.svelte';
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('LegacyFighterPortrait ultimate ring', () => {
+  it('scales ring progress with the supplied ultimate maximum', () => {
+    const { container } = render(LegacyFighterPortrait, {
+      props: {
+        fighter: {
+          id: 'luna',
+          element: 'light',
+          ultimate_charge: 7500,
+          ultimate_max: 15000
+        }
+      }
+    });
+
+    const fill = container.querySelector('.ultimate-ring .fill');
+    expect(fill).not.toBeNull();
+    expect(fill.getAttribute('style')).toContain('stroke-dasharray: 50');
+  });
+
+  it('uses the legacy fallback when no ultimate maximum is provided', () => {
+    const { container } = render(LegacyFighterPortrait, {
+      props: {
+        fighter: {
+          id: 'rookie',
+          element: 'wind',
+          ultimate_charge: 6
+        }
+      }
+    });
+
+    const fill = container.querySelector('.ultimate-ring .fill');
+    expect(fill).not.toBeNull();
+    expect(fill.getAttribute('style')).toContain('stroke-dasharray: 40');
+  });
+});


### PR DESCRIPTION
## Summary
- allow characters to advertise a custom ultimate charge capacity and surface it through battle/player payloads
- raise Luna's ultimate requirement to 15,000 charge and align backend tests with the configurable cap
- update battle UI components and tests so the ultimate gauge respects the provided maximum and handles larger values

## Testing
- `uv run pytest backend/tests/test_ultimate_charge.py`
- `uv run pytest backend/tests/test_battle_progress_helpers.py`
- `uv run pytest backend/tests/test_party_endpoint.py`
- `bun x vitest run tests/battle-fighter-card.vitest.js tests/legacy-fighter-portrait.vitest.js` *(fails: Svelte Vite plugin expects a hot-update consumer; Vitest server cannot start in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68e5660aef64832c99db981b8eabd7e5