### PR TITLE
feat: refactor run wizard layout

### DIFF
--- a/frontend/src/lib/components/ModifierList.svelte
+++ b/frontend/src/lib/components/ModifierList.svelte
@@ -1,0 +1,213 @@
+<script>
+  import Tooltip from './Tooltip.svelte';
+
+  export let modifiers = [];
+  export let values = {};
+  export let onChange = null;
+</script>
+
+<div class="modifiers" role="list">
+  {#each modifiers as mod}
+    <article class="modifier" role="listitem" data-modifier-id={mod.id}>
+      <div class="modifier-header">
+        <div class="modifier-title">
+          <span class="modifier-label">{mod.label || mod.id}</span>
+          {#if mod.category}
+            <span class="modifier-category">{mod.category}</span>
+          {/if}
+        </div>
+        <div class="modifier-controls">
+          {#if mod.meta?.tooltipText}
+            <Tooltip text={mod.meta.tooltipText}>
+              <button
+                type="button"
+                class="info-trigger"
+                aria-label={mod.meta.tooltipLabel}
+                data-tooltip={mod.meta.tooltipText}
+              >
+                <span aria-hidden="true">i</span>
+              </button>
+            </Tooltip>
+          {/if}
+          <label class="stack-input" for={`modifier-${mod.id}`}>
+            <span class="stack-label">Stacks</span>
+            <input
+              id={`modifier-${mod.id}`}
+              type="number"
+              min={mod.stacking?.minimum ?? 0}
+              step={mod.stacking?.step ?? 1}
+              max={Number.isFinite(mod.stacking?.maximum) ? mod.stacking.maximum : undefined}
+              value={values[mod.id] ?? ''}
+              on:input={(event) => onChange?.(mod.id, event.target.value)}
+            />
+          </label>
+        </div>
+      </div>
+      {#if mod.meta?.stackSummary || mod.meta?.effectsSummary || mod.meta?.rewardSummary || mod.meta?.diminishingSummary}
+        <div class="modifier-meta">
+          {#if mod.meta?.stackSummary}
+            <span>{mod.meta.stackSummary}</span>
+          {/if}
+          {#if mod.meta?.effectsSummary}
+            <span>{mod.meta.effectsSummary}</span>
+          {/if}
+          {#if mod.meta?.rewardSummary}
+            <span>{mod.meta.rewardSummary}</span>
+          {/if}
+          {#if mod.meta?.diminishingSummary}
+            <span>{mod.meta.diminishingSummary}</span>
+          {/if}
+        </div>
+      {/if}
+      {#if mod.description}
+        <p class="modifier-description">{mod.description}</p>
+      {/if}
+      {#if mod.meta?.previewChips?.length}
+        <div class="modifier-preview" role="list">
+          {#each mod.meta.previewChips as chip}
+            <div class="preview-chip" role="listitem">
+              <span class="chip-stack">{chip.label}</span>
+              <span class="chip-detail">{chip.detail}</span>
+            </div>
+          {/each}
+        </div>
+        {#if mod.meta?.previewSentence}
+          <p class="preview-sentence">{mod.meta.previewSentence}</p>
+        {/if}
+      {/if}
+    </article>
+  {/each}
+</div>
+
+<style>
+  .modifiers {
+    display: flex;
+    flex-direction: column;
+    gap: clamp(0.65rem, 1.5vw, 0.9rem);
+  }
+
+  .modifier {
+    display: flex;
+    flex-direction: column;
+    gap: clamp(0.45rem, 1vw, 0.7rem);
+    padding: clamp(0.7rem, 1.5vw, 0.95rem);
+    background: var(--wizard-card-bg, rgba(17, 23, 38, 0.7));
+    border: 1px solid var(--wizard-card-border, rgba(153, 201, 255, 0.18));
+    color: inherit;
+  }
+
+  .modifier-header {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    gap: clamp(0.45rem, 1vw, 0.6rem);
+  }
+
+  .modifier-title {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: clamp(0.35rem, 1vw, 0.55rem);
+    font-size: 1rem;
+    font-weight: 600;
+    letter-spacing: 0.01em;
+  }
+
+  .modifier-category {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    opacity: 0.7;
+  }
+
+  .modifier-controls {
+    display: inline-flex;
+    align-items: center;
+    gap: clamp(0.35rem, 0.9vw, 0.55rem);
+  }
+
+  .info-trigger {
+    width: 1.75rem;
+    height: 1.75rem;
+    border: 1px solid var(--wizard-border-muted, rgba(255, 255, 255, 0.25));
+    background: var(--wizard-ghost-bg, rgba(255, 255, 255, 0.02));
+    color: inherit;
+    font-weight: 600;
+    border-radius: 0;
+    cursor: pointer;
+  }
+
+  .info-trigger:hover,
+  .info-trigger:focus-visible {
+    border-color: var(--wizard-border-accent, rgba(173, 211, 255, 0.6));
+    background: var(--wizard-ghost-hover-bg, rgba(173, 211, 255, 0.1));
+    outline: none;
+  }
+
+  .stack-input {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+  }
+
+  .stack-input input {
+    width: clamp(4.5rem, 8vw, 5.5rem);
+    padding: 0.45rem 0.5rem;
+    border: 1px solid var(--wizard-border-muted, rgba(255, 255, 255, 0.25));
+    background: var(--wizard-input-bg, rgba(10, 15, 26, 0.85));
+    color: inherit;
+    font-size: 0.95rem;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .stack-input input:focus-visible {
+    outline: 2px solid var(--wizard-focus-outline, rgba(180, 220, 255, 0.75));
+    outline-offset: 2px;
+  }
+
+  .modifier-meta {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    font-size: 0.85rem;
+    opacity: 0.8;
+    line-height: 1.35;
+  }
+
+  .modifier-description {
+    margin: 0;
+    font-size: 0.9rem;
+    line-height: 1.45;
+    opacity: 0.85;
+  }
+
+  .modifier-preview {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+  }
+
+  .preview-chip {
+    display: flex;
+    gap: 0.5rem;
+    font-size: 0.85rem;
+    line-height: 1.35;
+  }
+
+  .chip-stack {
+    font-weight: 600;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    opacity: 0.8;
+  }
+
+  .preview-sentence {
+    margin: 0;
+    font-size: 0.85rem;
+    line-height: 1.35;
+    opacity: 0.8;
+  }
+</style>

--- a/frontend/src/lib/components/RewardPreviewCard.svelte
+++ b/frontend/src/lib/components/RewardPreviewCard.svelte
@@ -1,0 +1,74 @@
+<script>
+  export let title = 'Reward Preview';
+  export let preview = {
+    exp_bonus: 0,
+    rdr_bonus: 0,
+    foe_bonus: 0,
+    player_bonus: 0
+  };
+  export let formatValue = (value) => value;
+</script>
+
+<section class="reward-card" aria-label={title}>
+  <header>
+    <h3>{title}</h3>
+  </header>
+  <div class="preview-grid">
+    <div>
+      <span class="preview-label">EXP Bonus</span>
+      <span class="preview-value">{formatValue(preview.exp_bonus)}</span>
+    </div>
+    <div>
+      <span class="preview-label">RDR Bonus</span>
+      <span class="preview-value">{formatValue(preview.rdr_bonus)}</span>
+    </div>
+    <div>
+      <span class="preview-label">Foe Bonus</span>
+      <span class="preview-value">{formatValue(preview.foe_bonus)}</span>
+    </div>
+    <div>
+      <span class="preview-label">Player Bonus</span>
+      <span class="preview-value">{formatValue(preview.player_bonus)}</span>
+    </div>
+  </div>
+</section>
+
+<style>
+  .reward-card {
+    display: flex;
+    flex-direction: column;
+    gap: clamp(0.45rem, 1vw, 0.7rem);
+    background: var(--wizard-summary-bg, rgba(17, 23, 38, 0.78));
+    border: 1px solid var(--wizard-summary-border, rgba(153, 201, 255, 0.2));
+    padding: clamp(0.65rem, 1.5vw, 0.95rem);
+    color: inherit;
+  }
+
+  .reward-card h3 {
+    margin: 0;
+    font-size: 1rem;
+    font-weight: 600;
+    letter-spacing: 0.01em;
+    text-transform: uppercase;
+  }
+
+  .preview-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: clamp(0.4rem, 1vw, 0.6rem);
+  }
+
+  .preview-label {
+    display: block;
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    opacity: 0.7;
+  }
+
+  .preview-value {
+    font-size: 1.05rem;
+    font-variant-numeric: tabular-nums;
+    letter-spacing: 0.01em;
+  }
+</style>

--- a/frontend/src/lib/components/RunTypeGrid.svelte
+++ b/frontend/src/lib/components/RunTypeGrid.svelte
@@ -1,0 +1,124 @@
+<script>
+  export let runTypes = [];
+  export let activeId = '';
+  export let loading = false;
+  export let error = '';
+  export let onRetry = null;
+  export let onSelect = null;
+  export let getModifierLabel = (id) => id;
+</script>
+
+{#if loading}
+  <p class="loading">Loading configuration...</p>
+{:else if error}
+  <div class="error">
+    <p>{error}</p>
+    <button class="ghost" type="button" on:click={onRetry}>Retry</button>
+  </div>
+{:else}
+  <div class="run-types" role="list">
+    {#each runTypes as rt}
+      <button
+        type="button"
+        class="run-type-card"
+        class:active={rt.id === activeId}
+        on:click={() => onSelect?.(rt.id)}
+        role="listitem"
+      >
+        <div class="card-title">{rt.label}</div>
+        <p class="card-description">{rt.description}</p>
+        {#if Object.keys(rt.default_modifiers || {}).length > 0}
+          <div class="card-defaults">
+            <strong>Defaults</strong>
+            <ul>
+              {#each Object.entries(rt.default_modifiers || {}) as [key, value]}
+                <li>{getModifierLabel(key)}: {value}</li>
+              {/each}
+            </ul>
+          </div>
+        {/if}
+      </button>
+    {/each}
+  </div>
+{/if}
+
+<style>
+  .loading {
+    margin: 0;
+    opacity: 0.7;
+    font-size: 0.95rem;
+  }
+
+  .error {
+    display: flex;
+    flex-direction: column;
+    gap: clamp(0.5rem, 1vw, 0.75rem);
+    background: var(--wizard-error-bg, rgba(46, 12, 20, 0.85));
+    border: 1px solid var(--wizard-error-border, rgba(255, 117, 133, 0.5));
+    padding: clamp(0.75rem, 1.6vw, 1rem);
+  }
+
+  .error p {
+    margin: 0;
+    font-weight: 500;
+  }
+
+  .error .ghost {
+    align-self: flex-start;
+  }
+
+  .run-types {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: clamp(0.55rem, 1.6vw, 0.95rem);
+  }
+
+  .run-type-card {
+    display: flex;
+    flex-direction: column;
+    gap: clamp(0.35rem, 1vw, 0.6rem);
+    padding: clamp(0.75rem, 1.6vw, 1.1rem);
+    background: var(--wizard-card-bg, rgba(17, 23, 38, 0.7));
+    border: 1px solid var(--wizard-card-border, rgba(153, 201, 255, 0.18));
+    text-align: left;
+    color: inherit;
+    cursor: pointer;
+    transition: border-color 160ms ease, background 160ms ease, transform 120ms ease;
+  }
+
+  .run-type-card:hover,
+  .run-type-card:focus-visible {
+    outline: none;
+    border-color: var(--wizard-card-hover-border, rgba(173, 211, 255, 0.6));
+    background: var(--wizard-card-hover-bg, rgba(27, 37, 58, 0.82));
+  }
+
+  .run-type-card.active {
+    border-color: var(--wizard-card-active-border, rgba(173, 211, 255, 0.8));
+    background: var(--wizard-card-active-bg, rgba(27, 37, 58, 0.9));
+  }
+
+  .card-title {
+    font-weight: 600;
+    font-size: 1rem;
+    letter-spacing: 0.01em;
+  }
+
+  .card-description {
+    margin: 0;
+    font-size: 0.9rem;
+    line-height: 1.4;
+    opacity: 0.8;
+  }
+
+  .card-defaults {
+    font-size: 0.85rem;
+    opacity: 0.8;
+    line-height: 1.35;
+  }
+
+  .card-defaults ul {
+    margin: 0.4rem 0 0;
+    padding-left: 1rem;
+  }
+</style>

--- a/frontend/src/lib/components/RunWizardHeader.svelte
+++ b/frontend/src/lib/components/RunWizardHeader.svelte
@@ -1,0 +1,66 @@
+<script>
+  export let title = '';
+  export let steps = [];
+  export let activeStep = '';
+  export let currentIndex = 0;
+</script>
+
+<header class="wizard-header">
+  <h2>{title}</h2>
+  <div class="step-indicator" aria-hidden="true">
+    {#each steps as key, index}
+      <span class:selected={key === activeStep} class:done={index < currentIndex}>{index + 1}</span>
+    {/each}
+  </div>
+</header>
+
+<style>
+  .wizard-header {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: clamp(0.5rem, 1.4vw, 0.85rem);
+  }
+
+  .wizard-header h2 {
+    flex: 1 1 14rem;
+    margin: 0;
+    font-size: clamp(1.2rem, 2vw, 1.55rem);
+    font-weight: 600;
+    letter-spacing: -0.015em;
+  }
+
+  .step-indicator {
+    display: inline-flex;
+    flex-wrap: wrap;
+    gap: clamp(0.3rem, 0.9vw, 0.5rem);
+    justify-content: flex-end;
+  }
+
+  .step-indicator span {
+    width: 1.75rem;
+    height: 1.75rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.85rem;
+    border: 1px solid var(--wizard-step-border, rgba(255, 255, 255, 0.28));
+    background: var(--wizard-step-bg, transparent);
+    color: inherit;
+    opacity: 0.6;
+    transition: background 160ms ease, opacity 160ms ease, border-color 160ms ease;
+  }
+
+  .step-indicator span.selected {
+    background: var(--wizard-step-active-bg, rgba(153, 201, 255, 0.25));
+    border-color: var(--wizard-step-active-border, rgba(153, 201, 255, 0.65));
+    opacity: 1;
+  }
+
+  .step-indicator span.done {
+    opacity: 0.85;
+    border-color: var(--wizard-step-done-border, rgba(153, 201, 255, 0.4));
+    background: var(--wizard-step-done-bg, rgba(153, 201, 255, 0.12));
+  }
+</style>

--- a/frontend/src/lib/components/WizardNavigation.svelte
+++ b/frontend/src/lib/components/WizardNavigation.svelte
@@ -1,0 +1,77 @@
+<script>
+  export let backLabel = 'Back';
+  export let nextLabel = 'Next';
+  export let onBack = null;
+  export let onNext = null;
+  export let backDisabled = false;
+  export let nextDisabled = false;
+  export let nextVariant = 'primary';
+</script>
+
+<nav class="wizard-navigation">
+  <button type="button" class="btn ghost" disabled={backDisabled} on:click={onBack}>{backLabel}</button>
+  <button
+    type="button"
+    class={`btn ${nextVariant}`}
+    disabled={nextDisabled}
+    on:click={onNext}
+  >
+    {nextLabel}
+  </button>
+</nav>
+
+<style>
+  .wizard-navigation {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+    gap: clamp(0.5rem, 1.2vw, 0.75rem);
+  }
+
+  .btn {
+    appearance: none;
+    border: 1px solid transparent;
+    border-radius: 0;
+    padding: clamp(0.55rem, 1.5vw, 0.85rem) clamp(1.1rem, 2.8vw, 1.75rem);
+    font-size: 0.95rem;
+    font-weight: 550;
+    letter-spacing: 0.01em;
+    text-transform: uppercase;
+    background: transparent;
+    color: inherit;
+    cursor: pointer;
+    transition: background 160ms ease, color 160ms ease, border-color 160ms ease, transform 120ms ease;
+  }
+
+  .btn:focus-visible {
+    outline: 2px solid var(--wizard-focus-outline, rgba(180, 220, 255, 0.75));
+    outline-offset: 2px;
+  }
+
+  .btn:disabled {
+    opacity: 0.55;
+    cursor: default;
+  }
+
+  .ghost {
+    border-color: var(--wizard-border-muted, rgba(255, 255, 255, 0.25));
+    background: var(--wizard-ghost-bg, rgba(255, 255, 255, 0.02));
+  }
+
+  .ghost:not(:disabled):hover {
+    border-color: var(--wizard-border-accent, rgba(153, 201, 255, 0.6));
+    background: var(--wizard-ghost-hover-bg, rgba(153, 201, 255, 0.08));
+  }
+
+  .primary {
+    background: var(--wizard-primary-bg, linear-gradient(120deg, rgba(153, 201, 255, 0.6), rgba(113, 169, 240, 0.6)));
+    border-color: var(--wizard-primary-border, rgba(153, 201, 255, 0.8));
+    color: var(--wizard-primary-color, #0b0f19);
+  }
+
+  .primary:not(:disabled):hover {
+    transform: translateY(-1px);
+    background: var(--wizard-primary-hover-bg, linear-gradient(120deg, rgba(173, 211, 255, 0.75), rgba(133, 189, 250, 0.75)));
+    border-color: var(--wizard-primary-hover-border, rgba(173, 211, 255, 0.9));
+  }
+</style>


### PR DESCRIPTION
## Summary
- split the run chooser into dedicated header, navigation, modifier list, run-type grid, and reward preview components to simplify step markup
- reorganized the modifiers stage into a responsive two-column layout with a summary sidebar for presets, metadata, and rewards
- refreshed the wizard styling tokens for flatter cards, modern buttons, and consistent typography across steps

## Testing
- bun run lint
- bunx vitest run *(fails: @sveltejs/vite-plugin-svelte hot-update consumer undefined startup error)*

------
https://chatgpt.com/codex/tasks/task_b_68e693db2604832c84e5a67fa1afbba1