### PR TITLE
Fix RewardOverlay cache to respect reduced motion toggles

### DIFF
--- a/frontend/src/lib/components/RewardOverlay.svelte
+++ b/frontend/src/lib/components/RewardOverlay.svelte
@@ -144,6 +144,7 @@
   let dropSfxPlayer = null;
   let dropPopTransition = null;
   let lastDropSignature = null;
+  let lastReducedMotion = null;
 
   $: dropPopTransition = reducedMotion
     ? null
@@ -239,12 +240,15 @@
 
   $: {
     const nextSignature = snapshotDropSignature(dropEntries);
-    const unchanged = Array.isArray(lastDropSignature) && dropSignaturesEqual(lastDropSignature, nextSignature);
-    if (unchanged) {
+    const unchangedSignature =
+      Array.isArray(lastDropSignature) && dropSignaturesEqual(lastDropSignature, nextSignature);
+    const motionUnchanged = lastReducedMotion === reducedMotion;
+    if (unchangedSignature && motionUnchanged) {
       return;
     }
     updateDropSequence(dropEntries, reducedMotion);
     lastDropSignature = nextSignature;
+    lastReducedMotion = reducedMotion;
   }
 
   let cardsDone = false;
@@ -278,6 +282,7 @@
     clearDropRevealTimers();
     stopDropAudio(true);
     lastDropSignature = null;
+    lastReducedMotion = null;
   });
 
   // Show Next Room button when there's loot but no choices


### PR DESCRIPTION
## Summary
- include the reduced motion flag in the reward drop cache comparison
- reset the cached motion state on destroy so toggles rerun the drop sequence

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68e5c247d1cc832c82924d5d9e093337