### PR TITLE
Handle glitched Luna lightstream swords

### DIFF
--- a/.codex/implementation/player-foe-reference.md
+++ b/.codex/implementation/player-foe-reference.md
@@ -62,7 +62,7 @@ first spawn and reuse it for future sessions unless customized.
 | LadyOfFire | B | 5★ | Fire | `lady_of_fire_infernal_momentum` converts defeated foes into escalating heat-wave stacks for overwhelming fire damage. | Standard gacha recruit. |
 | LadyStorm | B | 6★ | Wind / Lightning (randomized) | `lady_storm_supercell` weaves slipstreams into charge detonations that grant tailwinds and shred mitigation. | 6★ gacha headliner. |
 | LadyWind | B | 5★ | Wind | `lady_wind_tempest_guard` sustains a permanent slipstream of dodge and mitigation, feeding on critical hits. | Standard gacha recruit. |
-| Luna | B | Story | Generic | `luna_lunar_reservoir` charges astral swords; boss-ranked variants pre-summon blades that mirror her actions. | Story antagonist only; cannot be unlocked or recruited. |
+| Luna | B | Story | Generic | `luna_lunar_reservoir` charges astral swords; boss-ranked variants pre-summon blades that mirror her actions, while glitched non-boss ranks cache twin Lightstream swords before combat. | Story antagonist only; cannot be unlocked or recruited. |
 | Mezzy | B | 5★ | Any (randomized) | `mezzy_gluttonous_bulwark` devours incoming attacks, siphoning stats and reducing damage taken. | Standard gacha recruit. |
 | Mimic | C | 0★ | Any (randomized) | `mimic_player_copy` mirrors allied passives and stat gains. | Mirrors an active party member during scripted mirror fights; non-selectable. |
 | PersonaIce | A | 5★ | Ice | `persona_ice_cryo_cycle` layers mitigation and thaws stored frost into end-of-turn healing barriers. | Standard gacha recruit. |

--- a/backend/tests/test_luna_swords.py
+++ b/backend/tests/test_luna_swords.py
@@ -6,8 +6,8 @@ from autofighter.rooms.battle.setup import setup_battle
 from autofighter.stats import BUS
 from autofighter.stats import Stats
 from autofighter.summons.manager import SummonManager
-from plugins.passives.normal.luna_lunar_reservoir import LunaLunarReservoir
 from plugins.characters.luna import Luna
+from plugins.passives.normal.luna_lunar_reservoir import LunaLunarReservoir
 
 
 @pytest.fixture(autouse=True)
@@ -33,6 +33,17 @@ def _boss_node() -> MapNode:
         room_id=0,
         room_type="battle-boss",
         floor=3,
+        index=1,
+        loop=1,
+        pressure=0,
+    )
+
+
+def _normal_node() -> MapNode:
+    return MapNode(
+        room_id=0,
+        room_type="battle",
+        floor=1,
         index=1,
         loop=1,
         pressure=0,
@@ -121,3 +132,49 @@ async def test_glitched_luna_sword_hits_double_charge():
     after = LunaLunarReservoir.get_charge(luna)
 
     assert after - before == 8
+
+
+@pytest.mark.asyncio
+async def test_luna_non_glitched_ranks_detach_helper():
+    node = _normal_node()
+    party = _basic_party()
+    luna = Luna()
+    luna.id = "luna_normal"
+    luna.rank = "champion"
+
+    await setup_battle(node, party, foe=luna)
+
+    helper = getattr(luna, "_luna_sword_helper", None)
+    assert helper is None
+    assert not SummonManager.get_summons(luna.id)
+
+
+@pytest.mark.asyncio
+async def test_luna_glitched_non_boss_gets_lightstream_swords(monkeypatch):
+    sequence = iter(["Fire", "Ice"])
+
+    def _choice(options):
+        try:
+            candidate = next(sequence)
+        except StopIteration:
+            candidate = options[0]
+        if candidate not in options:
+            return options[0]
+        return candidate
+
+    monkeypatch.setattr("plugins.characters.luna.random.choice", _choice)
+
+    node = _normal_node()
+    party = _basic_party()
+    luna = Luna()
+    luna.id = "luna_glitched_nonboss"
+    luna.rank = "glitched champion"
+
+    await setup_battle(node, party, foe=luna)
+
+    swords = SummonManager.get_summons(luna.id)
+    assert len(swords) == 2
+    assert {getattr(s, "luna_sword_label", None) for s in swords} == {"Lightstream"}
+    assert all(getattr(s, "summon_type", "") == "luna_sword_lightstream" for s in swords)
+    damage_ids = {getattr(getattr(s, "damage_type", None), "id", None) for s in swords}
+    assert damage_ids == {"Fire", "Ice"}


### PR DESCRIPTION
## Summary
- randomize the damage types applied to Lightstream swords when glitched non-boss Luna prepares for battle while still reserving two summon slots
- add deterministic coverage for glitched champion encounters to verify Lightstream sword allocation alongside existing helper checks
- document Luna's new Lightstream behavior for non-boss glitched ranks in the roster reference

## Testing
- [x] Backend tests (`uv run pytest tests/test_luna_swords.py`)
- [ ] Frontend tests
- [x] Linting (`uv run ruff check plugins/characters/luna.py tests/test_luna_swords.py`)
- [x] Doc sync updates (README and `.codex/implementation` docs; link tasks below)

## Checklist
- [ ] Linked or updated relevant `.codex/tasks` entries
- [x] Updated player roster and foe docs if adding or modifying fighters or enemies
- [ ] Referenced `.codex/implementation/ui-animation-guidelines.md` when adding UI animations

ready for review

------
https://chatgpt.com/codex/tasks/task_b_68e5c1afcb8c832c814d5b47e6f7d9b5