### PR TITLE
fix: guard wind ultimate against new foes

### DIFF
--- a/backend/plugins/damage_types/wind.py
+++ b/backend/plugins/damage_types/wind.py
@@ -114,7 +114,14 @@ class Wind(DamageTypeBase):
             except Exception:
                 pass
             try:
-                effect_managers[foe].maybe_inflict_dot(actor, dmg)
+                f_mgr = effect_managers.get(foe)
+                if f_mgr is None:
+                    f_mgr = getattr(foe, "effect_manager", None)
+                    if f_mgr is None:
+                        f_mgr = EffectManager(foe)
+                        foe.effect_manager = f_mgr
+                    effect_managers[foe] = f_mgr
+                f_mgr.maybe_inflict_dot(actor, dmg)
             except Exception:
                 pass
 


### PR DESCRIPTION
## Summary
- add a reusable `select_aggro_target` helper and wire it into the player turn loop
- rework damage-type ultimates to resample aggro-weighted targets for every hit and refresh the associated tests
- document that Wind now uses aggro-weighted targeting instead of deterministic sweeps
- guard the Wind ultimate's DoT application by resolving effect managers for foes added mid-ultimate

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68e5752a9850832c932ad3c0eb1b7e9d