### PR TITLE
Fix Luna sword detection for battle projectiles

### DIFF
--- a/frontend/src/lib/components/BattleView.svelte
+++ b/frontend/src/lib/components/BattleView.svelte
@@ -20,6 +20,7 @@
   import BattleTargetingOverlay from './BattleTargetingOverlay.svelte';
   import BattleProjectileLayer from './BattleProjectileLayer.svelte';
   import EffectsChargeContainer from './battle/EffectsChargeContainer.svelte';
+  import { isCandidateLuna } from './battle/lunaUtils.js';
   import { motionStore } from '../systems/settingsStorage.js';
   import { haltSync } from '../systems/overlayState.js';
 
@@ -1087,15 +1088,6 @@
       if (trimmed) return trimmed;
     }
     return '';
-  }
-
-  function isCandidateLuna(value) {
-    const text = toTrimmedId(value);
-    if (!text) return false;
-    const normalized = text.toLowerCase();
-    if (normalized === 'luna') return true;
-    const stripped = normalized.replace(/[^a-z]/g, '');
-    return stripped === 'luna';
   }
 
   function isLunaHitEvent(evt) {

--- a/frontend/src/lib/components/battle/lunaUtils.js
+++ b/frontend/src/lib/components/battle/lunaUtils.js
@@ -1,0 +1,18 @@
+export function isCandidateLuna(value) {
+  if (value === undefined || value === null) return false;
+  let text;
+  try {
+    text = String(value).trim();
+  } catch {
+    return false;
+  }
+  if (!text) return false;
+  const normalized = text.toLowerCase();
+  if (normalized === 'luna') return true;
+  const compact = normalized.replace(/[^a-z]/g, '');
+  if (compact === 'luna') return true;
+  const underscored = normalized.replace(/[^a-z0-9]+/g, '_');
+  if (underscored === 'luna') return true;
+  if (underscored.startsWith('luna_')) return true;
+  return underscored.includes('luna_sword');
+}

--- a/frontend/tests/components/luna-utils.vitest.js
+++ b/frontend/tests/components/luna-utils.vitest.js
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { isCandidateLuna } from '$lib/components/battle/lunaUtils.js';
+
+describe('isCandidateLuna', () => {
+  it('matches the plain luna identifier', () => {
+    expect(isCandidateLuna('luna')).toBe(true);
+  });
+
+  it('matches identifiers with a luna_ prefix', () => {
+    expect(isCandidateLuna('luna_blade')).toBe(true);
+    expect(isCandidateLuna('LUNA_SPELL')).toBe(true);
+  });
+
+  it('matches sword-specific identifiers', () => {
+    expect(isCandidateLuna('luna_sword_alpha')).toBe(true);
+    expect(isCandidateLuna('player:luna_sword_beta')).toBe(true);
+  });
+
+  it('ignores unrelated identifiers', () => {
+    expect(isCandidateLuna('lunatic')).toBe(false);
+    expect(isCandidateLuna('seluna')).toBe(false);
+    expect(isCandidateLuna('sword_master')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- expand the Luna source detector to accept identifiers with `luna_` prefixes and sword-specific tokens
- import the shared helper in `BattleView` so sword-originating `damage_taken` events continue to reach projectile handling
- add unit coverage that exercises the new identifier patterns

## Testing
- bun run lint
- bun x vitest run --config vitest.config.js *(fails: @sveltejs/vite-plugin-svelte hot update expects server.environments.consumer)*

------
https://chatgpt.com/codex/tasks/task_b_68e5d131ab80832ca594cbaa31e7cffb