### PR TITLE
Forward backend error context to ErrorOverlay host

### DIFF
--- a/frontend/src/lib/components/OverlayHost.svelte
+++ b/frontend/src/lib/components/OverlayHost.svelte
@@ -256,6 +256,7 @@
   <ErrorOverlay
     message={$overlayData.message || 'An unexpected error occurred.'}
     traceback={$overlayData.traceback || ''}
+    context={$overlayData.context ?? null}
     reducedMotion={overlayReducedMotion}
     on:close={() => dispatch('back')}
   />


### PR DESCRIPTION
## Summary
- forward the overlay controller's context payload into the ErrorOverlay component so backend metadata is rendered

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68e6887501e0832caddee4bbf1ffcc9c