### PR TITLE
Add Casno character plugin

### DIFF
--- a/.codex/implementation/player-foe-reference.md
+++ b/.codex/implementation/player-foe-reference.md
@@ -49,7 +49,7 @@ first spawn and reuse it for future sessions unless customized.
 | Becca | B | 5★ | Any (randomized) | `becca_menagerie_bond` reorganizes elemental pairings, pushing her attack growth at the cost of lowered defenses. | Standard gacha recruit. |
 | Bubbles | A | 5★ | Any (randomized) | `bubbles_bubble_burst` rotates elements each turn, building chain reactions that detonate after repeated hits. | Standard gacha recruit. |
 | Carly | B | 5★ | Light | `carly_guardians_aegis` heals the most injured ally, converts attack gains into defense, stacks mitigation, and shares shields on her ultimate. | Standard gacha recruit. |
-| Casno | TBD | TBD | TBD | `casno_phoenix_respite` enforces five-action cycles, cancelling the next move to trigger a full-heal Phoenix rest that adds permanent stat boons. | Unreleased roster addition. |
+| Casno | A | 5★ | Fire | `casno_phoenix_respite` enforces five-action cycles, cancelling the next move to trigger a full-heal Phoenix rest that adds permanent stat boons. | Standard gacha recruit. |
 | Graygray | B | 5★ | Any (randomized) | `graygray_counter_maestro` retaliates when struck and periodically releases max-HP bursts after stacking counters. | Standard gacha recruit. |
 | Hilander | A | 5★ | Any (randomized) | `hilander_critical_ferment` builds crit rate and crit damage with diminishing odds after 20 stacks, unleashing Aftertaste on crits. | Standard gacha recruit. |
 | Ixia | A | 5★ | Lightning | `ixia_tiny_titan` quadruples Vitality scaling, turning the small-statured brawler into a lightning bruiser. | Standard gacha recruit. |

--- a/backend/plugins/characters/casno.py
+++ b/backend/plugins/characters/casno.py
@@ -1,0 +1,29 @@
+from dataclasses import dataclass
+from dataclasses import field
+
+from autofighter.character import CharacterType
+from plugins.characters._base import PlayerBase
+from plugins.damage_types import load_damage_type
+from plugins.damage_types._base import DamageTypeBase
+
+
+@dataclass
+class Casno(PlayerBase):
+    """Fire-aligned gacha recruit who thrives on planned downtime."""
+
+    id = "casno"
+    name = "Casno"
+    char_type: CharacterType = CharacterType.A
+    gacha_rarity = 5
+    damage_type: DamageTypeBase = field(default_factory=lambda: load_damage_type("Fire"))
+    passives: list[str] = field(default_factory=lambda: ["casno_phoenix_respite"])
+    about: str = (
+        "A stoic veteran pyrokinetic who has learned to weaponize recovery. "
+        "Casno rotates through five-action battle cycles, deliberately canceling "
+        "his sixth move to enter a phoenix-like rest that restores his strength "
+        "and adds lasting boons before rejoining the fray."
+    )
+    voice_gender = "male"
+
+
+__all__ = ["Casno"]


### PR DESCRIPTION
## Summary
- add a Casno playable plugin with fire alignment, phoenix respite passive hookup, and male voice metadata
- update the roster reference to list Casno's rank, rarity, and element

## Testing
- ./run-tests.sh *(fails: known backend suite issues such as accelerate dependency checks, missing OptionKey.LRM_MODEL, battle logging imports, and snapshot/key errors)*

------
https://chatgpt.com/codex/tasks/task_b_68e57edde8fc832cb9c0fabf5028014a