### PR TITLE
fix: guard battle snapshot polling reentrancy

### DIFF
--- a/frontend/tests/battle-effect-queue-guard.vitest.js
+++ b/frontend/tests/battle-effect-queue-guard.vitest.js
@@ -116,4 +116,66 @@ describe('BattleView effect queue guard', () => {
 
     warnSpy.mockRestore();
   });
+
+  it('prevents recursive polling when summons queue effects', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const deferred = (() => {
+      let resolve;
+      const promise = new Promise((res) => {
+        resolve = res;
+      });
+      return { promise, resolve };
+    })();
+
+    roomAction.mockResolvedValue({
+      party: [],
+      foes: [],
+      recent_events: [],
+      effects_charge: [],
+    });
+    roomAction.mockReturnValueOnce(deferred.promise);
+
+    render(BattleView, {
+      props: {
+        runId: 'RUN-123',
+        active: true,
+        framerate: 60,
+        showHud: false,
+        showFoes: false,
+      },
+    });
+
+    expect(roomAction).toHaveBeenCalledTimes(1);
+
+    deferred.resolve({
+      party: [{ id: 'hero', hp: 10, max_hp: 10 }],
+      foes: [],
+      party_summons: [
+        {
+          owner_id: 'hero',
+          id: 'sprite-001',
+          hp: 5,
+          max_hp: 5,
+        },
+      ],
+      recent_events: [],
+      effects_charge: [],
+    });
+
+    await settle();
+
+    expect(roomAction).toHaveBeenCalledTimes(1);
+    expect(
+      warnSpy.mock.calls.some(([message]) =>
+        typeof message === 'string' && message.includes('effect_update_depth_exceeded'),
+      ),
+    ).toBe(false);
+
+    vi.advanceTimersByTime(1000);
+    await settle();
+
+    expect(roomAction).toHaveBeenCalledTimes(2);
+
+    warnSpy.mockRestore();
+  });
 });


### PR DESCRIPTION
## Summary
- add an isFetchingSnapshot guard in `BattleView` to prevent concurrent snapshot requests and re-entrant polling triggers
- clear the guard before rescheduling the timer so halted states tear down cleanly
- extend the battle effect queue guard test suite with a regression case that covers summon-driven polling

## Testing
- [ ] Backend tests
- [ ] Frontend tests
- [ ] Linting
- [ ] Doc sync updates (README and `.codex/implementation` docs; link tasks below)

## Checklist
- [ ] Linked or updated relevant `.codex/tasks` entries
- [ ] Updated player roster and foe docs if adding or modifying fighters or enemies
- [ ] Referenced `.codex/implementation/ui-animation-guidelines.md` when adding UI animations

------
https://chatgpt.com/codex/tasks/task_b_68e5d6d10d58832c849c460c0d0321ba