### PR TITLE
feat: centralize sequential sfx playback

### DIFF
--- a/frontend/.codex/implementation/pull-results-overlay.md
+++ b/frontend/.codex/implementation/pull-results-overlay.md
@@ -5,3 +5,11 @@ It accepts a `results` array and uses `CurioChoice.svelte` to render each
 entry. Results are queued and revealed one at a time with a simple slide/fade
 animation. After all items appear a Done button lets the player close the
 overlay.
+
+Audio cues are sourced through `createDealSfx`, a thin wrapper around the
+shared `createSequentialSfxPlayer` helper in `systems/sfx.js`. The helper
+normalizes the `sfxVolume`, clones active audio nodes so overlapping deal
+effects never cut each other off, and resolves clips from the
+`'ui/pull/deal'` alias before falling back to the Kenney book-flip effects.
+The same SFX utility also exposes the `'ui/reward/drop'` alias for loot drops
+so pull and reward overlays share a consistent retry-safe playback path.

--- a/frontend/.codex/implementation/reward-overlay.md
+++ b/frontend/.codex/implementation/reward-overlay.md
@@ -44,6 +44,14 @@ preferences are respected. Pop-in scale transitions mirror the sequential
 animation while guarding against prop changes by clearing timers and audio
 handles whenever the loot payload updates or the overlay unmounts.
 
+`createRewardDropSfx` now wraps the generic `createSequentialSfxPlayer`
+utility, which keeps a cached audio element ready and clones it if another
+playback request arrives mid-sound. The helper clamps volume updates, respects
+`reducedMotion`, and pulls clips from the registry's `'ui/reward/drop'` alias
+before falling back to the Kenney coin and satchel samples. The pull-results
+overlay reuses the same utility through `createDealSfx`, so both overlays share
+identical clone-and-retry behaviour when the user mashes through reward queues.
+
 Ambient effects from `EnrageIndicator.svelte` continue to render while the
 rewards overlay is shown and fade out gracefully, so the transition from
 combat to rewards remains smooth.

--- a/frontend/src/lib/components/PullResultsOverlay.svelte
+++ b/frontend/src/lib/components/PullResultsOverlay.svelte
@@ -77,23 +77,12 @@
   });
 
   function playDeal() {
-    if (reducedMotion || !dealSfx) return;
+    if (reducedMotion || !dealSfx || typeof dealSfx.play !== 'function') return;
+    if (typeof dealSfx.setVolume === 'function') {
+      dealSfx.setVolume(sfxVolume);
+    }
     try {
-      const node = dealSfx.paused ? dealSfx : dealSfx.cloneNode(true);
-      if (node === dealSfx) {
-        dealSfx.currentTime = 0;
-      } else {
-        node.volume = dealSfx.volume;
-      }
-      node
-        .play()
-        .catch((error) => {
-          if (error?.name === 'AbortError') {
-            console.debug('PullResultsOverlay: playback aborted');
-          } else {
-            console.debug('PullResultsOverlay: playback failed', error);
-          }
-        });
+      dealSfx.play();
     } catch {}
   }
 

--- a/frontend/src/lib/components/RewardOverlay.svelte
+++ b/frontend/src/lib/components/RewardOverlay.svelte
@@ -141,7 +141,7 @@
   let visibleDrops = [];
   let dropRevealTimers = [];
   let dropRevealGeneration = 0;
-  let dropSfxHandle = null;
+  let dropSfxPlayer = null;
   let dropPopTransition = null;
 
   $: dropPopTransition = reducedMotion
@@ -157,15 +157,14 @@
   }
 
   function stopDropAudio(release = false) {
-    if (!dropSfxHandle) return;
+    if (!dropSfxPlayer) return;
     try {
-      dropSfxHandle.pause();
-      dropSfxHandle.currentTime = 0;
+      dropSfxPlayer.stop?.();
     } catch {
       // ignore playback reset failures
     }
     if (release) {
-      dropSfxHandle = null;
+      dropSfxPlayer = null;
     }
   }
 
@@ -175,18 +174,14 @@
       stopDropAudio(true);
       return;
     }
-    if (!dropSfxHandle) {
-      dropSfxHandle = createRewardDropSfx(normalizedSfxVolume, { reducedMotion });
+    if (!dropSfxPlayer) {
+      dropSfxPlayer = createRewardDropSfx(normalizedSfxVolume, { reducedMotion });
     }
-    if (!dropSfxHandle) return;
-    const targetVolume = Math.max(0, Math.min(10, normalizedSfxVolume)) / 10;
-    try {
-      dropSfxHandle.volume = targetVolume;
-      dropSfxHandle.currentTime = 0;
-    } catch {
-      // Ignore audio property assignment failures
+    if (!dropSfxPlayer || typeof dropSfxPlayer.play !== 'function') return;
+    if (typeof dropSfxPlayer.setVolume === 'function') {
+      dropSfxPlayer.setVolume(normalizedSfxVolume);
     }
-    const playPromise = dropSfxHandle.play?.();
+    const playPromise = dropSfxPlayer.play();
     if (playPromise && typeof playPromise.catch === 'function') {
       playPromise.catch(() => {});
     }

--- a/frontend/src/lib/systems/assetRegistry.js
+++ b/frontend/src/lib/systems/assetRegistry.js
@@ -596,6 +596,13 @@ registerSfxAlias('ui/pull/deal', [
   'kenney_audio/switch22'
 ]);
 
+registerSfxAlias('ui/reward/drop', [
+  'kenney_audio/handleCoins',
+  'kenney_audio/handleCoins2',
+  'kenney_audio/dropLeather',
+  'kenney_audio/impactGeneric_light_001'
+]);
+
 registerSfxAlias('ui/default', [
   'kenney_audio/click1',
   'kenney_audio/click2',

--- a/frontend/src/lib/systems/sfx.js
+++ b/frontend/src/lib/systems/sfx.js
@@ -11,49 +11,161 @@ const REWARD_DROP_SFX_KEYS = [
   'ui/reward/drop',
   'kenney_audio/handleCoins',
   'kenney_audio/handleCoins2',
+  'kenney_audio/dropLeather',
   'kenney_audio/impactGeneric_light_001'
 ];
 
 const coerceOptions = options => (options && typeof options === 'object' ? { ...options } : {});
 
-export function createDealSfx(volumeSteps = 5, options = {}) {
+const clampVolumeSteps = value => {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) return 0;
+  if (numeric <= 0) return 0;
+  if (numeric >= 10) return 10;
+  return numeric;
+};
+
+const createNoopPlayer = volume => ({
+  play: () => Promise.resolve(false),
+  stop: () => {},
+  setVolume: () => {},
+  getVolume: () => clampVolumeSteps(volume),
+  get element() {
+    return null;
+  }
+});
+
+export function createSequentialSfxPlayer({ keys = [], volume = 5, reducedMotion = false, options = {} } = {}) {
   if (typeof Audio === 'undefined') return null;
+  const normalizedKeys = Array.isArray(keys) ? keys : [keys];
+  const filteredKeys = normalizedKeys.filter(key => typeof key === 'string' && key.length > 0);
+  if (filteredKeys.length === 0) return null;
+
+  if (reducedMotion) {
+    return createNoopPlayer(volume);
+  }
+
   const opts = coerceOptions(options);
   if (opts.fallback === undefined) {
     opts.fallback = true;
   }
-  const clip = getSfxClip(DEAL_SFX_KEYS, opts);
+
+  const clip = getSfxClip(filteredKeys, opts);
   if (!clip) return null;
-  try {
-    const audio = new Audio(clip);
-    const numericVolume = Number(volumeSteps);
-    const clamped = Number.isFinite(numericVolume)
-      ? Math.max(0, Math.min(10, numericVolume))
-      : 0;
-    audio.volume = clamped / 10;
-    return audio;
-  } catch {
-    return null;
-  }
+
+  let steps = clampVolumeSteps(volume);
+  let baseElement = null;
+
+  const ensureBaseElement = () => {
+    if (baseElement) return baseElement;
+    try {
+      baseElement = new Audio(clip);
+      baseElement.volume = steps / 10;
+      return baseElement;
+    } catch {
+      baseElement = null;
+      return null;
+    }
+  };
+
+  const stop = () => {
+    if (!baseElement) return;
+    try {
+      baseElement.pause();
+      baseElement.currentTime = 0;
+    } catch {
+      // ignore failures when resetting audio nodes
+    }
+  };
+
+  const play = () => {
+    const base = ensureBaseElement();
+    if (!base) return Promise.resolve(false);
+    let node = base;
+    if (!base.paused) {
+      try {
+        node = base.cloneNode(true);
+      } catch {
+        node = base;
+      }
+    }
+
+    try {
+      node.volume = steps / 10;
+    } catch {
+      // ignore volume assignment failures on cloned nodes
+    }
+
+    if (node === base) {
+      try {
+        node.currentTime = 0;
+      } catch {
+        // ignore failures while rewinding audio
+      }
+    }
+
+    try {
+      const result = node.play();
+      if (result && typeof result.catch === 'function') {
+        return result.catch(error => {
+          if (error?.name !== 'AbortError') {
+            try {
+              console.debug('[sfx] playback failed', error);
+            } catch {}
+          }
+          return false;
+        });
+      }
+      return Promise.resolve(true);
+    } catch (error) {
+      if (error?.name !== 'AbortError') {
+        try {
+          console.debug('[sfx] playback failed', error);
+        } catch {}
+      }
+      return Promise.resolve(false);
+    }
+  };
+
+  const setVolume = nextSteps => {
+    steps = clampVolumeSteps(nextSteps);
+    if (!baseElement) return;
+    try {
+      baseElement.volume = steps / 10;
+    } catch {
+      // ignore volume assignment failures
+    }
+  };
+
+  return {
+    play,
+    stop,
+    setVolume,
+    getVolume: () => steps,
+    get element() {
+      return ensureBaseElement();
+    }
+  };
+}
+
+export function createDealSfx(volumeSteps = 5, options = {}) {
+  const opts = coerceOptions(options);
+  const { reducedMotion = false, ...rest } = opts;
+  return createSequentialSfxPlayer({
+    keys: DEAL_SFX_KEYS,
+    volume: volumeSteps,
+    reducedMotion,
+    options: rest
+  });
 }
 
 export function createRewardDropSfx(volumeSteps = 5, options = {}) {
-  if (typeof Audio === 'undefined') return null;
   const opts = coerceOptions(options);
-  if (opts.fallback === undefined) {
-    opts.fallback = true;
-  }
-  const clip = getSfxClip(REWARD_DROP_SFX_KEYS, opts);
-  if (!clip) return null;
-  try {
-    const audio = new Audio(clip);
-    const numericVolume = Number(volumeSteps);
-    const clamped = Number.isFinite(numericVolume)
-      ? Math.max(0, Math.min(10, numericVolume))
-      : 0;
-    audio.volume = clamped / 10;
-    return audio;
-  } catch {
-    return null;
-  }
+  const { reducedMotion = false, ...rest } = opts;
+  return createSequentialSfxPlayer({
+    keys: REWARD_DROP_SFX_KEYS,
+    volume: volumeSteps,
+    reducedMotion,
+    options: rest
+  });
 }


### PR DESCRIPTION
## Summary
- add a reusable createSequentialSfxPlayer helper powering deal and reward drop cues
- update pull and reward overlays to use the helper and new ui/reward/drop alias
- document the shared sfx utility and reward-drop alias in the implementation guides

## Testing
- bun run lint

------
https://chatgpt.com/codex/tasks/task_b_68e593858244832c9800ed694c4896b1