### PR TITLE
Fix OverlayHost room change watcher after log helper removal

### DIFF
--- a/frontend/src/lib/components/OverlayHost.svelte
+++ b/frontend/src/lib/components/OverlayHost.svelte
@@ -197,8 +197,6 @@
   $: if (roomData !== lastRoom) {
     lootConsumed = false;
     lastRoom = roomData;
-    // Log room changes for debug tracing
-    try { console.log(`[OverlayHost] ${now()} roomData changed`, { runId, result: roomData?.result, battle_index: roomData?.battle_index, roomId: roomData?.id || roomData?.room_id || null }); } catch(e) {}
   }
   $: if (!lootConsumed && roomData?.loot) {
     if (roomData.loot.gold) pushLoot(`Gold +${roomData.loot.gold}`);


### PR DESCRIPTION
## Summary
- stop the OverlayHost room change watcher from calling the removed now() helper
- leave the loot reset logic intact so room transitions still clear prior messages

## Testing
- bun run lint

------
https://chatgpt.com/codex/tasks/task_b_68e5e9807c7c832cbb58e2a46d4ea4e9