### PR TITLE
feat: sequential reward drop reveal

### DIFF
--- a/frontend/.codex/implementation/reward-overlay.md
+++ b/frontend/.codex/implementation/reward-overlay.md
@@ -34,6 +34,16 @@ both `aria-label`s and visually hidden text for assistive technologies. Failed
 lookups and network errors fall back to the shared material placeholder via
 `onMaterialIconError` so the overlay never shows broken images.
 
+To emphasise each pickup, the component keeps a `visibleDrops` array separate
+from the aggregated `dropEntries`. When motion reduction is disabled the list
+is populated one entry at a time on a timed interval; each reveal triggers the
+shared `createRewardDropSfx` helper so coins or materials play the reward-drop
+sound at the player's current `sfxVolume`. Reduced-motion mode bypasses the
+timers, shows all icons immediately, and skips the audio so accessibility
+preferences are respected. Pop-in scale transitions mirror the sequential
+animation while guarding against prop changes by clearing timers and audio
+handles whenever the loot payload updates or the overlay unmounts.
+
 Ambient effects from `EnrageIndicator.svelte` continue to render while the
 rewards overlay is shown and fade out gracefully, so the transition from
 combat to rewards remains smooth.

--- a/frontend/src/lib/systems/sfx.js
+++ b/frontend/src/lib/systems/sfx.js
@@ -7,6 +7,13 @@ const DEAL_SFX_KEYS = [
   'kenney_audio/switch22'
 ];
 
+const REWARD_DROP_SFX_KEYS = [
+  'ui/reward/drop',
+  'kenney_audio/handleCoins',
+  'kenney_audio/handleCoins2',
+  'kenney_audio/impactGeneric_light_001'
+];
+
 const coerceOptions = options => (options && typeof options === 'object' ? { ...options } : {});
 
 export function createDealSfx(volumeSteps = 5, options = {}) {
@@ -16,6 +23,27 @@ export function createDealSfx(volumeSteps = 5, options = {}) {
     opts.fallback = true;
   }
   const clip = getSfxClip(DEAL_SFX_KEYS, opts);
+  if (!clip) return null;
+  try {
+    const audio = new Audio(clip);
+    const numericVolume = Number(volumeSteps);
+    const clamped = Number.isFinite(numericVolume)
+      ? Math.max(0, Math.min(10, numericVolume))
+      : 0;
+    audio.volume = clamped / 10;
+    return audio;
+  } catch {
+    return null;
+  }
+}
+
+export function createRewardDropSfx(volumeSteps = 5, options = {}) {
+  if (typeof Audio === 'undefined') return null;
+  const opts = coerceOptions(options);
+  if (opts.fallback === undefined) {
+    opts.fallback = true;
+  }
+  const clip = getSfxClip(REWARD_DROP_SFX_KEYS, opts);
   if (!clip) return null;
   try {
     const audio = new Audio(clip);


### PR DESCRIPTION
## Summary
- reveal loot drops sequentially with pop-in animation and reward-drop audio that respects reduced-motion and volume settings
- add a shared reward-drop SFX helper for coin-style clips and reuse it from the overlay
- document the new sequential reveal and audio behavior for the reward overlay

## Testing
- bun run lint

ready for review

------
https://chatgpt.com/codex/tasks/task_b_68e58a074ed8832c84735f4ea3761cf0