### PR TITLE
[FIX] Keep Phoenix Respite rest helper active until intercept

### DIFF
--- a/backend/plugins/passives/normal/casno_phoenix_respite.py
+++ b/backend/plugins/passives/normal/casno_phoenix_respite.py
@@ -20,6 +20,13 @@ class _PhoenixRestInterval(HealingOverTime):
 
     owner_id: int = 0
 
+    async def tick(self, target: "Stats", *_: object) -> bool:
+        """Keep the helper active until the intercept completes."""
+
+        if getattr(target, "hp", 0) <= 0:
+            return False
+        return True
+
     async def on_action(self, target: "Stats") -> bool:
         return await CasnoPhoenixRespite._complete_rest(target, self)
 
@@ -78,7 +85,7 @@ class CasnoPhoenixRespite:
         helper_effect = _PhoenixRestInterval(
             name=f"{cls.id}_rest_interval",
             healing=0,
-            turns=1,
+            turns=-1,
             id=helper_id,
             source=target,
             owner_id=entity_id,


### PR DESCRIPTION
## Summary
- add the Casno Phoenix Respite passive that tracks action cadence and schedules restorative turns
- grant full-heal rest interrupts that convert to permanent stat boosts with UI stack accessors
- keep the Phoenix Respite rest helper active until the action intercept fires so restorative turns resolve correctly

## Testing
- [ ] Backend tests (`uv run pytest backend/tests/test_effects.py`) *(fails locally: ModuleNotFoundError: cryptography)*
- [ ] Frontend tests
- [ ] Linting
- [ ] Doc sync updates (README and `.codex/implementation` docs; link tasks below)


------
https://chatgpt.com/codex/tasks/task_b_68e5817508e0832cbf1e99484c7a948d