### PR TITLE
feat: centralize summon handling in reusable manager

### DIFF
--- a/frontend/.codex/implementation/summon-manager.md
+++ b/frontend/.codex/implementation/summon-manager.md
@@ -1,0 +1,60 @@
+# Summon Manager
+
+The summon manager centralizes all logic for detecting, normalizing, and tracking summons that appear in battle snapshots.  It
+wraps the behaviors that previously lived inside `BattleView.svelte` so that multiple components can share a single definition
+of what constitutes a summon and how summon metadata is derived.
+
+## Responsibilities
+
+- **Normalization** – converts the variety of snapshot shapes (`array` or keyed `object`) into maps of `owner_id -> summons[]`
+  while ensuring each summon carries HP tracking keys, render keys, anchor aliases, and normalized elements.
+- **Lifecycle tracking** – keeps a persistent render-key pool per summon signature so summons keep a stable key even when
+  snapshots omit explicit IDs, and exposes a `reset()` hook used when a new battle is loaded.
+- **HP bookkeeping** – calls the provided `trackHp` callback whenever a summon is prepared so the HP drains history stays in sync
+  with the rest of the battle UI.
+- **New summon events** – deduplicates summons via `instance_id`/`id` and calls the optional `onNewSummon` callback exactly once
+  per previously unseen summon, enabling `BattleView` to queue summon VFX without reimplementing the checks.
+- **Shared helpers** – exports `isSummon`, `filterPartyEntities`, and `getSummonIdentifier` so other modules (e.g. overlay views,
+  party seed logic) never drift from the canonical summon definition.
+
+## API
+
+```js
+import { createSummonManager } from '$lib/systems/summonManager.js';
+
+const summonManager = createSummonManager({
+  combatantKey,                 // (kind, id, ownerId) => string used for HP tracking
+  resolveEntityElement,         // (summon) => normalized element id (defaults to 'generic')
+  applyLunaSwordVisuals,        // (summon, ownerId, baseElement) => summon with Luna Sword visuals applied
+  normalizeOwnerId,             // (value) => stable owner identifier string
+});
+
+const { partySummons, foeSummons, partySummonIds, foeSummonIds } = summonManager.processSnapshot(snapshot, {
+  trackHp: (hpKey, hp, maxHp) => { /* update HP history */ },
+  onNewSummon: ({ side, ownerId, summon }) => { /* queue summon effect */ },
+});
+
+// Reset between battles
+summonManager.reset();
+```
+
+The returned maps are keyed by the owning combatant ID and contain fully prepared summon entries.  `partySummonIds` and
+`foeSummonIds` expose the identifier sets used by `BattleView` to avoid duplicating summons in the primary party/foe arrays.
+
+Helper exports:
+
+- `isSummon(entity)` – canonical check used across the UI.
+- `filterPartyEntities(list)` – strips summons from arbitrary party lists (used by the review overlay).
+- `getSummonIdentifier(summon)` – exposes the identifier derivation for tooling/tests.
+
+## Integration Points
+
+- **`BattleView.svelte`** instantiates a manager with battle-specific helpers.  `fetchSnapshot` now delegates summon preparation
+  to the manager, relies on `processSnapshot` for deduplication, and resets the manager when the run changes.
+- **`OverlayHost.svelte`** imports `filterPartyEntities` to keep the battle review overlay aligned with the battle view’s summon
+  definition.
+- **`partySeed.js`** imports `isSummon` to skip summons when deriving seed party IDs.
+- **Vitest coverage** – see `frontend/tests/summonManager.test.js` for scenarios covering normalization, deduplication, and render
+  key persistence.
+
+When extending summon behavior, update the manager so every consumer automatically receives the new logic.

--- a/frontend/src/lib/components/OverlayHost.svelte
+++ b/frontend/src/lib/components/OverlayHost.svelte
@@ -31,6 +31,7 @@
   import { getBattleSummary } from '../systems/uiApi.js';
   import { motionStore } from '../systems/settingsStorage.js';
   import { setRewardOverlayOpen, setReviewOverlayState } from '../systems/overlayState.js';
+  import { filterPartyEntities } from '../systems/summonManager.js';
 
   export let selected = [];
   export let runId = '';
@@ -144,14 +145,6 @@
     dispatch('nextRoom');
   }
 
-  // Ensure Battle Review receives only true party members (exclude summons)
-  function filterPartyEntities(list) {
-    if (!Array.isArray(list)) return [];
-    return list.filter((e) => {
-      const obj = (e && typeof e === 'object') ? e : null;
-      return !(obj && (obj.summon_type || obj.type === 'summon' || obj.is_summon));
-    });
-  }
   $: reviewPartyData = (() => {
     let src = [];
     if (battleSnapshot?.party && battleSnapshot.party.length) {

--- a/frontend/src/lib/systems/partySeed.js
+++ b/frontend/src/lib/systems/partySeed.js
@@ -1,12 +1,6 @@
-const PLACEHOLDER_IDS = new Set(['sample_player']);
+import { isSummon } from './summonManager.js';
 
-function isSummon(entry) {
-  if (!entry || typeof entry !== 'object') return false;
-  if (entry.summon_type) return true;
-  if (entry.type === 'summon') return true;
-  if (entry.is_summon === true) return true;
-  return false;
-}
+const PLACEHOLDER_IDS = new Set(['sample_player']);
 
 function readId(entry) {
   if (typeof entry === 'string') {

--- a/frontend/src/lib/systems/summonManager.js
+++ b/frontend/src/lib/systems/summonManager.js
@@ -1,0 +1,277 @@
+const DEFAULT_CONFIG = {
+  combatantKey: () => '',
+  resolveEntityElement: () => 'generic',
+  applyLunaSwordVisuals: (entry) => entry,
+  normalizeOwnerId: (value) => {
+    if (value === undefined || value === null) return '';
+    try {
+      return String(value);
+    } catch {
+      return '';
+    }
+  }
+};
+
+export function isSummon(entry) {
+  if (!entry || typeof entry !== 'object') return false;
+  if (entry.summon_type) return true;
+  if (entry.type === 'summon') return true;
+  if (entry.is_summon === true) return true;
+  return false;
+}
+
+export function filterPartyEntities(list) {
+  if (!Array.isArray(list)) return [];
+  return list.filter((entry) => !isSummon(entry));
+}
+
+export function getSummonIdentifier(summon) {
+  if (!summon || typeof summon !== 'object') return '';
+  const value = summon?.instance_id ?? summon?.id;
+  if (value === undefined || value === null) return '';
+  try {
+    return String(value);
+  } catch {
+    return '';
+  }
+}
+
+function normalizeSummonPayload(payload) {
+  if (!payload) {
+    return [];
+  }
+  if (Array.isArray(payload)) {
+    return payload.filter(Boolean);
+  }
+  if (payload && typeof payload === 'object') {
+    return Object.entries(payload).flatMap(([owner, list]) => {
+      const source = Array.isArray(list) ? list : [list];
+      return source.filter(Boolean).map((entry) => ({ owner_id: owner, ...entry }));
+    });
+  }
+  return [];
+}
+
+function assignAliasValues(renderKey, baseId, summon) {
+  const aliasSet = new Set();
+  const addAlias = (value) => {
+    if (value === undefined || value === null) return;
+    try {
+      const str = String(value);
+      if (str && str !== renderKey) {
+        aliasSet.add(str);
+      }
+    } catch {}
+  };
+  addAlias(summon?.instance_id);
+  addAlias(summon?.id);
+  addAlias(baseId);
+  return Array.from(aliasSet);
+}
+
+export function createSummonManager(config = {}) {
+  const settings = { ...DEFAULT_CONFIG, ...config };
+  let knownSummons = new Set();
+  const renderState = new Map();
+
+  function reset() {
+    knownSummons = new Set();
+    renderState.clear();
+  }
+
+  function prepareSummon(summon, ownerId, side, helpers) {
+    if (!summon) return null;
+
+    const { trackHp, summonCounters, seenSummonSlots } = helpers;
+
+    let baseId = getSummonIdentifier(summon);
+    if (!baseId) {
+      const typeLabel = summon?.summon_type || summon?.type || 'summon';
+      const ownerLabel = summon?.summoner_id || ownerId || 'owner';
+      const counterKey = `${side}:${ownerLabel}:${typeLabel}`;
+      const count = summonCounters.get(counterKey) || 0;
+      summonCounters.set(counterKey, count + 1);
+      baseId = `${typeLabel}_${ownerLabel}_${count}`;
+    }
+
+    const hpKey = settings.combatantKey(`${side}-summon`, baseId, ownerId);
+    if (hpKey) {
+      trackHp?.(hpKey, summon.hp, summon.max_hp);
+    }
+
+    const ownerKey = settings.normalizeOwnerId(ownerId) || 'owner';
+    const signatureSource = baseId || summon?.summon_type || summon?.type || 'summon';
+    const signature = `${side}:${ownerKey}:${signatureSource}`;
+    const slotIndex = seenSummonSlots.get(signature) || 0;
+    seenSummonSlots.set(signature, slotIndex + 1);
+
+    let stored = renderState.get(signature);
+    if (!stored) {
+      stored = [];
+      renderState.set(signature, stored);
+    }
+
+    let renderKey = '';
+    const instanceKey = summon?.instance_id;
+    if (instanceKey !== undefined && instanceKey !== null && instanceKey !== '') {
+      try {
+        renderKey = String(instanceKey);
+      } catch {
+        renderKey = '';
+      }
+    }
+
+    if (!renderKey && summon?.renderKey) {
+      try {
+        renderKey = String(summon.renderKey);
+      } catch {
+        renderKey = '';
+      }
+    }
+
+    if (!renderKey && stored[slotIndex]) {
+      renderKey = stored[slotIndex];
+    }
+
+    if (!renderKey) {
+      const baseKey = hpKey || signature;
+      renderKey = `${String(baseKey)}#${slotIndex}`;
+    }
+
+    if (!renderKey) {
+      renderKey = `${signature}#${slotIndex}`;
+    }
+
+    if (stored[slotIndex] !== renderKey) {
+      stored[slotIndex] = renderKey;
+    }
+
+    const anchorIds = assignAliasValues(renderKey, baseId, summon);
+    const baseElement = settings.resolveEntityElement?.(summon) ?? 'generic';
+
+    let result = { ...summon, hpKey, renderKey, anchorIds };
+    if (baseElement && baseElement !== 'generic') {
+      result = { ...result, element: baseElement };
+    }
+
+    if (typeof settings.applyLunaSwordVisuals === 'function') {
+      const visualized = settings.applyLunaSwordVisuals(result, ownerId, baseElement);
+      if (visualized) {
+        result = visualized;
+      }
+    }
+
+    return result;
+  }
+
+  function collectSummons(payload, side, helpers) {
+    const normalized = normalizeSummonPayload(payload);
+    const byOwner = new Map();
+    for (const entry of normalized) {
+      const owner = entry?.owner_id;
+      if (!owner) continue;
+      const prepared = prepareSummon(entry, owner, side, helpers);
+      if (!prepared) continue;
+      if (!byOwner.has(owner)) {
+        byOwner.set(owner, []);
+      }
+      byOwner.get(owner).push(prepared);
+    }
+    return byOwner;
+  }
+
+  function pruneRenderState(seenSummonSlots) {
+    for (const [signature, count] of seenSummonSlots) {
+      const pool = renderState.get(signature);
+      if (pool && pool.length > count) {
+        pool.length = count;
+      }
+    }
+    for (const signature of Array.from(renderState.keys())) {
+      if (!seenSummonSlots.has(signature)) {
+        renderState.delete(signature);
+      }
+    }
+  }
+
+  function detectNewSummons(collections, onNewSummon) {
+    const observed = new Set(knownSummons);
+    for (const { side, map } of collections) {
+      for (const [owner, summons] of map) {
+        for (const summon of summons) {
+          const ident = getSummonIdentifier(summon);
+          if (ident && !observed.has(ident)) {
+            if (typeof onNewSummon === 'function') {
+              onNewSummon({ side, ownerId: owner, summon });
+            }
+            observed.add(ident);
+            break;
+          }
+        }
+      }
+    }
+    knownSummons = observed;
+  }
+
+  function collectSummonIds(collection, { includeAnchors = false } = {}) {
+    const set = new Set();
+    for (const summons of collection.values()) {
+      for (const summon of summons) {
+        const ident = getSummonIdentifier(summon);
+        if (ident) {
+          set.add(ident);
+        }
+        if (includeAnchors && Array.isArray(summon?.anchorIds)) {
+          for (const alias of summon.anchorIds) {
+            if (alias === undefined || alias === null) continue;
+            try {
+              const str = String(alias);
+              if (str) {
+                set.add(str);
+              }
+            } catch {}
+          }
+        }
+      }
+    }
+    return set;
+  }
+
+  function processSnapshot(snapshot, context = {}) {
+    const summonCounters = new Map();
+    const seenSummonSlots = new Map();
+    const helpers = {
+      trackHp: context.trackHp,
+      summonCounters,
+      seenSummonSlots
+    };
+
+    const partySummons = collectSummons(snapshot?.party_summons, 'party', helpers);
+    const foeSummons = collectSummons(snapshot?.foe_summons, 'foe', helpers);
+
+    detectNewSummons(
+      [
+        { side: 'party', map: partySummons },
+        { side: 'foe', map: foeSummons }
+      ],
+      context.onNewSummon
+    );
+
+    pruneRenderState(seenSummonSlots);
+
+    return {
+      partySummons,
+      foeSummons,
+      partySummonIds: collectSummonIds(partySummons),
+      foeSummonIds: collectSummonIds(foeSummons, { includeAnchors: true })
+    };
+  }
+
+  return {
+    processSnapshot,
+    reset,
+    get knownSummons() {
+      return new Set(knownSummons);
+    }
+  };
+}

--- a/frontend/tests/summon-manager.test.js
+++ b/frontend/tests/summon-manager.test.js
@@ -1,0 +1,156 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  createSummonManager,
+  filterPartyEntities,
+  isSummon,
+} from '../src/lib/systems/summonManager.js';
+
+function createManager() {
+  return createSummonManager({
+    combatantKey: (kind, id, ownerId) => `${kind}:${ownerId}:${id}`,
+    resolveEntityElement: (entity) => entity?.element ?? 'generic',
+    applyLunaSwordVisuals: (entry) => ({ ...entry, visualized: true }),
+    normalizeOwnerId: (value) => String(value ?? ''),
+  });
+}
+
+describe('summonManager', () => {
+  it('normalizes snapshot summons and tracks hp', () => {
+    const manager = createManager();
+    const hpCalls = [];
+
+    const snapshot = {
+      party_summons: {
+        alpha: [{ owner_id: 'alpha', id: 'wolf', hp: 18, max_hp: 40, element: 'wind' }],
+      },
+      foe_summons: [
+        { owner_id: 'omega', id: 'orb', instance_id: 'orb-1', hp: 5, max_hp: 5 },
+      ],
+    };
+
+    const result = manager.processSnapshot(snapshot, {
+      trackHp: (key, hp, max) => hpCalls.push({ key, hp, max }),
+    });
+
+    const partySummon = result.partySummons.get('alpha')?.[0];
+    expect(partySummon).toMatchObject({
+      id: 'wolf',
+      hpKey: 'party-summon:alpha:wolf',
+      element: 'wind',
+      visualized: true,
+    });
+    expect(partySummon.renderKey).toContain('party-summon:alpha:wolf');
+
+    const foeSummon = result.foeSummons.get('omega')?.[0];
+    expect(foeSummon).toMatchObject({
+      id: 'orb',
+      hpKey: 'foe-summon:omega:orb-1',
+      renderKey: 'orb-1',
+      visualized: true,
+    });
+
+    expect(hpCalls).toEqual([
+      { key: 'party-summon:alpha:wolf', hp: 18, max: 40 },
+      { key: 'foe-summon:omega:orb-1', hp: 5, max: 5 },
+    ]);
+
+    expect(result.partySummonIds.has('wolf')).toBe(true);
+    expect(result.foeSummonIds.has('orb-1')).toBe(true);
+  });
+
+  it('emits new summon events once per owner and dedupes repeats', () => {
+    const manager = createManager();
+    const onNewSummon = vi.fn();
+
+    manager.processSnapshot(
+      {
+        party_summons: {
+          hero: [
+            { owner_id: 'hero', id: 'sprite-a' },
+            { owner_id: 'hero', id: 'sprite-b' },
+          ],
+        },
+      },
+      { onNewSummon }
+    );
+
+    expect(onNewSummon).toHaveBeenCalledTimes(1);
+    expect(onNewSummon).toHaveBeenCalledWith(
+      expect.objectContaining({ side: 'party', ownerId: 'hero' })
+    );
+
+    onNewSummon.mockClear();
+
+    manager.processSnapshot(
+      {
+        party_summons: {
+          hero: [{ owner_id: 'hero', id: 'sprite-a' }],
+        },
+      },
+      { onNewSummon }
+    );
+
+    expect(onNewSummon).not.toHaveBeenCalled();
+
+    manager.processSnapshot(
+      {
+        foe_summons: [{ owner_id: 'foe', id: 'wisp' }],
+      },
+      { onNewSummon }
+    );
+
+    expect(onNewSummon).toHaveBeenCalledTimes(1);
+    expect(onNewSummon).toHaveBeenLastCalledWith(
+      expect.objectContaining({ side: 'foe', ownerId: 'foe' })
+    );
+  });
+
+  it('preserves render keys across snapshots without explicit identifiers', () => {
+    const manager = createManager();
+
+    const first = manager.processSnapshot(
+      {
+        party_summons: {
+          alpha: [{ owner_id: 'alpha', summon_type: 'shade' }],
+        },
+      },
+      { trackHp: () => {} }
+    );
+
+    const initial = first.partySummons.get('alpha')?.[0];
+    expect(initial?.renderKey).toBeTruthy();
+
+    const second = manager.processSnapshot(
+      {
+        party_summons: {
+          alpha: [{ owner_id: 'alpha', summon_type: 'shade' }],
+        },
+      },
+      { trackHp: () => {} }
+    );
+
+    const next = second.partySummons.get('alpha')?.[0];
+    expect(next?.renderKey).toBe(initial?.renderKey);
+  });
+});
+
+describe('summon helpers', () => {
+  it('identifies summons and filters party entities', () => {
+    expect(isSummon({ summon_type: 'golem' })).toBe(true);
+    expect(isSummon({ type: 'summon' })).toBe(true);
+    expect(isSummon({ id: 'hero' })).toBe(false);
+
+    const filtered = filterPartyEntities([
+      { id: 'hero' },
+      { id: 'phoenix', summon_type: 'companion' },
+      { id: 'summoner', is_summon: false },
+      null,
+    ]);
+
+    expect(filtered).toEqual([
+      { id: 'hero' },
+      { id: 'summoner', is_summon: false },
+      null,
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- extract summon normalization, render-key persistence, and summon detection into a shared summonManager system
- refactor BattleView, OverlayHost, and party seeding helpers to consume the manager APIs and shared summon filters
- document the summon manager responsibilities and add Vitest coverage for normalization, dedupe, and render-key reuse

## Testing
- `bun test --filter summon-manager`
- `bun test` *(fails: actionqueue.test.js still expects the literal string `class="entry turn-counter"` in ActionQueue.svelte)*

------
https://chatgpt.com/codex/tasks/task_b_68e687397d80832ca33cec3838037caa