### PR TITLE
Fix glitched non-boss Luna action charge scaling

### DIFF
--- a/backend/plugins/passives/normal/luna_lunar_reservoir.py
+++ b/backend/plugins/passives/normal/luna_lunar_reservoir.py
@@ -33,6 +33,18 @@ class LunaLunarReservoir:
         cls._events_registered = True
 
     @classmethod
+    def _is_glitched_nonboss(cls, target: "Stats") -> bool:
+        rank = str(getattr(target, "rank", ""))
+        if not rank:
+            return False
+        lowered = rank.lower()
+        return "glitched" in lowered and "boss" not in lowered
+
+    @classmethod
+    def _charge_multiplier(cls, charge_holder: "Stats") -> int:
+        return 2 if cls._is_glitched_nonboss(charge_holder) else 1
+
+    @classmethod
     def _resolve_charge_holder(cls, target: "Stats") -> "Stats":
         owner_attr = getattr(target, "luna_sword_owner", None)
         if owner_attr is not None:
@@ -163,10 +175,12 @@ class LunaLunarReservoir:
         charge_target = cls._resolve_charge_holder(target)
         entity_id = cls._ensure_charge_slot(charge_target)
 
+        multiplier = cls._charge_multiplier(charge_target)
+
         if event == "ultimate_used":
-            cls._charge_points[entity_id] += 64
+            cls._charge_points[entity_id] += 64 * multiplier
         else:
-            cls._charge_points[entity_id] += 1
+            cls._charge_points[entity_id] += 1 * multiplier
 
         current_charge = cls._charge_points[entity_id]
         cls._apply_actions(charge_target, current_charge)

--- a/backend/tests/test_character_passives.py
+++ b/backend/tests/test_character_passives.py
@@ -54,6 +54,33 @@ async def test_luna_lunar_reservoir_passive():
 
 
 @pytest.mark.asyncio
+async def test_luna_glitched_nonboss_actions_double_charge():
+    """Glitched non-boss Luna should gain double charge from actions and ultimates."""
+    passive = LunaLunarReservoir()
+
+    LunaLunarReservoir._charge_points.clear()
+    LunaLunarReservoir._swords_by_owner.clear()
+
+    try:
+        luna = Stats(hp=1000, damage_type=Generic())
+        luna.rank = "glitched champion"
+
+        starting_charge = LunaLunarReservoir.get_charge(luna)
+        await passive.apply(luna, event="action_taken")
+        after_action = LunaLunarReservoir.get_charge(luna)
+
+        assert after_action - starting_charge == 2
+
+        await passive.apply(luna, event="ultimate_used")
+        after_ultimate = LunaLunarReservoir.get_charge(luna)
+
+        assert after_ultimate - after_action == 128
+    finally:
+        LunaLunarReservoir._charge_points.clear()
+        LunaLunarReservoir._swords_by_owner.clear()
+
+
+@pytest.mark.asyncio
 async def test_graygray_counter_maestro_passive():
     """Test Graygray's Counter Maestro passive retaliation."""
     registry = PassiveRegistry()


### PR DESCRIPTION
## Summary
- double Lunar Reservoir per-action and ultimate charge when the holder is a glitched non-boss rank while keeping sword hit handling unchanged
- add a regression test covering glitched non-boss Luna actions and ultimates to confirm the doubled stacking behavior

## Testing
- uv run pytest tests/test_character_passives.py::test_luna_glitched_nonboss_actions_double_charge

------
https://chatgpt.com/codex/tasks/task_b_68e5cbda28f8832cab5c16213c3ac802