### PR TITLE
Add action queue spend override support

### DIFF
--- a/backend/autofighter/rooms/battle/turn_loop/foe_turn.py
+++ b/backend/autofighter/rooms/battle/turn_loop/foe_turn.py
@@ -170,6 +170,7 @@ async def _run_foe_turn_iteration(
             acting_foe,
             action_start,
             active_target_id=getattr(target, "id", None),
+            spent_override=0.0,
         )
         return FoeTurnIterationResult(repeat=False, battle_over=True)
 

--- a/backend/autofighter/rooms/battle/turn_loop/player_turn.py
+++ b/backend/autofighter/rooms/battle/turn_loop/player_turn.py
@@ -236,6 +236,7 @@ async def _run_player_turn_iteration(
             member,
             action_start,
             active_target_id=None,
+            spent_override=0.0,
         )
         return PlayerTurnIterationResult(repeat=False, battle_over=True)
 
@@ -247,6 +248,7 @@ async def _run_player_turn_iteration(
             member,
             action_start,
             active_target_id=None,
+            spent_override=0.0,
         )
         return PlayerTurnIterationResult(repeat=False, battle_over=True)
     await BUS.emit_async("target_acquired", member, target_foe)
@@ -293,6 +295,7 @@ async def _run_player_turn_iteration(
             member,
             action_start,
             active_target_id=getattr(target_foe, "id", None),
+            spent_override=0.0,
         )
         return PlayerTurnIterationResult(repeat=False, battle_over=True)
 

--- a/backend/autofighter/rooms/battle/turn_loop/turn_end.py
+++ b/backend/autofighter/rooms/battle/turn_loop/turn_end.py
@@ -19,6 +19,7 @@ async def finish_turn(
     *,
     include_summon_foes: bool = False,
     active_target_id: str | None = None,
+    spent_override: float | None = None,
 ) -> None:
     """Finalize a combatant's turn and emit post-action updates."""
 
@@ -50,6 +51,7 @@ async def finish_turn(
         context.turn,
         context.run_id,
         turn_phase="end",
+        spent_override=spent_override,
     )
     if cycle_count:
         context.turn += cycle_count

--- a/backend/autofighter/rooms/battle/turns.py
+++ b/backend/autofighter/rooms/battle/turns.py
@@ -73,11 +73,17 @@ async def push_progress_update(
 async def _advance_visual_queue(
     visual_queue: Any,
     actor: Stats | None,
+    *,
+    spent_override: float | None = None,
 ) -> int:
     if visual_queue is None or actor is None:
         return 0
     try:
-        return await asyncio.to_thread(visual_queue.advance_with_actor, actor)
+        return await asyncio.to_thread(
+            visual_queue.advance_with_actor,
+            actor,
+            spent_override=spent_override,
+        )
     except Exception:
         log.debug("Failed to advance visual queue", exc_info=True)
     return 0
@@ -96,10 +102,15 @@ async def dispatch_turn_end_snapshot(
     run_id: str | None,
     *,
     turn_phase: str | None = "end",
+    spent_override: float | None = None,
 ) -> int:
     """Advance the visual queue and emit an updated snapshot."""
 
-    cycle_count = await _advance_visual_queue(visual_queue, actor)
+    cycle_count = await _advance_visual_queue(
+        visual_queue,
+        actor,
+        spent_override=spent_override,
+    )
     effective_turn = turn + cycle_count
     await push_progress_update(
         progress,


### PR DESCRIPTION
## Summary
- allow the action queue to accept optional spend overrides and propagate them through battle turn helpers
- prevent visual queue advancement when turns end before an action resolves by passing a zero override
- add regression coverage for queue overrides and visual queue forwarding

## Testing
- uv run pytest backend/tests/test_action_queue.py

------
https://chatgpt.com/codex/tasks/task_b_68e5d8956490832ca9864d4a4aa18334